### PR TITLE
Add 'pool_waitings' counter to 'SHOW STATS'.

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -191,6 +191,7 @@ struct PgStats {
 	uint64_t request_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
+	uint64_t pool_waitings;
 	usec_t query_time;	/* total req time in us */
 };
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -185,6 +185,9 @@ void change_client_state(PgSocket *client, SocketState newstate)
 		statlist_append(&login_client_list, &client->head);
 		break;
 	case CL_WAITING:
+                /* count only logged in clients waiting for busy pool */
+		if (pool->active_server_list.cur_count >= pool->db->pool_size)
+			pool->stats.pool_waitings++;
 	case CL_WAITING_LOGIN:
 		statlist_append(&pool->waiting_client_list, &client->head);
 		break;


### PR DESCRIPTION
'cl_waiting' is main metric for monitoring pool satturation and postgres performance.
But it is not enough because it shows only current state and can't be aggregated.
It would be nice to have counter of waiting clients in pgbouncer pool.

I added 'pool_waitings' counter to 'SHOW STATS' which counts only logged in clients waiting for busy pool.
