### PR TITLE
Add support for map= option

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -147,6 +147,8 @@ extern int cf_sbuf_len;
 /* buffer size for startup noise */
 #define STARTUP_BUF	1024
 
+#define RULE_HAS_MAP_MASK_ON  0x10
+#define RULE_HAS_MAP_MASK_OFF 0xFFEF
 
 /*
  * Remote/local address
@@ -272,6 +274,8 @@ struct PgUser {
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
+  bool has_map; // username matched a hba rule map
+	char matched_name[MAX_USERNAME];
 };
 
 /*
@@ -481,6 +485,19 @@ extern usec_t g_suspend_start;
 
 extern struct DNSContext *adns;
 extern struct HBA *parsed_hba;
+extern struct MapList *map_list;
+
+struct MapList {
+	struct List maps;
+};
+
+struct HBAIdent {
+	struct List node;
+  char *mapname;
+  char *sys_name;
+  char *db_name;
+};
+
 
 static inline PgSocket * _MUSTCHECK
 pop_socket(struct StatList *slist)
@@ -514,3 +531,7 @@ void load_config(void);
 bool set_config_param(const char *key, const char *val);
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, bool reloadable),
 		     void *arg);
+
+void hba_load_map( char *fn, struct MapList *map_list);
+void get_usermap( char *username, char *mapname );
+bool get_usermap_tls( char *username, char *uname, char *mapname );

--- a/include/hba.h
+++ b/include/hba.h
@@ -20,5 +20,4 @@ struct HBA;
 
 struct HBA *hba_load_rules(const char *fn);
 void hba_free(struct HBA *hba);
-int hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username);
-
+int hba_eval(struct HBA *hba, PgSocket *client);

--- a/src/hba.c
+++ b/src/hba.c
@@ -21,6 +21,7 @@
 #include <usual/cxextra.h>
 #include <usual/cbtree.h>
 #include <usual/fileutil.h>
+#include <regex.h>
 
 enum RuleType {
 	RULE_LOCAL,
@@ -42,6 +43,34 @@ struct HBAName {
 	struct StrSet *name_set;
 };
 
+struct HBAOpts {
+  char *name;
+  char *value;
+
+	char *usermap;
+	char *pamservice;
+	bool pam_use_hostname;
+	bool ldaptls;
+	char *ldapserver;
+	int	 ldapport;
+	char *ldapbinddn;
+	char *ldapbindpasswd;
+	char *ldapsearchattribute;
+	char *ldapbasedn;
+	int  ldapscope;
+	char *ldapprefix;
+	char *ldapsuffix;
+	bool clientcert;
+	char *krb_realm;
+	bool include_realm;
+	bool compat_realm;
+	bool upn_username;
+	char *radiusserver;
+	char *radiussecret;
+	char *radiusidentifier;
+	int  radiusport;
+};
+
 struct HBARule {
 	struct List node;
 	enum RuleType rule_type;
@@ -51,6 +80,7 @@ struct HBARule {
 	uint8_t rule_mask[16];
 	struct HBAName db_name;
 	struct HBAName user_name;
+  struct HBAOpts auth_opts;
 };
 
 struct HBA {
@@ -78,6 +108,7 @@ struct StrSet *strset_new(CxMem *cx);
 void strset_free(struct StrSet *set);
 bool strset_add(struct StrSet *set, const char *str, unsigned int len);
 bool strset_contains(struct StrSet *set, const char *str, unsigned int len);
+bool parse_hba_auth_opt( struct HBARule *rule, char *buf);
 
 struct StrSet *strset_new(CxMem *cx)
 {
@@ -197,7 +228,7 @@ static bool tok_buf_check(struct TokParser *p, size_t len)
 	if (p->buflen >= len)
 		return true;
 	tmplen = len*2;
-	tmp = realloc(p->buf, tmplen);
+	tmp = realloc(p->buf, tmplen+1);
 	if (!tmp)
 		return false;
 	p->buf = tmp;
@@ -517,7 +548,7 @@ static bool parse_line(struct HBA *hba, struct TokParser *tp, int linenr, const 
 		return false;
 	}
 
-	rule = calloc(sizeof *rule, 1);
+	rule = calloc(sizeof(*rule), 1);
 	if (!rule) {
 		log_warning("hba: no mem for rule");
 		goto failed;
@@ -588,6 +619,14 @@ static bool parse_line(struct HBA *hba, struct TokParser *tp, int linenr, const 
 		log_warning("hba line %d: unsupported method: buf=%s", linenr, tp->buf);
 		goto failed;
 	}
+
+  if(parse_hba_auth_opt( rule, tp->buf ))
+  {
+    while(eat(tp,TOK_IDENT))
+    {
+      parse_hba_auth_opt( rule, tp->buf );
+    }
+  }
 
 	if (!eat(tp, TOK_EOL)) {
 		log_warning("hba line %d: unsupported parameters", linenr);
@@ -689,13 +728,24 @@ static bool match_inet6(const struct HBARule *rule, PgAddr *addr)
 		(src[2] & mask[2]) == base[2] && (src[3] & mask[3]) == base[3];
 }
 
-int hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username)
+int hba_eval(struct HBA *hba, PgSocket *client)
 {
 	struct List *el;
 	struct HBARule *rule;
-	unsigned int dbnamelen = strlen(dbname);
-	unsigned int unamelen = strlen(username);
+  PgAddr *addr;
+  bool is_tls;
+  const char *dbname;
+  char *username;
+	unsigned int dbnamelen ;
+	unsigned int unamelen ;
 
+  addr     = &client->remote_addr;
+  is_tls   = !!client->sbuf.tls;
+  dbname   = client->db->name;
+  username = client->auth_user->name;
+
+  dbnamelen = strlen(dbname);
+  unamelen = strlen(username);
 	if (!hba)
 		return AUTH_REJECT;
 
@@ -728,9 +778,554 @@ int hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, con
 		if (!name_match(&rule->user_name, username, unamelen, dbname))
 			continue;
 
+    /* apply usermap */
+    if( rule->auth_opts.name )
+    {
+      if( (rule->rule_method == AUTH_CERT) && is_tls )
+      {
+        // Compare to the CN entry returned in client.c
+        if(get_usermap_tls(client->auth_user->matched_name,client->auth_user->name,rule->auth_opts.value))
+        {
+          client->auth_user->has_map = true;
+        }
+      }
+      else if ( rule->rule_method == AUTH_PEER ) {
+        // Save the current name
+        /* client->auth_user->matched_name = *username; */
+        get_usermap(username,rule->auth_opts.value);
+      }
+    }
+
 		/* rule matches */
 		return rule->rule_method;
 	}
 	return AUTH_REJECT;
 }
 
