### PR TITLE
Put IP address in brackets in log

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -51,7 +51,7 @@ int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstl
 	}
 	port = pga_port(&sock->remote_addr);
 
-	return snprintf(dst, dstlen, "%c-%p: %s/%s@%s:%d ",
+	return snprintf(dst, dstlen, "%c-%p: %s/%s@[%s]:%d ",
 			is_server_socket(sock) ? 'S' : 'C',
 			sock, db, user, host, port);
 }


### PR DESCRIPTION
This is necessary in particular to separate IPv6 addresses from the port number.  But it might as well be done for all address families, as it is common styles to put IP addresses in brackets in URLs, for example.

(I'm also open to an alternative version that only puts IPv6 in brackets, but this seemed simpler and also more future proof if you ever wanted to support resolved host names in the logs.)
