### PR TITLE
Add max_waiting_clients

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -897,6 +897,13 @@ max_db_connections
 Configure a database-wide maximum (i.e. all pools within the database will
 not have more than this many server connections).
 
+max_waiting_clients
+-------------------
+
+Configure a pool-wide maximum (i.e. each pool within the database will not have
+more than this many waiting clients.) Total maximum connected clients per pool
+are pool_size + the number of waiting clients on that pool.
+
 client_encoding
 ---------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -298,6 +298,7 @@ struct PgDatabase {
 	int pool_size;		/* max server connections in one pool */
 	int res_pool_size;	/* additional server connections in case of trouble */
 	int pool_mode;		/* pool mode for this database */
+        int max_waiting_clients; /* maximum number of clients waiting on this db */
 	int max_db_connections;	/* max server connections between all pools */
 
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */

--- a/src/client.c
+++ b/src/client.c
@@ -92,7 +92,8 @@ static void start_auth_request(PgSocket *client, const char *username)
 	/* have to fetch user info from db */
 	client->pool = get_pool(client->db, client->db->auth_user);
 	if (!find_server(client)) {
-		client->wait_for_user_conn = true;
+                if (client->state != CL_JUSTFREE)
+			client->wait_for_user_conn = true;
 		return;
 	}
 	slog_noise(client, "Doing auth_conn query");

--- a/src/loader.c
+++ b/src/loader.c
@@ -183,6 +183,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	struct CfValue cv;
 	int pool_size = -1;
 	int res_pool_size = -1;
+        int max_waiting_clients = -1;
 	int max_db_connections = -1;
 	int dbname_ofs;
 	int pool_mode = POOL_INHERIT;
@@ -246,6 +247,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			pool_size = atoi(val);
 		} else if (strcmp("reserve_pool", key) == 0) {
 			res_pool_size = atoi(val);
+		} else if (strcmp("max_waiting_clients", key) == 0) {
+			max_waiting_clients = atoi(val);
 		} else if (strcmp("max_db_connections", key) == 0) {
 			max_db_connections = atoi(val);
 		} else if (strcmp("pool_mode", key) == 0) {
@@ -325,6 +328,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	db->pool_size = pool_size;
 	db->res_pool_size = res_pool_size;
 	db->pool_mode = pool_mode;
+        db->max_waiting_clients = max_waiting_clients;
 	db->max_db_connections = max_db_connections;
 
 	if (db->host)

--- a/src/main.c
+++ b/src/main.c
@@ -100,6 +100,7 @@ int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
 int cf_max_user_connections;
+int cf_max_waiting_clients;
 
 char *cf_server_reset_query;
 int cf_server_reset_query_always;
@@ -225,6 +226,7 @@ CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),
 CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
+CF_ABS("max_waiting_clients", CF_INT, cf_max_waiting_clients, 0, "0"),
 CF_ABS("syslog", CF_INT, cf_syslog, 0, "0"),
 CF_ABS("syslog_facility", CF_STR, cf_syslog_facility, 0, "daemon"),
 CF_ABS("syslog_ident", CF_STR, cf_syslog_ident, 0, "pgbouncer"),

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,7 +1,7 @@
 ;; database name = connect string
 [databases]
 
-p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
+p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2 max_waiting_clients=1
 p1 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer
 p2 = port=6668 host=127.0.0.1 dbname=p2 user=bouncer
 


### PR DESCRIPTION
This allows failing fast when there are too many connections to a pool, without
needing to wait for timeouts.