### PR TITLE
Increased maximum length for postgres password

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -855,6 +855,8 @@ for this database.
 Otherwise PgBouncer tries to log into the destination database with client
 username, meaning that there will be one pool per user.
 
+The value for ``password``is limited to 128 characters maximum.
+
 auth_user
 ---------
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -855,7 +855,7 @@ for this database.
 Otherwise PgBouncer tries to log into the destination database with client
 username, meaning that there will be one pool per user.
 
-The value for ``password``is limited to 128 characters maximum.
+The length for ``password`` is limited to 128 characters maximum.
 
 auth_user
 ---------

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -110,7 +110,7 @@ extern int cf_sbuf_len;
 /* to avoid allocations will use static buffers */
 #define MAX_DBNAME	64
 #define MAX_USERNAME	64
-#define MAX_PASSWORD	64
+#define MAX_PASSWORD	128
 
 /* no-auth modes */
 #define AUTH_ANY	-1 /* same as trust but without username check */


### PR DESCRIPTION
As the postgres password is hashed it can easily become bigger than 64 characters on some deployments. 

Some providers (for example Heroku) have begun to adopt improved security policies for the postgres credentials generated automatically by their systems. In the situation where the credential is bigger than 64 characters, pgbouncer will simply read an incomplete password from the configuration file and then try to use it for authentication, resulting on a log message stating that the password authentication has failed, as below:

`WARNING server login failed: FATAL password authentication failed for user "blablatest"`

There is no indication whatsoever that the problem is actually located on the pgbouncer side. This small change increases the size of the password buffer to cope with lengthier passwords.