### PR TITLE
Make build reproducible by dropping DBGVER handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,6 @@ LIBUSUAL_DIST = $(filter-out %/config.h, $(wildcard \
 		lib/README lib/COPYRIGHT \
 		lib/find_modules.sh ))
 
-ifeq ($(enable_debug),yes)
-CPPFLAGS += -DDBGVER="\"compiled by <$${USER}@`hostname`> at `date '+%Y-%m-%d %H:%M:%S'`\""
-endif
-
 #
 # win32
 #

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -37,11 +37,7 @@
 #include <usual/event.h>
 #include <usual/strpool.h>
 
-#ifdef DBGVER
-#define FULLVER   PACKAGE_NAME " version " PACKAGE_VERSION " (" DBGVER ")"
-#else
 #define FULLVER   PACKAGE_NAME " version " PACKAGE_VERSION
-#endif
 
 /* each state corresponds to a list */
 enum SocketState {


### PR DESCRIPTION
Debian wants debug symbols for all builds (the binaries are stripped by
debhelper's dh_strip), but the "(compiled by...)" information added for
debug builds defeats the goal to make builds reproducible on the binary
level. Fix by dropping the DBGVER information which doesn't serve any
purpose if the build output is byte-identical on rebuild.

https://wiki.debian.org/ReproducibleBuilds