### PR TITLE
Fatal error when reloaded w/ user=somebody

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -445,17 +445,22 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 /* create separate user object for storing server user info */
 PgUser *force_user(PgDatabase *db, const char *name, const char *passwd)
 {
-	PgUser *user = db->forced_user;
+	PgUser *user = find_user(name);
+
 	if (!user) {
 		user = slab_alloc(user_cache);
 		if (!user)
 			return NULL;
+
 		list_init(&user->head);
 		list_init(&user->pool_list);
+
 		user->pool_mode = POOL_INHERIT;
+
+		safe_strcpy(user->name, name, sizeof(user->name));
+		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	}
-	safe_strcpy(user->name, name, sizeof(user->name));
-	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
+
 	db->forced_user = user;
 	return user;
 }

--- a/test/regression/fatal_on_reload.bash
+++ b/test/regression/fatal_on_reload.bash
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+# pgbouncer-config <tmpdir> <second-database>
+function pgbouncer-config() {
+  cat <<EOF
+[databases]
+* =
+$2
+
+[pgbouncer]
+logfile = $1/pgbouncer.log
+pidfile = $1/pgbouncer.pid
+
+unix_socket_dir = $1
+
+auth_type = trust
+auth_file = $1/userlist.txt
+
+verbose = 1
+EOF
+}
+
+# userlist <user>
+function userlist() {
+  cat <<EOF
+"$1" "whatever_we_trust"
+EOF
+}
+
+# postgresql-conf <tmpdir>
+function postgresql-conf() {
+  cat <<EOF
+unix_socket_directories = '$1'
+port = 5432
+listen_addresses = ''
+log_filename = '$1/postgresql.log'
+EOF
+}
+
+TMPDIR="$(mktemp -d -t pgbouncer-regression)"
+PGUSER="$(whoami)"
+export PGDATABASE="postgres"
+
+function cleanup() {
+  (sleep 2 && pg_ctl -D "${TMPDIR}/testdb" stop -m fast) || rm -rfv "${TMPDIR}"
+}
+
+trap cleanup EXIT
+
+pgbouncer-config "${TMPDIR}" "; postgres = user=${PGUSER}" > "${TMPDIR}/pgbouncer.ini"
+userlist "$PGUSER" > "${TMPDIR}/userlist.txt"
+
+initdb "${TMPDIR}/testdb"
+postgresql-conf "${TMPDIR}" >> "${TMPDIR}/testdb/postgresql.conf"
+pg_ctl -D "${TMPDIR}/testdb" start
+
+./pgbouncer -d "${TMPDIR}/pgbouncer.ini" >/dev/null 2>&1 && sleep 2
+
+psql -h "${TMPDIR}" -p 6432 --tuples-only -c "select NOW()" | xargs
+pgbouncer-config "${TMPDIR}" "postgres = user=${PGUSER}" > "${TMPDIR}/pgbouncer.ini"
+pkill -HUP -F "${TMPDIR}/pgbouncer.pid" && sleep 1
+
+psql -h "${TMPDIR}" -p 6432 --tuples-only -c "select NOW()" || echo "psql failed, as expected"
+sleep 1
+
+cat "${TMPDIR}/pgbouncer.log"


### PR DESCRIPTION
This change includes a script that can be used verify that PgBouncer 1.7.2 is definitely vulnerable to this bug (production issue... ouch) and the second commit modifies `force_user` to avoid this problem.

Given I'm unfamiliar with PgBouncer as a codebase, I'd love to get someone with more expertise to vet the change.

Thanks!

---

As described in issue #41, PgBouncer will fatally crash when config is
reloaded that specifies a user parameter for a database that already exists.

This is due to the config loader calling force_user for the newly
supplied user parameter, which creates a new user with an empty list of
user pools. When we later call find_pool(db, user) it is determined that
there is no associated pool, so we recreate a pool that already exists
and add it to the global pool list which then FATALs as a consequence of
duplicate elements.

We fix this bug by having force_user only create a new user if one for
this username does not already exist.