### PR TITLE
Log error on failure to load auth_file

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -550,6 +550,13 @@ bool load_auth_file(const char *fn)
 
 	buf = load_file(fn, NULL);
 	if (buf == NULL) {
+		/*
+		 * Defaults to the string unconfigured_file, so don't log
+		 * error in this case.
+		 */
+		if (strcmp(fn, "unconfigured_file"))
+			log_error("could not open auth_file %s: %m", fn);
+
 		/* reset file info */
 		auth_loaded(NULL);
 		return false;


### PR DESCRIPTION
Only logging a debug message when things work and not an error when they
don't is a bit user-unfriendly.

Explicitly avoid logging in the case that auth_file hasn't been
configured at all, to make sure we don't spam logs unnecessraily. But if
a configured file exists and can't be opened, we log.

Fixes #192