### PR TITLE
Track separate stats for queries and transactions

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -195,6 +195,9 @@ total_query_time
     Total number of microseconds spent by **pgbouncer** when actively
     connected to PostgreSQL, executing queries.
 
+total_wait_time
+    Time spent by clients waiting for a server in microseconds.
+
 avg_xact_count
     Average transactions per second in last stat period.
 
@@ -212,6 +215,10 @@ avg_xact_time
 
 avg_query_time
     Average query duration in microseconds.
+
+avg_wait_time
+    Time spent by clients waiting for a server in microseconds (average
+    per second).
 
 SHOW SERVERS;
 -------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -174,8 +174,11 @@ Shows statistics.
 database
     Statistics are presented per database.
 
-total_requests
-    Total number of SQL requests pooled by **pgbouncer**.
+total_xact_count
+    Total number of SQL transactions pooled by **pgbouncer**.
+
+total_query_count
+    Total number of SQL queries pooled by **pgbouncer**.
 
 total_received
     Total volume in bytes of network traffic received by **pgbouncer**.
@@ -183,12 +186,20 @@ total_received
 total_sent
     Total volume in bytes of network traffic sent by **pgbouncer**.
 
+total_xact_time
+    Total number of microseconds spent by **pgbouncer** when connected
+    to PostgreSQL in a transaction, either idle in transaction or
+    executing queries.
+
 total_query_time
     Total number of microseconds spent by **pgbouncer** when actively
-    connected to PostgreSQL.
+    connected to PostgreSQL, executing queries.
 
-avg_req
-    Average requests per second in last stat period.
+avg_xact_count
+    Average transactions per second in last stat period.
+
+avg_query_count
+    Average queries per second in last stat period.
 
 avg_recv
     Average received (from clients) bytes per second.
@@ -196,7 +207,10 @@ avg_recv
 avg_sent
     Average sent (to clients) bytes per second.
 
-avg_query
+avg_xact_time
+	Average transaction duration in microseconds.
+
+avg_query_time
     Average query duration in microseconds.
 
 SHOW SERVERS;

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -220,6 +220,18 @@ avg_wait_time
     Time spent by clients waiting for a server in microseconds (average
     per second).
 
+SHOW STATS_TOTALS;
+------------------
+
+Subset of **SHOW STATS** showing the total values (**total_**).
+
+
+SHOW STATS_AVERAGES;
+--------------------
+
+Subset of **SHOW STATS** showing the average values (**avg_**).
+
+
 SHOW SERVERS;
 -------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -188,10 +188,12 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
  * Stats, kept per-pool.
  */
 struct PgStats {
-	uint64_t request_count;
+	uint64_t xact_count;
+	uint64_t query_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
-	usec_t query_time;	/* total req time in us */
+	usec_t xact_time;	/* total transaction time in us */
+	usec_t query_time;	/* total query time in us */
 };
 
 /*
@@ -356,6 +358,7 @@ struct PgSocket {
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */
 	usec_t query_start;	/* query start moment */
+	usec_t xact_start;	/* xact start moment */
 
 	uint8_t cancel_key[BACKENDKEY_LEN]; /* client: generated, server: remote */
 	PgAddr remote_addr;	/* ip:port for remote endpoint */

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -194,6 +194,7 @@ struct PgStats {
 	uint64_t client_bytes;
 	usec_t xact_time;	/* total transaction time in us */
 	usec_t query_time;	/* total query time in us */
+	usec_t wait_time;	/* total time clients had to wait */
 };
 
 /*
@@ -359,6 +360,7 @@ struct PgSocket {
 	usec_t request_time;	/* last activity time */
 	usec_t query_start;	/* query start moment */
 	usec_t xact_start;	/* xact start moment */
+	usec_t wait_start;	/* waiting start moment */
 
 	uint8_t cancel_key[BACKENDKEY_LEN]; /* client: generated, server: remote */
 	PgAddr remote_addr;	/* ip:port for remote endpoint */

--- a/include/stats.h
+++ b/include/stats.h
@@ -19,5 +19,7 @@
 void stats_setup(void);
 
 bool admin_database_stats(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
+bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
+bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
 bool show_stat_totals(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -1226,6 +1226,16 @@ static bool admin_show_stats(PgSocket *admin, const char *arg)
 	return admin_database_stats(admin, &pool_list);
 }
 
+static bool admin_show_stats_totals(PgSocket *admin, const char *arg)
+{
+	return admin_database_stats_totals(admin, &pool_list);
+}
+
+static bool admin_show_stats_averages(PgSocket *admin, const char *arg)
+{
+	return admin_database_stats_averages(admin, &pool_list);
+}
+
 static bool admin_show_totals(PgSocket *admin, const char *arg)
 {
 	return show_stat_totals(admin, &pool_list);
@@ -1244,6 +1254,8 @@ static struct cmd_lookup show_map [] = {
 	{"sockets", admin_show_sockets},
 	{"active_sockets", admin_show_active_sockets},
 	{"stats", admin_show_stats},
+	{"stats_totals", admin_show_stats_totals},
+	{"stats_averages", admin_show_stats_averages},
 	{"users", admin_show_users},
 	{"version", admin_show_version},
 	{"totals", admin_show_totals},

--- a/src/client.c
+++ b/src/client.c
@@ -661,8 +661,14 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 
 	/* update stats */
 	if (!client->query_start) {
-		client->pool->stats.request_count++;
+		client->pool->stats.query_count++;
 		client->query_start = get_cached_time();
+	}
+
+	/* remember timestamp of the first query in a transaction */
+	if (!client->xact_start) {
+		client->pool->stats.xact_count++;
+		client->xact_start = client->query_start;
 	}
 
 	if (client->pool->db->admin)


### PR DESCRIPTION
The documentation claimed avg_query tracks average query duration,
but it was only updated when switching into 'idle' state. So in
transaction or session pooling modes, it was actually the duration
of the whole transaction, including 'idle in transaction' time and
time spen executing (multiple) queries.

This was causing confusion, e.g. when the application was keeping
transactions open without executing any queries. In that case the
avg_query metric was increasing although the database was handling
queries just fine (without any slow-down).

Instead of just fixing the avg_query metric, it seems quite useful
to have timing data both for queries and transactions. So this
patch replaces

 - total_query_time
 - avg_query

with

 - total_xact_time
 - total_query_time
 - avg_xact_time
 - avg_query_time

This is also related to the definition of 'request' which was used
to compute the avg_query, and so it equal to a transaction. This
patch replaces the counter with two - one for transactions and one
for queries. As we also computed avg_req, the patch replaces

 - total_requests
 - avg_req

with

 - total_xact_count
 - total_query_time
 - avg_xact_count
 - avg_query_count

Note: This is likely to affect monitoring solutions, as the column
names in SHOW STATS change.