### PR TITLE
Fix reserve_pool parameter

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -878,6 +878,11 @@ pool_size
 Set maximum size of pools for this database.  If not set,
 the default_pool_size is used.
 
+reserve_pool
+------------
+Set additional connections for this database. If not set, reserve_pool_size is
+used.
+
 connect_query
 -------------
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -17,7 +17,7 @@
 ;forcedb = host=127.0.0.1 port=300 user=baz password=foo client_encoding=UNICODE datestyle=ISO connect_query='SELECT 1'
 
 ; use custom pool sizes
-;nondefaultdb = pool_size=50 reserve_pool_size=10
+;nondefaultdb = pool_size=50 reserve_pool=10
 
 ; use auth_user with auth_query if user not present in  auth_file
 ; auth_user must exist in auth_file


### PR DESCRIPTION
The correct per pool parameter is reserve_pool. The global parameter is named
reserve_pool_size.

While at it, document reserve_pool parameter.