### PR TITLE
Set last_connect_time for pool only when it really failed to connect

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -230,7 +230,7 @@ struct PgPool {
 	usec_t last_lifetime_disconnect;/* last time when server_lifetime was applied */
 
 	/* if last connect failed, there should be delay before next */
-	usec_t last_connect_time;
+	usec_t last_connect_failed_time;
 	unsigned last_connect_failed:1;
 
 	unsigned welcome_msg_ready:1;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -231,7 +231,6 @@ struct PgPool {
 
 	/* if last connect failed, there should be delay before next */
 	usec_t last_connect_failed_time;
-	unsigned last_connect_failed:1;
 
 	unsigned welcome_msg_ready:1;
 };


### PR DESCRIPTION
and rename last_connect_time to last_connect_failed_time to make it
clearer its purpose.

Last couple of months we were observing very strange issues with pgbouncer.
From time to time it was starting to fail and producing following log lines:
'launch_new_connection: last failed, wait'
And clients were disconnected with the message: "pgbouncer cannot connect to server"

We run pgbouncer with server_login_retry = 15 seconds (default setting)
That means after 15 seconds it should try to establish connection to backend and after success reset `last_connect_failed` flag. But it was never happened (flag was never reset).
We had enabled debug logs (verbose = 2) and started investigating.
Every time problems were starting with:
WARNING sbuf_connect failed: Resource temporarily unavailable (EAGAIN, full backlog on unix domain socket)

laster there were a lot of messages "launch_new_connection: last failed, wait" and after 15 seconds:
2016-04-06 13:43:29.221 75936 DEBUG S-0x1734db0: db_name/user_name@unix:5432 launching new connection to server
2016-04-06 13:43:29.221 75936 DEBUG S-0x1734db0: db_name/user_name@unix:5432 S: connect ok
2016-04-06 13:43:29.221 75936 DEBUG S-0x1734db0: db_name/user_name@unix:5432 use it for pending cancel req

That means, connection was opened successfully, but this connection was used for forwarding "cancel request" and closed right after. As a consequence, LOGIN phase was not complete and 
`last_connect_failed` flag was not reset. BUT! `last_connect_time` value was updated much earlier, before it even tried to establish connection with the postgres.

And again we have "launch_new_connection: last failed, wait" during 15 seconds.

Obviously we have some issues with our setup:
1) `pool_size` is too small and pgbouncer is opening new connections too often.
2) `net.core.somaxconn = 128` is too small and definitely must be increased (this should help to mitigate `backlog` problems)
3) Somehow we have too much "cancel requests". But I expect this to be a consequence of first failure to open a new connection. Because Our pgbouncer is used only by plproxy and for every query executed through plproxy we have 8 connections to pgbouncer (to the same database). 

Sure, we already fixed 1 and 2, but in my opinion pgbouncer should handle such case (when there are pending cancel requests) correctly and this pull request intended to fix it.
