### PR TITLE
track maxwait_us to enable seeing sub 1s maxwait stats

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -792,7 +792,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				    "sv_active", "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
-				    "pool_mode");
+                    "maxwait_us", "pool_mode");
 	statlist_for_each(item, &pool_list) {
 		pool = container_of(item, PgPool, head);
 		waiter = first_socket(&pool->waiting_client_list);
@@ -809,6 +809,9 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				     /* how long is the oldest client waited */
 				     (waiter && waiter->query_start)
 				     ?  (int)((now - waiter->query_start) / USEC) : 0,
+				     /* how long has the oldest client waited, in microseconds */
+				     (waiter && waiter->query_start)
+				     ?  (int)((now - waiter->query_start)) : 0,
 				     cf_get_lookup(&cv));
 	}
 	admin_flush(admin, buf, "SHOW");


### PR DESCRIPTION
seeing as `maxwait` is measured in seconds, and cast from an integer, you cannot see any `maxwait` below 999ms - they all show up as `0`.

The existing `maxwait` stat is left around for backwards compatability, but in general is far less useful to the average user.
