### PR TITLE
Consistent search_path between client and server

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -476,6 +476,8 @@ extern char *cf_server_tls_cert_file;
 extern char *cf_server_tls_key_file;
 extern char *cf_server_tls_ciphers;
 
+extern int cf_consistent_search_path;
+
 extern const struct CfLookup pool_mode_map[];
 
 extern usec_t g_suspend_start;

--- a/include/loader.h
+++ b/include/loader.h
@@ -1,12 +1,12 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
- * 
+ *
  * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -18,7 +18,6 @@
 
 /* connstring parsing */
 bool parse_database(void *base, const char *name, const char *connstr);
-
 bool parse_user(void *base, const char *name, const char *params);
 
 /* user file parsing */

--- a/include/objects.h
+++ b/include/objects.h
@@ -57,11 +57,11 @@ void launch_new_connection(PgPool *pool);
 
 bool use_client_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,
-		       const char *password)
+		       const char *password, const char *search_path)
 			_MUSTCHECK;
 bool use_server_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,
-		       const char *password)
+		       const char *password, const char *search_path)
 			_MUSTCHECK;
 
 void activate_client(PgSocket *client);

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -5,7 +5,8 @@ enum VarCacheIdx {
 	VTimeZone,
 	VStdStr,
 	VAppName,
-	NumVars
+	VSearchPath,
+	NumVars,
 };
 
 typedef struct VarCache VarCache;

--- a/src/admin.c
+++ b/src/admin.c
@@ -161,6 +161,7 @@ static const struct FakeParam fake_param_list[] = {
 	{ "standard_conforming_strings", "on" },
 	{ "datestyle", "ISO" },
 	{ "timezone", "GMT" },
+	{ "search_path", NULL },
 	{ NULL },
 };
 
@@ -245,7 +246,8 @@ static bool send_one_fd(PgSocket *admin,
 			const char *std_strings,
 			const char *datestyle,
 			const char *timezone,
-			const char *password)
+			const char *password,
+			const char *search_path)
 {
 	struct msghdr msg;
 	struct cmsghdr *cmsg;
@@ -255,10 +257,10 @@ static bool send_one_fd(PgSocket *admin,
 
 	struct PktBuf *pkt = pktbuf_temp();
 
-	pktbuf_write_DataRow(pkt, "issssiqisssss",
+	pktbuf_write_DataRow(pkt, "issssiqissssss",
 		      fd, task, user, db, addr, port, ckey, link,
 		      client_enc, std_strings, datestyle, timezone,
-		      password);
+		      password, search_path);
 	if (pkt->failed)
 		return false;
 	iovec.iov_base = pkt->buf;
@@ -308,6 +310,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	VarCache *v = &sk->vars;
 	uint64_t ckey;
 	const struct PStr *client_encoding = v->var_list[VClientEncoding];
+	const struct PStr *search_path = v->var_list[VSearchPath];
 	const struct PStr *std_strings = v->var_list[VStdStr];
 	const struct PStr *datestyle = v->var_list[VDateStyle];
 	const struct PStr *timezone = v->var_list[VTimeZone];
@@ -337,7 +340,8 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 			   std_strings ? std_strings->str : NULL,
 			   datestyle ? datestyle->str : NULL,
 			   timezone ? timezone->str : NULL,
-			   password);
+			   password,
+			   search_path ? search_path->str : NULL);
 }
 
 static bool show_pooler_cb(void *arg, int fd, const PgAddr *a)
@@ -346,7 +350,7 @@ static bool show_pooler_cb(void *arg, int fd, const PgAddr *a)
 
 	return send_one_fd(arg, fd, "pooler", NULL, NULL,
 			   pga_ntop(a, buf, sizeof(buf)), pga_port(a), 0, 0,
-			   NULL, NULL, NULL, NULL, NULL);
+			   NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 /* send a row with sendmsg, optionally attaching a fd */
@@ -412,13 +416,14 @@ static bool admin_show_fds(PgSocket *admin, const char *arg)
 	/*
 	 * send resultset
 	 */
-	SEND_RowDescription(res, admin, "issssiqisssss",
+	SEND_RowDescription(res, admin, "issssiqissssss",
 				 "fd", "task",
 				 "user", "database",
 				 "addr", "port",
 				 "cancel", "link",
 				 "client_encoding", "std_strings",
-				 "datestyle", "timezone", "password");
+				 "datestyle", "timezone",
+				 "password", "search_path");
 	if (res)
 		res = show_pooler_fds(admin);
 

--- a/src/client.c
+++ b/src/client.c
@@ -1,12 +1,12 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
- * 
+ *
  * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -23,6 +23,13 @@
 #include "bouncer.h"
 
 #include <usual/pgutil.h>
