### PR TITLE
Don't send ReadyForQuery on main_connection for CancelQuery requests

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1529,18 +1529,11 @@ void admin_pause_done(void)
 /* admin on console has pressed ^C */
 void admin_handle_cancel(PgSocket *admin)
 {
-	bool res;
-
 	/* weird, but no reason to fail */
 	if (!admin->wait_for_response)
 		slog_warning(admin, "admin cancel request for non-waiting client?");
 
 	if (cf_pause_mode != P_NONE)
 		full_resume();
-
-	/* notify readiness */
-	SEND_ReadyForQuery(res, admin);
-	if (!res)
-		disconnect_client(admin, false, "readiness send failed");
 }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -1280,8 +1280,6 @@ found:
 
 	/* not linked client, just drop it then */
 	if (!main_client->link) {
-		bool res;
-
 		/* let administrative cancel be handled elsewhere */
 		if (main_client->pool->db->admin) {
 			disconnect_client(req, false, "cancel request for console client");
@@ -1291,10 +1289,6 @@ found:
 
 		disconnect_client(req, false, "cancel request for idle client");
 
-		/* notify readiness */
-		SEND_ReadyForQuery(res, main_client);
-		if (!res)
-			disconnect_client(main_client, true, "ReadyForQuery for main_client failed");
 		return;
 	}
 


### PR DESCRIPTION
Don't send ReadyForQuery on main_connection as it may cause clients to get out of sync. Drop the connection for idle clients.

https://github.com/pgbouncer/pgbouncer/issues/141
