### PR TITLE
Add a maxwait microseconds column to SHOW POOLS.

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -778,6 +778,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 	PktBuf *buf;
 	PgSocket *waiter;
 	usec_t now = get_cached_time();
+	usec_t max_wait;
 	struct CfValue cv;
 	int pool_mode;
 
@@ -788,18 +789,19 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		admin_error(admin, "no mem");
 		return true;
 	}
-	pktbuf_write_RowDescription(buf, "ssiiiiiiiis",
+	pktbuf_write_RowDescription(buf, "ssiiiiiiiiis",
 				    "database", "user",
 				    "cl_active", "cl_waiting",
 				    "sv_active", "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
-				    "pool_mode");
+				    "maxwait_us", "pool_mode");
 	statlist_for_each(item, &pool_list) {
 		pool = container_of(item, PgPool, head);
 		waiter = first_socket(&pool->waiting_client_list);
+		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
 		pool_mode = pool_pool_mode(pool);
-		pktbuf_write_DataRow(buf, "ssiiiiiiiis",
+		pktbuf_write_DataRow(buf, "ssiiiiiiiiis",
 				     pool->db->name, pool->user->name,
 				     statlist_count(&pool->active_client_list),
 				     statlist_count(&pool->waiting_client_list),
@@ -809,8 +811,8 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				     statlist_count(&pool->tested_server_list),
 				     statlist_count(&pool->new_server_list),
 				     /* how long is the oldest client waited */
-				     (waiter && waiter->query_start)
-				     ?  (int)((now - waiter->query_start) / USEC) : 0,
+				     (int)(max_wait / USEC),
+				     (int)(max_wait % USEC),
 				     cf_get_lookup(&cv));
 	}
 	admin_flush(admin, buf, "SHOW");


### PR DESCRIPTION
Higher resolution maxwait allows for earlier detection of issues and better measurement of performance tuning efforts.

This PR enables that behaviour by exposing the full resolution max-wait value in the SHOW POOLS command. In order to both maintain backwards compatibility and keep everything as 32 bit integers, this adds only the sub-second microseconds part of the time that was previously being truncated. Existing statistics collectors can continue reading the `maxwait` column at second resolution without interruption, while clients that need the full precision can treat the `maxwait` + `maxwait_us` pair as a `struct timeval` and use all the normal tools for dealing with that type of time.