+bool parse_hba_auth_opt( struct HBARule *rule, char *buf)
+{
+  char *name = strdup(buf);
+  char *val  = strchr(name, '=');
+  bool res = false;
+
+  if ( val != NULL ) {
+    *val++ = 0;
+    if ( strcmp( name, "map") == 0) {
+      if( 
+          rule->rule_method != AUTH_PEER &&
+          rule->rule_method != AUTH_CERT
+        )
+      {
+        res = false;
+        goto exit;
+      }
+      rule->auth_opts.name  = strdup(name);
+      rule->auth_opts.value = strdup(val);
+      res = true;
+    }
+    else if (strcmp(name, "clientcert") == 0)
+    {
+      /*
+       * Since we require ctHostSSL, this really can never happen on
+       * non-SSL-enabled builds, so don't bother checking for USE_SSL.
+       */
+      if ( rule->rule_type != RULE_HOSTSSL )
+      {
+        log_error("clientcert can only be configured for \"hostssl\" rows");
+        res = false;
+        goto exit;
+      }
+      if (strcmp(val, "1") == 0)
+      {
+        // TODO : Check
+        // if (!secure_loaded_verify_locations())
+        // {
+        //   ereport(LOG,
+        //       (errcode(ERRCODE_CONFIG_FILE_ERROR),
+        //        errmsg("client certificates can only be checked if a root certificate store is available"),
+        //        errhint("Make sure the configuration parameter \"%s\" is set.", "ssl_ca_file"),
+        //        errcontext("line %d of configuration file \"%s\"",
+        //          line_num, HbaFileName)));
+        //   return false;
+        // }
+        rule->auth_opts.clientcert = true;
+        res = true;
+      }
+      else
+      {
+        if ( rule->rule_method == AUTH_CERT )
+        {
+          log_error("clientcert can not be set to 0 when using \"cert\" authentication");
+          res = false;
+          goto exit;
+        }
+        rule->auth_opts.clientcert = false;
+        res = true;
+      }
+    }
+    else if (strcmp(name, "pamservice") == 0)
+    {
+      /* REQUIRE_AUTH_OPTION(uaPAM, "pamservice", "pam"); */
+      rule->auth_opts.pamservice = strdup(val);
+      res = true;
+    }
+    else if (strcmp(name, "pam_use_hostname") == 0)
+    {
+      /* REQUIRE_AUTH_OPTION(uaPAM, "pam_use_hostname", "pam"); */
+      if (strcmp(val, "1") == 0)
+      {
+        rule->auth_opts.pam_use_hostname = true;
+      }
+      else
+      {
+        rule->auth_opts.pam_use_hostname = false;
+      }
+
+      res = true;
+
+    }
+    else if (strcmp(name, "ldapurl") == 0)
+    {
+// #ifdef LDAP_API_FEATURE_X_OPENLDAP
+//       LDAPURLDesc *urldata;
+//       int			rc;
+// #endif
+// 
+//       REQUIRE_AUTH_OPTION(uaLDAP, "ldapurl", "ldap");
+// #ifdef LDAP_API_FEATURE_X_OPENLDAP
+//       rc = ldap_url_parse(val, &urldata);
+//       if (rc != LDAP_SUCCESS)
+//       {
+//         ereport(LOG,
+//             (errcode(ERRCODE_CONFIG_FILE_ERROR),
+//              errmsg("could not parse LDAP URL \"%s\": %s", val, ldap_err2string(rc))));
+//         return false;
+//       }
+// 
+//       if (strcmp(urldata->lud_scheme, "ldap") != 0)
+//       {
+//         ereport(LOG,
+//             (errcode(ERRCODE_CONFIG_FILE_ERROR),
+//              errmsg("unsupported LDAP URL scheme: %s", urldata->lud_scheme)));
+//         ldap_free_urldesc(urldata);
+//         return false;
+//       }
+// 
+//       hbaline->ldapserver = pstrdup(urldata->lud_host);
+//       hbaline->ldapport = urldata->lud_port;
+//       hbaline->ldapbasedn = pstrdup(urldata->lud_dn);
+// 
+//       if (urldata->lud_attrs)
+//         hbaline->ldapsearchattribute = pstrdup(urldata->lud_attrs[0]);		/* only use first one */
+//       hbaline->ldapscope = urldata->lud_scope;
+//       if (urldata->lud_filter)
+//       {
+//         ereport(LOG,
+//             (errcode(ERRCODE_CONFIG_FILE_ERROR),
+//              errmsg("filters not supported in LDAP URLs")));
+//         ldap_free_urldesc(urldata);
+//         return false;
+//       }
+//       ldap_free_urldesc(urldata);
+// #else							/* not OpenLDAP */
+//       ereport(LOG,
+//           (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+//            errmsg("LDAP URLs not supported on this platform")));
+// #endif   /* not OpenLDAP */
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldaptls") == 0)
+    {
+    //   REQUIRE_AUTH_OPTION(uaLDAP, "ldaptls", "ldap");
+    //   if (strcmp(val, "1") == 0)
+    //     hbaline->ldaptls = true;
+    //   else
+    //     hbaline->ldaptls = false;
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapserver") == 0)
+    {
+    //  REQUIRE_AUTH_OPTION(uaLDAP, "ldapserver", "ldap");
+    //  hbaline->ldapserver = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapport") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapport", "ldap");
+      // hbaline->ldapport = atoi(val);
+      // if (hbaline->ldapport == 0)
+      // {
+      //   ereport(LOG,
+      //       (errcode(ERRCODE_CONFIG_FILE_ERROR),
+      //        errmsg("invalid LDAP port number: \"%s\"", val),
+      //        errcontext("line %d of configuration file \"%s\"",
+      //          line_num, HbaFileName)));
+      //   return false;
+      // }
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapbinddn") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapbinddn", "ldap");
+      // hbaline->ldapbinddn = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapbindpasswd") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapbindpasswd", "ldap");
+      // hbaline->ldapbindpasswd = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapsearchattribute") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapsearchattribute", "ldap");
+      // hbaline->ldapsearchattribute = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapbasedn") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapbasedn", "ldap");
+      // hbaline->ldapbasedn = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapprefix") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapprefix", "ldap");
+      // hbaline->ldapprefix = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "ldapsuffix") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaLDAP, "ldapsuffix", "ldap");
+      // hbaline->ldapsuffix = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "krb_realm") == 0)
+    {
+      // if (rule->auth_method != uaGSS &&
+      //     rule->auth_method != uaSSPI)
+        // INVALID_AUTH_OPTION("krb_realm", gettext_noop("gssapi and sspi"));
+        // hbaline->krb_realm = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "include_realm") == 0)
+    {
+      // if (hbaline->auth_method != uaGSS &&
+      //     hbaline->auth_method != uaSSPI)
+      //   INVALID_AUTH_OPTION("include_realm", gettext_noop("gssapi and sspi"));
+      if (strcmp(val, "1") == 0)
+      {
+        rule->auth_opts.include_realm = true;
+      }
+      else
+      {
+        rule->auth_opts.include_realm = false;
+      }
+      res = true;
+    }
+    else if (strcmp(name, "compat_realm") == 0)
+    {
+      // if (hbaline->auth_method != uaSSPI)
+      //   INVALID_AUTH_OPTION("compat_realm", gettext_noop("sspi"));
+      // if (strcmp(val, "1") == 0)
+      //   hbaline->compat_realm = true;
+      // else
+      //   hbaline->compat_realm = false;
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "upn_username") == 0)
+    {
+      // if (hbaline->auth_method != uaSSPI)
+      //   INVALID_AUTH_OPTION("upn_username", gettext_noop("sspi"));
+      // if (strcmp(val, "1") == 0)
+      //   hbaline->upn_username = true;
+      // else
+      //   hbaline->upn_username = false;
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "radiusserver") == 0)
+    {
+     // struct addrinfo *gai_result;
+     //   struct addrinfo hints;
+     //   int			ret;
+  
+     //   REQUIRE_AUTH_OPTION(uaRADIUS, "radiusserver", "radius");
+  
+     //   MemSet(&hints, 0, sizeof(hints));
+     //   hints.ai_socktype = SOCK_DGRAM;
+     //   hints.ai_family = AF_UNSPEC;
+  
+     //   ret = pg_getaddrinfo_all(val, NULL, &hints, &gai_result);
+     //   if (ret || !gai_result)
+     //   {
+     //     ereport(LOG,
+     //         (errcode(ERRCODE_CONFIG_FILE_ERROR),
+     //          errmsg("could not translate RADIUS server name \"%s\" to address: %s",
+     //            val, gai_strerror(ret)),
+     //          errcontext("line %d of configuration file \"%s\"",
+     //            line_num, HbaFileName)));
+     //     if (gai_result)
+     //       pg_freeaddrinfo_all(hints.ai_family, gai_result);
+     //     return false;
+     //   }
+     //   pg_freeaddrinfo_all(hints.ai_family, gai_result);
+     //   hbaline->radiusserver = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "radiusport") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaRADIUS, "radiusport", "radius");
+      // hbaline->radiusport = atoi(val);
+      // if (hbaline->radiusport == 0)
+      // {
+      //   ereport(LOG,
+      //       (errcode(ERRCODE_CONFIG_FILE_ERROR),
+      //        errmsg("invalid RADIUS port number: \"%s\"", val),
+      //        errcontext("line %d of configuration file \"%s\"",
+      //          line_num, HbaFileName)));
+      //   return false;
+      // }
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "radiussecret") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaRADIUS, "radiussecret", "radius");
+      // hbaline->radiussecret = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else if (strcmp(name, "radiusidentifier") == 0)
+    {
+      // REQUIRE_AUTH_OPTION(uaRADIUS, "radiusidentifier", "radius");
+      // hbaline->radiusidentifier = pstrdup(val);
+        res = false;
+        goto exit;
+    }
+    else
+    {
+      log_error("unrecognized authentication option name: \"%s\"", name);
+      res = false;
+      goto exit;
+    }
+  }
+
+exit:
+  free(name);
+  return res;
+}
+
+void hba_load_map( char *fn ,  struct MapList *mlist)
+{
+  struct HBAIdent *map_ident = NULL;
+	FILE *f = NULL;
+	char *ln = NULL;
+	size_t lnbuf = 0;
+	ssize_t len;
+	int linenr;
+	struct TokParser tp;
+
+  if (!mlist) {
+    return;
+  }
+
+  list_init(&mlist->maps);
+	init_parser(&tp);
+
+	f = fopen(fn, "r");
+	if (!f)
+  {
+		free(fn);
+    log_error("no ident file, please set cf_auth_ident_file");
+    return;
+  }
+
+	for (linenr = 1; ; linenr++) {
+    map_ident = calloc(sizeof(*map_ident), 1);
+    if (!map_ident) {
+      log_warning("hba: no mem for map_ident");
+      fclose(f);
+      goto finish;
+    }
+
+		len = getline(&ln, &lnbuf, f);
+		if (len < 0)
+    {
+      free(map_ident);
+			break;
+    }
+
+    parse_from_string(&tp, ln);
+    
+    if( tp.cur_tok == TOK_EOL   ||
+        tp.cur_tok == TOK_FAIL  ||
+        tp.cur_tok == TOK_COMMA
+      )
+    {
+      free(map_ident);
+      continue;
+    }
+
+    map_ident->mapname = strdup(tp.cur_tok_str);
+    if(!eat(&tp, TOK_IDENT))
+    {
+      free(map_ident);
+      continue;
+    }
+
+    map_ident->sys_name = strdup(tp.cur_tok_str);
+    if(!eat(&tp, TOK_IDENT))
+    {
+      free(map_ident);
+      continue;
+    }
+
+
+    map_ident->db_name = strdup(tp.cur_tok_str);
+
+    list_append(&mlist->maps, &map_ident->node);
+
+		/* if (!parse_line(hba, &tp, linenr, fn)) { */
+		/* 	 Ignore line, but parse to the end. */ 
+		/* 	continue; */
+		/* } */
+	}
+
+	if (!eat(&tp, TOK_IDENT)) {
+		log_warning("Malformed line %d", linenr);
+	}
+
+finish:
+  map_ident = NULL;
+  free(ln);
+  fclose(f);
+  free_parser(&tp);
+  return;
+}
+
+void get_usermap( char *uname, char *map_name )
+{
+  // Chercher une règle mname matchant uname 
+  struct List *el;
+  struct HBAIdent *map;
+  extern struct MapList *map_list;
+  char *regex;
+  int nm_len,err;
+  regex_t preg;
+
+  if( !map_list )
+  {
+    return;
+  }
+
+  list_for_each(el, &map_list->maps){
+
+    map = container_of(el, struct HBAIdent, node);
+    if ( strcmp( map->mapname, map_name) != 0 ) {
+      continue;
+    }
+
+    if( strcmp( uname, map->sys_name) == 0 )
+    {
+
+      if( strlen(map->db_name) <= MAX_USERNAME )
+      {
+        strcpy( uname, map->db_name);
+      }
+      return;
+      
+    } else if ( map->sys_name[0] == '/' )
+    {
+      //regex case
+      nm_len = 0;
+      while( map->sys_name[nm_len] != '\0' )
+      {
+        nm_len++;
+      }
+      nm_len--;
+      
+      regex = strdup(map->sys_name+1);
+      /* regex[nm_len-1] = '\0'; */
+
+      // Compile
+      err = regcomp (&preg, regex, REG_EXTENDED);
+      if( !err )
+      {
+        int match;
+        match = regexec (&preg, uname, 0, NULL, 0);
+        regfree (&preg);
+
+        if (match == 0)
+        {
+          
+          if( strlen(map->db_name) <= MAX_USERNAME )
+          {
+            strcpy( uname, map->db_name);
+          }
+          return;
+        }
+        else if (match == REG_NOMATCH)
+        {
+          return;
+        } 
+        else
+        {
+          char *text;
+          size_t size;
+
+          size = regerror (err, &preg, NULL, 0);
+          text = malloc (sizeof (*text) * size);
+          if (text)
+          {
+            regerror (err, &preg, text, size);
+            log_warning( "%s\n",text);
+            free (text);
+          }
+          else
+          {
+            log_warning("No memory for text");
+          }
+          return;
+        }
+      }
+      else
+      {
+        log_warning("Couldnt compile regex, no memory left");
+      }
+
+      return;
+    }
+  }
+  // No rule found
+  return;
+
+}
+
+bool get_usermap_tls( char *CN, char* uname, char *map_name )
+{
+  char *name = strdup(CN);
+  get_usermap(name, map_name);
+
+  if( strcmp(name, uname) == 0)
+  {
+    // There's a rule matching and submitted user
+    return true;
+  }
+
+  free(name);
+  return false;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 
 noinst_PROGRAMS = hba_test
 hba_test_CPPFLAGS = -I../include
-hba_test_CFLAGS = -O0
+hba_test_CFLAGS = -O0 -g -std=c99
 hba_test_SOURCES = hba_test.c ../src/hba.c ../src/util.c
 hba_test_EMBED_LIBUSUAL = 1
 
@@ -36,3 +36,5 @@ all: run_test
 run_test: hba_test
 	./hba_test
 
+valgrind: hba_test
+	valgrind --leak-check=full ./hba_test > valtest.txt 2>&1

--- a/test/hba_test.rules
+++ b/test/hba_test.rules
@@ -17,7 +17,7 @@ local		all		userp					password
 local		dbz		userz					trust
 local		all		all					md5
 
-hostssl		all		all	10.0.0.0/8			cert
+hostssl		all		all	10.0.0.0/8			cert map=gui
 hostnossl	all		all	11.0.0.0/8			md5
 host		all		all	127.0.0.0  255.255.255.0	password
 

--- a/test/map_ident_test.rules
+++ b/test/map_ident_test.rules
@@ -1,0 +1,4 @@
+gui   user bottom
+gui   user2    rapouille
+triche  jiji  crapule
+guo /^.*$/  robtnik


### PR DESCRIPTION
Allow map and clientcert options with regex support.
Require a new function from libusual
