### PR TITLE
canceling orphan backend

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -199,6 +199,10 @@ avg_sent
 avg_query
     Average query duration in microseconds.
 
+total_homeless
+  Total number of clients who left in an unexpected manner:
+  network problems, client killed by SIGKILL and so on.
+
 SHOW SERVERS;
 -------------
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -199,7 +199,7 @@ avg_sent
 avg_query
     Average query duration in microseconds.
 
-total_homeless
+total_orphan
   Total number of clients who left in an unexpected manner:
   network problems, client killed by SIGKILL and so on.
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -191,6 +191,7 @@ struct PgStats {
 	uint64_t request_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
+	uint64_t homeless_count;
 	usec_t query_time;	/* total req time in us */
 };
 
@@ -481,6 +482,8 @@ extern usec_t g_suspend_start;
 
 extern struct DNSContext *adns;
 extern struct HBA *parsed_hba;
+
+extern int cf_cancel_homeless_backend;
 
 static inline PgSocket * _MUSTCHECK
 pop_socket(struct StatList *slist)

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -191,7 +191,7 @@ struct PgStats {
 	uint64_t request_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
-	uint64_t homeless_count;
+	uint64_t orphan_count;
 	usec_t query_time;	/* total req time in us */
 };
 
@@ -483,7 +483,7 @@ extern usec_t g_suspend_start;
 extern struct DNSContext *adns;
 extern struct HBA *parsed_hba;
 
-extern int cf_cancel_homeless_backend;
+extern int cf_cancel_orphan_backend;
 
 static inline PgSocket * _MUSTCHECK
 pop_socket(struct StatList *slist)

--- a/src/main.c
+++ b/src/main.c
@@ -158,7 +158,7 @@ char *cf_server_tls_cert_file;
 char *cf_server_tls_key_file;
 char *cf_server_tls_ciphers;
 
-int cf_cancel_homeless_backend;
+int cf_cancel_orphan_backend;
 
 /*
  * config file description
@@ -289,7 +289,7 @@ CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, CF_NO_RELOAD, ""),
 CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, CF_NO_RELOAD, "all"),
 CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, CF_NO_RELOAD, "fast"),
 
-CF_ABS("cancel_homeless_backend", CF_INT, cf_cancel_homeless_backend, 0, "0"),
+CF_ABS("cancel_orphan_backend", CF_INT, cf_cancel_orphan_backend, 0, "0"),
 
 {NULL}
 };

--- a/src/main.c
+++ b/src/main.c
@@ -158,6 +158,8 @@ char *cf_server_tls_cert_file;
 char *cf_server_tls_key_file;
 char *cf_server_tls_ciphers;
 
+int cf_cancel_homeless_backend;
+
 /*
  * config file description
  */
@@ -286,6 +288,8 @@ CF_ABS("server_tls_cert_file", CF_STR, cf_server_tls_cert_file, CF_NO_RELOAD, ""
 CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, CF_NO_RELOAD, ""),
 CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, CF_NO_RELOAD, "all"),
 CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, CF_NO_RELOAD, "fast"),
+
+CF_ABS("cancel_homeless_backend", CF_INT, cf_cancel_homeless_backend, 0, "0"),
 
 {NULL}
 };

--- a/src/objects.c
+++ b/src/objects.c
@@ -852,8 +852,8 @@ void disconnect_server(PgSocket *server, bool notify, const char *reason, ...)
 		log_noise("sbuf_close failed, retry later");
 }
 
-/* cancel homeless postgresql backend */
-static void cancel_homeless_backend(PgSocket *server, PgSocket *client)
+/* cancel orphan postgresql backend */
+static void cancel_orphan_backend(PgSocket *server, PgSocket *client)
 {
 	/*
 	 * function for canceling postgresql backend
@@ -881,7 +881,7 @@ static void cancel_homeless_backend(PgSocket *server, PgSocket *client)
 	accept_cancel_request(new_socket);
 
 	/* add stats */
-	client->pool->stats.homeless_count++;
+	client->pool->stats.orphan_count++;
 }
 
 /* drop client connection */
@@ -911,10 +911,10 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 				/* retval does not matter here */
 				release_server(server);
 			} else {
-				/* cancel homeless PostgreSQL backend */
-				if (cf_cancel_homeless_backend == 1) {
+				/* cancel orphan PostgreSQL backend */
+				if (cf_cancel_orphan_backend == 1) {
 					hold_connection = true;
-					cancel_homeless_backend(server, client);
+					cancel_orphan_backend(server, client);
 				}
 
 				server->link = NULL;
@@ -940,7 +940,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 	}
 
 	/*
-	 * we don't want to free new 'cancel' connection for homeless client
+	 * we don't want to free new 'cancel' connection for orphan client
 	 */
 	if (!hold_connection)
 		change_client_state(client, CL_JUSTFREE);

--- a/src/stats.c
+++ b/src/stats.c
@@ -27,7 +27,7 @@ static void reset_stats(PgStats *stat)
 	stat->client_bytes = 0;
 	stat->request_count = 0;
 	stat->query_time = 0;
-	stat->homeless_count = 0;
+	stat->orphan_count = 0;
 }
 
 static void stat_add(PgStats *total, PgStats *stat)
@@ -36,7 +36,7 @@ static void stat_add(PgStats *total, PgStats *stat)
 	total->client_bytes += stat->client_bytes;
 	total->request_count += stat->request_count;
 	total->query_time += stat->query_time;
-	total->homeless_count += stat->homeless_count;
+	total->orphan_count += stat->orphan_count;
 }
 
 static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
@@ -66,7 +66,7 @@ static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
 			     stat->server_bytes, stat->query_time,
 			     avg.request_count, avg.client_bytes,
 			     avg.server_bytes, avg.query_time,
-			     stat->homeless_count);
+			     stat->orphan_count);
 }
 
 bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
@@ -93,7 +93,7 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 				    "total_requests", "total_received",
 				    "total_sent", "total_query_time",
 				    "avg_req", "avg_recv", "avg_sent",
-				    "avg_query", "total_homeless");
+				    "avg_query", "total_orphan");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
 
@@ -159,7 +159,7 @@ bool show_stat_totals(PgSocket *client, struct StatList *pool_list)
 	WTOTAL(client_bytes);
 	WTOTAL(server_bytes);
 	WTOTAL(query_time);
-	WTOTAL(homeless_count);
+	WTOTAL(orphan_count);
 	WAVG(request_count);
 	WAVG(client_bytes);
 	WAVG(server_bytes);


### PR DESCRIPTION
PostgreSQL and pgbouncer 'chain' have a problem:

If client of PgBouncer goes away in unexpected manner (for example, python client dies, network problems),
PgBouncer will send to PostgreSQL only "terminate" request (I mean terminate packet by protocol, not pg_terminate_backend).
After that, PostgreSQL will fully process
query/transaction before terminate backend.

This is a problem when we have a lot of expensive and long queries. Why should we waste CPU and I/O for 'homeless'
backends?

I created a concept of patch for resolving this problem.
This patch is for master branch.
Can anybody review it?
