### PR TITLE
Fix incorrect references to auth_mode

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -713,8 +713,8 @@ PgBouncer 1.3.x
 
   * Fix SHOW DATABASES which was broken due to column addition.
 
-  * Console access was disabled when "auth_mode=any" as pgbouncer dropped username.
-    Fix: if "auth_mode=any", allow any user to console as admin.
+  * Console access was disabled when "auth_type=any" as pgbouncer dropped username.
+    Fix: if "auth_type=any", allow any user to console as admin.
 
   * Fix bad CUSTOM_ALIGN macro.  Luckily it's unused if OS already
     defines ALIGN macro thus seems the bug has not happened in wild.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -154,7 +154,7 @@ database **pgbouncer**::
   $ psql -p 6543 pgbouncer
 
 Only users listed in configuration parameters **admin_users** or **stats_users**
-are allowed to login to the console.  (Except when `auth_mode=any`, then
+are allowed to login to the console.  (Except when `auth_type=any`, then
 any user is allowed in as a stats_user.)
 
 Additionally, the username **pgbouncer** is allowed to log in without password,

--- a/src/admin.c
+++ b/src/admin.c
@@ -1377,7 +1377,7 @@ bool admin_pre_login(PgSocket *client, const char *username)
 	}
 
 	/*
-	 * auth_mode=any does not keep original username around,
+	 * auth_type=any does not keep original username around,
 	 * so username based check has to take place here
 	 */
 	if (cf_auth_type == AUTH_ANY) {


### PR DESCRIPTION
The parameter is called auth_type, not auth_mode.