### PR TITLE
Fix cancellation of waiting clients

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1076,6 +1076,13 @@ void accept_cancel_request(PgSocket *req)
 				goto found;
 			}
 		}
+		statlist_for_each(citem, &pool->waiting_client_list) {
+			client = container_of(citem, PgSocket, head);
+			if (memcmp(client->cancel_key, req->cancel_key, 8) == 0) {
+				main_client = client;
+				goto found;
+			}
+		}
 	}
 found:
 


### PR DESCRIPTION
Attached pull-request changes cancel handling to search waiting_client_list for client to-be-cancelled, in addition to active_client_list.  I've been seeing a few issues with "failed cancel request" errors when a pool is overloaded and client-side timeouts are happening, and this seems to be a logical thing to allow.  I'm assuming that cancelling a waiting client will prevent its pending query from ever reaching the backend server.
