### PR TITLE
Fix memleak on pg_hba file reload

### DIFF
--- a/src/hba.c
+++ b/src/hba.c
@@ -448,6 +448,8 @@ eat_comma:
 
 static void rule_free(struct HBARule *rule)
 {
+	strset_free(rule->db_name.name_set);
+	strset_free(rule->user_name.name_set);
 	free(rule);
 }
 


### PR DESCRIPTION
For some unknown reason function `strset_free` was defined but never used. This lead to memory leak of `db_name` and `user_name` on `rule_free` call.