### PR TITLE
Fixed issue #161 unable to connect to EDB-PostGreSQL

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -175,7 +175,7 @@ bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, int sa_len, int timeout
 		/* unix socket gives connection immediately */
 		sbuf_connect_cb(sock, EV_WRITE, sbuf);
 		return true;
-	} else if (errno == EINPROGRESS) {
+	} else if (errno == EINPROGRESS || errno == WSAEWOULDBLOCK) {
 		/* tcp socket needs waiting */
 		event_set(&sbuf->ev, sock, EV_WRITE, sbuf_connect_cb, sbuf);
 		res = event_add(&sbuf->ev, &timeout);


### PR DESCRIPTION
I was having the same issue as 00j using EDB-PostgreSQL on windows. I compiled versions 1.6.1, 1.7.1, 1.7.2 and had the same issue across all three versions. I added in the logging around the socket connection and noticed an error code was coming back but not one that was recognised by the log_warning after the failed label. Googling the error code took me here [stack overflow recfrom error](http://stackoverflow.com/questions/17064069/recvfrom-error-10035-using-non-blocking-sockets)

Putting in the same delay as EINPROGRESS fixes the issue by adding errno == WSAEWOULDBLOCK to the error check.