### PR TITLE
add config to disable libevent2 randomize case

### DIFF
--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -324,6 +324,9 @@ default_pool_size = 20
 ;; DNS negative result caching time
 ;dns_nxdomain_ttl = 15
 
+;; DNS randomize case
+;cf_dns_randomize_case = 1
+
 ;;;
 ;;; Random stuff
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -426,6 +426,7 @@ extern int cf_disable_pqexec;
 extern usec_t cf_dns_max_ttl;
 extern usec_t cf_dns_nxdomain_ttl;
 extern usec_t cf_dns_zone_check_period;
+extern int cf_dns_randomize_case;
 
 extern int cf_auth_type;
 extern char *cf_auth_file;

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -382,6 +382,9 @@ static bool impl_init(struct DNSContext *ctx)
 		log_warning("evdns_base_new failed");
 		return false;
 	}
+	if (!cf_dns_randomize_case) {
+		evdns_base_set_option(ctx->edns, "randomize-case", "0");
+	}
 	return true;
 }
 
@@ -391,7 +394,6 @@ static void impl_launch_query(struct DNSRequest *req)
 
 	struct evdns_getaddrinfo_request *gai_req;
 	struct evdns_base *dns = req->ctx->edns;
-
 	gai_req = evdns_getaddrinfo(dns, req->name, NULL, &hints, got_result_gai, req);
 	log_noise("dns: evdns_getaddrinfo(%s)=%p", req->name, gai_req);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -110,6 +110,7 @@ int cf_disable_pqexec;
 usec_t cf_dns_max_ttl;
 usec_t cf_dns_nxdomain_ttl;
 usec_t cf_dns_zone_check_period;
+int cf_dns_randomize_case;
 unsigned int cf_max_packet_size;
 
 char *cf_ignore_startup_params;
@@ -254,6 +255,7 @@ CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),
 CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
 CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
+CF_ABS("dns_randomize_case", CF_INT, cf_dns_randomize_case, 0, "1"),
 
 CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),
 CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),


### PR DESCRIPTION
add config to disable libevent2 randomize case，just like discuss in this issue https://github.com/libevent/libevent/pull/97 ，some nameservers do not follow the expected response behavior, they do not match the exact case of the name in the response. 