### PR TITLE
Don't prematurely release the server in the middle of a parse/bind/execute on the unnamed statement.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ endif
 #
 
 pgbouncer_LDADD := $(CARES_LIBS) $(LIBS)
-LIBS :=
+LIBS := -lpthread
+#LIBS :=
 
 EXTRA_pgbouncer_SOURCES = win32/win32support.c win32/win32support.h
 EXTRA_PROGRAMS = pgbevent

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -329,6 +329,8 @@ struct PgSocket {
 	bool own_user:1;	/* console client: client with same uid on unix socket */
 	bool wait_for_response:1;/* console client: waits for completion of PAUSE/SUSPEND cmd */
 
+	bool wait_for_bind:1;  /* state of extended query mode on unnamed statement */
+
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */
 	usec_t query_start;	/* query start moment */

--- a/src/client.c
+++ b/src/client.c
@@ -492,10 +492,22 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 	return true;
 }
 
+static bool is_unnamed_statement_parse(PktHdr *pkt)
+{
+
+	if (pkt->type != 'P')
+		return false; /* not a Parse packet */
+	if (pkt->data.data[5] != '\0')
+		return false; /* not the unnamed statement */
+	return true;
+}
+
 /* decide on packets of logged-in client */
 static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 {
 	SBuf *sbuf = &client->sbuf;
+
+	slog_debug(client,"client packet type %c",pkt->type);
 
 	switch (pkt->type) {
 
@@ -545,6 +557,13 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 		/* tag the server as dirty */
 		client->link->ready = false;
 		client->link->idle_tx = false;
+
+		if (is_unnamed_statement_parse(pkt))
+			client->link->wait_for_bind = true;
+		else if (pkt->type == 'B' || pkt->type == 'Q')
+			client->link->wait_for_bind = false;
+
+		slog_debug(client,"wait_for_bind: %d",client->link->wait_for_bind);
 
 		/* forward the packet */
 		sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);


### PR DESCRIPTION
We found this feature useful especially for drivers like Go. It has been tested in the field and found to work seamlessly on our client's site.