+
+static inline const char *str_skip_ws(const char *p)
+{
+  while (*p && isspace(*p))
+    p++;
+  return p;
+}
 
 static const char *hdr2hex(const struct MBuf *data, char *buf, unsigned buflen)
 {
@@ -592,6 +599,109 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 	return true;
 }
 
+static char *scan_for_search_path(struct MBuf *buf, const char type)
+{
+	size_t token_length      = 0;
+	const char * query_str_p = (char *)buf->data + buf->read_pos;
+	const char * nul         = memchr(query_str_p, 0, mbuf_avail_for_read(buf));
+
+	if (!nul) {
+		log_debug("scan_for_search_path: couldn't find null terminator.");
+		return NULL;
+	}
+
+	/* A Parse packet's buffer is composed of the following elements:
+			<null terminated string: prepared statement name>
+			<null terminated string: query string>
+			...
+	   So, to get to the query string, we need to skip past the "prepared statement name" */
+	if (type == 'P') {
+		size_t skip_length = (nul - query_str_p) + 1;
+		query_str_p += skip_length;
+
+		/* make sure we have a null terminated query string */
+		nul = memchr(query_str_p, 0, mbuf_avail_for_read(buf) - skip_length);
+		if (!nul) {
+			log_debug("scan_for_search_path: "
+			          "couldn't find null terminator for query component of Parse packet.");
+			return NULL;
+		}
+	}
+
+#define TOKEN_CHECK(token) \
+	do { \
+		query_str_p  = str_skip_ws(query_str_p); \
+		token_length = strlen(token); \
+		if (strncasecmp(token, query_str_p, token_length) == 0) { \
+			query_str_p += token_length; \
+		} else { \
+			return NULL; \
+		} \
+	} while(0)
+
+	TOKEN_CHECK("SET");
+	TOKEN_CHECK("SEARCH_PATH");
+
+	query_str_p = str_skip_ws(query_str_p);
+
+	/* check for '=' or 'TO' */
+	if (*query_str_p == '=') {
+		query_str_p++;
+	} else {
+		if (toupper(*query_str_p++) != 'T') return NULL;
+		if (toupper(*query_str_p++) != 'O') return NULL;
+	}
+
+	/* skip the last bit of whitespace, leading up to the actual search_path */
+	return (char *) str_skip_ws(query_str_p);
+}
+
+static bool store_client_search_path(PgSocket *client, PktHdr *pkt)
+{
+	/* 112 is large enough for varcache.c::apply_var to not fail */
+	char spath[112];
+	char *spath_p = NULL;
+	char *end     = NULL;
+	size_t length = 0;
+
+	spath_p = scan_for_search_path(&pkt->data, pkt->type);
+	if (spath_p) {
+		length = strlen(spath_p);
+		/* make sure client didn't send an empty search_path */
+		if (length == 0 || *spath_p == ';') {
+			slog_warning(client, "encountered empty search_path; skipping");
+			return false;
+		}
+
+		/* find where the search_path ends and semicolon/whitespace begins */
+		end = spath_p + length - 1;
+		while(end > spath_p && (isspace(*end) || *end == ';'))
+			end--;
+
+		/* and now length is the length of the actual search_path,
+		   sans trailing semicolon/whitespaces */
+		length = (end - spath_p + 1);
+
+		/* make sure our search path is smaller than spath with room for
+		   a null terminator */
+		if (length >= sizeof(spath) - 1) {
+			slog_warning(client, "unable to store search_path; too big (%.*s)", (int) length, spath_p);
+			return false;
+		}
+
+		/* only copy the calculated length, which takes into account
+		   whitespace and semicolons, as defined above */
+		strncpy(spath, spath_p, length);
+		spath[length] = 0; /* we have to null terminate on our own here */
+
+		slog_noise(client, "storing search path (%s)", spath);
+		varcache_set(&client->vars, "search_path", spath);
+		return true;
+	}
+
+	return false;
+}
+
 /* decide on packets of logged-in client */
 static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 {
@@ -640,6 +750,12 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	case 'X': /* Terminate */
 		disconnect_client(client, false, "client close request");
 		return false;
+	}
+
+ 	if (pkt->type == 'Q' || pkt->type == 'P') {
+		/* search_path caching is superfluous in session pool mode, so don't do it */
+		if (cf_consistent_search_path && pool_pool_mode(client->pool) != POOL_SESSION)
+			store_client_search_path(client, pkt);
 	}
 
 	/* update stats */

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,12 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
- * 
+ *
  * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -140,6 +140,7 @@ int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
 int cf_application_name_add_host;
