### PR TITLE
It solves possible infinite login to dropped database via pgbouncer.

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -218,6 +218,8 @@ struct PgPool {
 
 	usec_t last_lifetime_disconnect;/* last time when server_lifetime was applied */
 
+	/* remember first attempt for connect */
+	usec_t first_connect_time;
 	/* if last connect failed, there should be delay before next */
 	usec_t last_connect_time;
 	unsigned last_connect_failed:1;
@@ -390,6 +392,7 @@ extern char * cf_server_reset_query;
 extern char * cf_server_check_query;
 extern usec_t cf_server_check_delay;
 extern usec_t cf_server_connect_timeout;
+extern usec_t cf_server_max_connect_timeout;
 extern usec_t cf_server_login_retry;
 extern usec_t cf_query_timeout;
 extern usec_t cf_query_wait_timeout;

--- a/src/main.c
+++ b/src/main.c
@@ -115,6 +115,7 @@ usec_t cf_autodb_idle_timeout;
 usec_t cf_server_lifetime;
 usec_t cf_server_idle_timeout;
 usec_t cf_server_connect_timeout;
+usec_t cf_server_max_connect_timeout;
 usec_t cf_server_login_retry;
 usec_t cf_query_timeout;
 usec_t cf_query_wait_timeout;
@@ -209,6 +210,7 @@ CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0,
 CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
 CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
 CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
+CF_ABS("server_max_connect_timeout", CF_TIME_USEC, cf_server_max_connect_timeout, 0, "120"),
 CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 CF_ABS("server_round_robin", CF_INT, cf_server_round_robin, 0, "0"),
 CF_ABS("suspend_timeout", CF_TIME_USEC, cf_suspend_timeout, 0, "10"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1126,6 +1126,10 @@ allow_new:
 	server->auth_user = server->pool->user;
 	server->connect_time = get_cached_time();
 	pool->last_connect_time = get_cached_time();
+
+	if (!pool->last_connect_failed)
+		pool->first_connect_time = pool->last_connect_time;
+
 	change_server_state(server, SV_LOGIN);
 	pool->db->connection_count++;
 	pool->user->connection_count++;


### PR DESCRIPTION
We have to handle this issue, due limmited number of available clients.

Test case:

createdb iii; psql -p 6543 -U pavel -c "select 10" iii; \
echo "select pg_terminate_backend((select pid from pg_stat_activity where datname = 'iii'));drop database iii;" |  \
psql  postgres; \
psql -p 6543 -U pavel -c "select 10" iii;

Solution:

I implemented new config option server_max_connect_timeout. This parameter is checked
on every connect fail and if it is exceed, then client is disconnected forced. Default
value is two minutes.