### PR TITLE
add a separate config for controlling negative dns caching

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -361,6 +361,13 @@ Actual DNS TTL is ignored.  [seconds]
 
 Default: 15.0
 
+==== dns_nxdomain_ttl ====
+
+How long error and NXDOMAIN DNS lookups can be cached. [seconds]
+
+Default: 15.0
+
+
 ==== dns_zone_check_period ====
 
 Period to check if zone serial has changed.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -377,6 +377,7 @@ extern usec_t cf_idle_transaction_timeout;
 extern int cf_server_round_robin;
 extern int cf_disable_pqexec;
 extern usec_t cf_dns_max_ttl;
+extern usec_t cf_dns_nxdomain_ttl;
 extern usec_t cf_dns_zone_check_period;
 
 extern int cf_auth_type;

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -1394,13 +1394,14 @@ static void got_result_gai(int result, struct addrinfo *res, void *arg)
 				ai = ai->ai_next;
 			}
 		}
+		req->res_ttl = get_cached_time() + cf_dns_max_ttl;
 	} else {
 		/* lookup failed */
 		log_warning("lookup failed: %s: result=%d", req->name, result);
+		req->res_ttl = get_cached_time() + cf_dns_nxdomain_ttl;
 	}
 
 	req->done = true;
-	req->res_ttl = get_cached_time() + cf_dns_max_ttl;
 
 	deliver_info(req);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -99,6 +99,7 @@ usec_t cf_server_check_delay;
 int cf_server_round_robin;
 int cf_disable_pqexec;
 usec_t cf_dns_max_ttl;
+usec_t cf_dns_nxdomain_ttl;
 usec_t cf_dns_zone_check_period;
 unsigned int cf_max_packet_size;
 
@@ -207,6 +208,7 @@ CF_ABS("suspend_timeout", CF_TIME_USEC, cf_suspend_timeout, 0, "10"),
 CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),
 CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
+CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
 
 CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),


### PR DESCRIPTION
this is especially important for a DNS hiccup. if a few packets drop, and a dns lookup failure happens, you can configure this so that it retries _much_ faster than the normal positive caching, both reducing load on the DNS server while not exposing yourself to a risk of greater downtime if a DNS hiccup does occure
