### PR TITLE
Add newline at the end of the PID file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -546,7 +546,7 @@ static void write_pidfile(void)
 		return;
 
 	pid = getpid();
-	snprintf(buf, sizeof(buf), "%u", (unsigned)pid);
+	snprintf(buf, sizeof(buf), "%u\n", (unsigned)pid);
 
 	fd = open(cf_pidfile, O_WRONLY | O_CREAT | O_EXCL, 0644);
 	if (fd < 0)


### PR DESCRIPTION
This is standard for PID files elsewhere, and makes it behave better
when inspecting the file manually.
