### PR TITLE
Add the client host IP address and port to application_name.

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -227,6 +227,15 @@ exclusively use Extended Query protocol will stay working.
 
 Default: 0
 
+==== application_name_add_host ====
+
+Add the client host address and port to the application name setting set on connection start.
+This helps in identifying the source of bad queries etc. The setting will be overwritten
+without any detection if the application does SET APPLICATION_NAME after connecting.
+Note that this is on by default.
+
+Default: 1
+
 === Log settings ===
 
 ==== syslog ====

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -427,6 +427,7 @@ extern int cf_tcp_defer_accept;
 extern int cf_log_connections;
 extern int cf_log_disconnections;
 extern int cf_log_pooler_errors;
+extern int cf_application_name_add_host;
 
 extern const struct CfLookup pool_mode_map[];
 

--- a/src/main.c
+++ b/src/main.c
@@ -134,6 +134,7 @@ int cf_stats_period;
 int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
+int cf_application_name_add_host;
 
 /*
  * config file description
@@ -231,6 +232,7 @@ CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
+CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "1"),
 {NULL}
 };
 


### PR DESCRIPTION
This is enabled by a config parameter which defaults to 'on'

If the client subsequently overwrites the application_name parameter
during the session then this won't be sticky, but it does let you see
(and log) where queries are actually coming from instead of just seeing
pgbouncer as the source address and port.
