### PR TITLE
Add some more statistics

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -199,6 +199,25 @@ avg_sent
 avg_query
     Average query duration in microseconds.
 
+total_server
+    Total number of server connections openned since startup.
+
+total_client
+    Total number of client connections openned since startup.
+
+total_client_time
+    Total number of microseconds spent by clients connected
+    to **pgbouncer**.
+
+avg_server
+    Average number of server connections openned by second.
+
+avg_client
+    Average number of client connections openned by second.
+
+avg_client_time
+    Average client connection duration in microseconds.
+
 SHOW SERVERS;
 -------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -190,9 +190,12 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
  * Stats, kept per-pool.
  */
 struct PgStats {
+	uint64_t server_count;
+	uint64_t client_count;
 	uint64_t request_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
+	usec_t client_time;	/* total cli session time in us */
 	usec_t query_time;	/* total req time in us */
 };
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -837,6 +837,9 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 	case CL_LOGIN:
 		if (client->link) {
 			PgSocket *server = client->link;
+
+			client->pool->stats.client_time += now - client->connect_time;
+
 			/* ->ready may be set before all is sent */
 			if (server->ready && sbuf_is_empty(&server->sbuf)) {
 				/* retval does not matter here */
@@ -1202,6 +1205,8 @@ bool finish_client_login(PgSocket *client)
 		return false;
 
 	slog_debug(client, "logged in");
+
+	client->pool->stats.client_count++;
 
 	return true;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -151,6 +151,7 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 		/* login ok */
 		slog_debug(server, "server login ok, start accepting queries");
 		server->ready = 1;
+		server->pool->stats.server_count++;
 
 		/* got all params */
 		finish_welcome_msg(server);

--- a/src/stats.c
+++ b/src/stats.c
@@ -23,23 +23,29 @@ static usec_t old_stamp, new_stamp;
 
 static void reset_stats(PgStats *stat)
 {
+	stat->server_count = 0;
+	stat->client_count = 0;
 	stat->server_bytes = 0;
 	stat->client_bytes = 0;
 	stat->request_count = 0;
 	stat->query_time = 0;
+	stat->client_time = 0;
 }
 
 static void stat_add(PgStats *total, PgStats *stat)
 {
+	total->server_count += stat->server_count;
+	total->client_count += stat->client_count;
 	total->server_bytes += stat->server_bytes;
 	total->client_bytes += stat->client_bytes;
 	total->request_count += stat->request_count;
 	total->query_time += stat->query_time;
+	total->client_time += stat->client_time;
 }
 
 static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
 {
-	uint64_t qcount;
+	uint64_t count;
 	usec_t dur = get_cached_time() - old_stamp;
 
 	reset_stats(avg);
@@ -47,23 +53,33 @@ static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
 	if (dur <= 0)
 		return;
 
+	avg->server_count = USEC * (cur->server_count - old->server_count) / dur;
+	avg->client_count = USEC * (cur->client_count - old->client_count) / dur;
 	avg->request_count = USEC * (cur->request_count - old->request_count) / dur;
 	avg->client_bytes = USEC * (cur->client_bytes - old->client_bytes) / dur;
 	avg->server_bytes = USEC * (cur->server_bytes - old->server_bytes) / dur;
-	qcount = cur->request_count - old->request_count;
-	if (qcount > 0)
-		avg->query_time = (cur->query_time - old->query_time) / qcount;
+
+	count = cur->request_count - old->request_count;
+	if (count > 0)
+		avg->query_time = (cur->query_time - old->query_time) / count;
+
+	count = cur->client_count - old->client_count;
+	if (count > 0)
+		avg->client_time = (cur->client_time - old->client_time) / count;
 }
 
 static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
 {
 	PgStats avg;
 	calc_average(&avg, stat, old);
-	pktbuf_write_DataRow(buf, "sqqqqqqqq", dbname,
+	pktbuf_write_DataRow(buf, "sqqqqqqqqqqqqqq", dbname,
 			     stat->request_count, stat->client_bytes,
 			     stat->server_bytes, stat->query_time,
 			     avg.request_count, avg.client_bytes,
-			     avg.server_bytes, avg.query_time);
+			     avg.server_bytes, avg.query_time,
+			     stat->server_count, stat->client_count,
+			     stat->client_time, avg.server_count,
+			     avg.client_count, avg.client_time);
 }
 
 bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
@@ -86,11 +102,14 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 		return true;
 	}
 
-	pktbuf_write_RowDescription(buf, "sqqqqqqqq", "database",
+	pktbuf_write_RowDescription(buf, "sqqqqqqqqqqqqqq", "database",
 				    "total_requests", "total_received",
 				    "total_sent", "total_query_time",
 				    "avg_req", "avg_recv", "avg_sent",
-				    "avg_query");
+				    "avg_query", "total_server",
+				    "total_client", "total_client_time",
+				    "avg_server", "avg_client",
+				    "avg_client_time");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
 
@@ -160,6 +179,12 @@ bool show_stat_totals(PgSocket *client, struct StatList *pool_list)
 	WAVG(client_bytes);
 	WAVG(server_bytes);
 	WAVG(query_time);
+	WTOTAL(server_count);
+	WTOTAL(client_count);
+	WTOTAL(client_time);
+	WAVG(server_count);
+	WAVG(client_count);
+	WAVG(client_time);
 
 	admin_flush(client, buf, "SHOW");
 	return true;
@@ -191,9 +216,14 @@ static void refresh_stats(int s, short flags, void *arg)
 	log_info("Stats: %" PRIu64 " req/s,"
 		 " in %" PRIu64 " b/s,"
 		 " out %" PRIu64 " b/s,"
-		 "query %" PRIu64 " us",
+		 " query %" PRIu64 " us,"
+		 " server %" PRIu64 " srv/s,"
+		 " client %" PRIu64 " cli/s,"
+		 " session %" PRIu64 " us",
 		 avg.request_count, avg.client_bytes,
-		 avg.server_bytes, avg.query_time);
+		 avg.server_bytes, avg.query_time,
+		 avg.server_count, avg.client_count,
+		 avg.client_time);
 
 	safe_evtimer_add(&ev_stats, &period);
 }


### PR DESCRIPTION
This adds the following stats to "show stats" and in periodic stats
reported in logs:
- total_server: total number of server connections openned since
  startup
- total_client: total number of client connections openned since
  startup
- total_client_time: total number of microseconds spent by clients
  connected to pgbouncer
- avg_server: average number of server connections openned by
  second
- avg_client: average number of client connections openned by
  second
- avg_client_time: average client connection duration in
  microseconds
