### PR TITLE
Make pam_init happen in the child process when forking

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -891,7 +891,6 @@ int main(int argc, char *argv[])
 	check_limits();
 
 	admin_setup();
-	pam_init();
 
 	if (cf_reboot) {
 		if (check_old_process_unix()) {
@@ -919,6 +918,8 @@ int main(int argc, char *argv[])
 	signal_setup();
 	janitor_setup();
 	stats_setup();
+
+	pam_init();
 
 	if (did_takeover) {
 		takeover_finish();


### PR DESCRIPTION
When starting pgbouncer with -d (which is for example what the default is on a CentOS platform when using yum.postgresql.org at least), the pam authentication method does not work. Looking at it with gdb, it seems the background thread required for it is simply not created.

When starting without -d it works fine -- so just modifying the systemd startup file to not be a forking server works. But it seems there's an issue somewhere in pgbouncer as well, and it's 100% reproducible outside a systemd environment.

My guess is that the pam_init() call is happening in the process than then goes away, and it needs to happen after the go_daemon() call. 

The following patch *seems* to work, but I'd appreciate a review from somebody who knows pgbouncer better than me. In particular, there may be an even better place for it? In particular related to the takeover code?
