### PR TITLE
Fix incorrect keyword in example config file

### DIFF
--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -16,7 +16,7 @@
 ;forcedb = host=127.0.0.1 port=300 user=baz password=foo client_encoding=UNICODE datestyle=ISO connect_query='SELECT 1'
 
 ; use custom pool sizes
-;nondefaultdb = pool_size=50 reserve_pool=10
+;nondefaultdb = pool_size=50 reserve_pool_size=10
 
 ; fallback connect string
 ;* = host=testserver


### PR DESCRIPTION
The example should be using reserve_pool_size, which is the correct name for the parameter.

Hopefully, a github PR is an acceptable way to contribute these days?