+int cf_consistent_search_path;
 
 int cf_client_tls_sslmode;
 char *cf_client_tls_protocols;
@@ -266,6 +267,7 @@ CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
+CF_ABS("enable_consistent_search_path", CF_INT, cf_consistent_search_path, 0, "0"),
 
 CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, CF_NO_RELOAD, "disabled"),
 CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, CF_NO_RELOAD, ""),

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -79,7 +79,7 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 {
 	int fd;
 	char *task, *saddr, *user, *db;
-	char *client_enc, *std_string, *datestyle, *timezone, *password;
+	char *client_enc, *std_string, *datestyle, *timezone, *password, *search_path;
 	int oldfd, port, linkfd;
 	int got;
 	uint64_t ckey;
@@ -100,10 +100,10 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	}
 
 	/* parse row contents */
-	got = scan_text_result(pkt, "issssiqisssss", &oldfd, &task, &user, &db,
+	got = scan_text_result(pkt, "issssiqissssss", &oldfd, &task, &user, &db,
 			       &saddr, &port, &ckey, &linkfd,
 			       &client_enc, &std_string, &datestyle, &timezone,
-			       &password);
+			       &password, &search_path);
 	if (got < 0 || task == NULL || saddr == NULL)
 		fatal("NULL data from old process");
 
@@ -127,11 +127,11 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	if (strcmp(task, "client") == 0) {
 		res = use_client_socket(fd, &addr, db, user, ckey, oldfd, linkfd,
 				  client_enc, std_string, datestyle, timezone,
-				  password);
+				  password, search_path);
 	} else if (strcmp(task, "server") == 0) {
 		res = use_server_socket(fd, &addr, db, user, ckey, oldfd, linkfd,
 				  client_enc, std_string, datestyle, timezone,
-				  password);
+				  password, search_path);
 	} else if (strcmp(task, "pooler") == 0) {
 		res = use_pooler_socket(fd, pga_is_unix(&addr));
 	} else {

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -1,12 +1,12 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
- * 
+ *
  * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -35,6 +35,7 @@ static const struct var_lookup lookup [] = {
  {"TimeZone",                    VTimeZone },
  {"standard_conforming_strings", VStdStr },
  {"application_name",            VAppName },
+ {"search_path",                 VSearchPath },
  {NULL},
 };
 
@@ -99,9 +100,29 @@ static int apply_var(PktBuf *pkt, const char *key,
 	if (strcasecmp(cval->str, sval->str) == 0)
 		return 0;
 
-	/* the string may have been taken from startup pkt */
-	if (!pg_quote_literal(qbuf, cval->str, sizeof(qbuf)))
-		return 0;
+	/*
+	   Assume the client quoted the search_path correctly, otherwise
+	   pg_quote_literal will incorrectly quote something like
+
+	   		"public", "shared_extensions"
+	   to:
+	   		'"public", "shared_extensions"'
+
+	   Given the above, we memcpy instead of pg_quote_literal if we are
+	   working on the search_path key/value.
+	*/
+	if (strncasecmp("search_path", key, 11) != 0) {
+		/* the string may have been taken from startup pkt */
+		if (!pg_quote_literal(qbuf, cval->str, sizeof(qbuf)))
+			return 0;
+	} else {
+		if (strlen(cval->str) >= sizeof(qbuf)) {
+			log_warning("varcache_apply: search_path to long; skipping (%s)", cval->str);
+			return 0;
+		}
+		/* include null terminator in copy */
+		memcpy(qbuf, cval->str, strlen(cval->str) + 1);
+	}
 
 	/* add SET statement to packet */
 	len = snprintf(buf, sizeof(buf), "SET %s=%s;", key, qbuf);


### PR DESCRIPTION
This enables consistent search_path caching on the client, which is applied to the server each time a client is assigned a server socket.

This is useful for transaction and statement modes as it will ensure that, in e.g., a multi-tenant situation using multiple schemas, the state of the search_path a client socket sets up and expects for a given set of requests, will be maintained across multiple backend server assignments.  In particular, every time a client sends a 'SET SEARCH_PATH...', the client->vars are updated with the current search_path value. This value is then set on a server each time that client is reassigned a server socket.

Note: search_path is not cached on the client if the pool_mode is set to POOL_SESSION as it would be superfluous to do so, given that there is a 1:1 mapping between client & server.

Additional Note: This also adds output to 'SHOW FDS' to allow viewing of currently cached search_path values on client fds.


P.s. This backports pretty cleanly to the 1.6 stable line - I can push a patch for that too if you accept this one.