### PR TITLE
Allow setting per-user connection limits to unlimited, improve logging

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -180,6 +180,9 @@ extern int cf_sbuf_len;
 #define POOL_STMT	2
 #define POOL_INHERIT	3
 
+#define MAXCONN_UNLIMITED 0
+#define MAXCONN_FALLBACK  -1
+
 #define BACKENDKEY_LEN	8
 
 /* buffer size for startup noise */

--- a/src/loader.c
+++ b/src/loader.c
@@ -398,8 +398,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	PgUser *user;
 	struct CfValue cv;
 	int pool_mode = POOL_INHERIT;
-	int max_user_connections = -1;
-
+	int max_user_connections = MAXCONN_FALLBACK;
 
 	cv.value_p = &pool_mode;
 	cv.extra = (const void *)pool_mode_map;

--- a/src/server.c
+++ b/src/server.c
@@ -212,7 +212,11 @@ int database_max_connections(PgDatabase *db)
 
 int user_max_connections(PgUser *user)
 {
-	if (user->max_user_connections <= 0) {
+	// user->max_user_connections == MAXCONN_FALLBACK (-1) is the default, which means
+	// "not specified for this user, fall back to global setting." While
+	// max_user_connections == MAXCONN_UNLIMITED (0) can be specified explicitly in the
+	// per-user settings.
+	if (user->max_user_connections == MAXCONN_FALLBACK) {
 		return cf_max_user_connections;
 	} else {
 		return user->max_user_connections;


### PR DESCRIPTION
See https://github.com/pgbouncer/pgbouncer/issues/166 for rationale.

There is undocumented support for per-user connection limits already in pgBouncer. However it is not quite flexible enough for us. We wanted to be able to put a limit on all users, except for specific users (e.g. DBAs, system processes) which are unlimited. So we hoped to have a low setting for the
global `max_user_connections`, and override it for specific users to *unlimited* in `pgbouncer.ini:`

    max_user_connections=3

    [users]
    system = max_user_connections=0
    dba = max_user_connections=0

This patch makes it possible to set the per-user connection limit to either `0`
(unlimited) or `-1` (fallback to global default), or a specific limit as before.