### PR TITLE
Fixed "bad packet header: '70'"

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -595,7 +595,7 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		disconnect_server(client->link, false, "Server connection closed");
 		break;
 	case SBUF_EV_READ:
-		if (mbuf_avail_for_read(data) < NEW_HEADER_LEN && client->state != CL_LOGIN) {
+		if (mbuf_avail_for_read(data) < NEW_HEADER_LEN) {
 			slog_noise(client, "C: got partial header, trying to wait a bit");
 			return false;
 		}


### PR DESCRIPTION
The following patch fixes the incorrect assumption that a partial header can only be received after a successful user authentication.  This bug surfaces when when stunnel is used to wrap the connection with TLS.  Other possible cases include a very low network MTU or a very long username.

The bug does *not* seem to be reproducible with PgBouncer authentication disabled with "auth_type = any" or "auth_type = trust".  Also, the bug is triggered by connections initiated with JDBC, but it is *not* triggered by connections initiated with the PostgreSQL interactive terminal (psql).  This is probably due to different implementation-specific PostgreSQL protocol packet layouts or different network buffering code.

A number of people struggled with this issue (some of them incorrectly attributed the bug to some other software components):
* https://github.com/pgbouncer/pgbouncer/issues/53
* https://github.com/pgjdbc/pgjdbc/issues/300
* https://stackoverflow.com/questions/28466014
* http://www.brainleg.com/external/290881

The cryptic error "bad packet header: '70'" means that the PostgreSQL protocol packet header for authentication data had not been fully retrieved before PgBouncer started processing it.  70 hex = 'p' ASCII is the protocol's code for authentication.

The buggy code was introduced in commit https://github.com/pgbouncer/pgbouncer/commit/18f4e290b19418f837e3b3b50b8545269fd5e349.