### PR TITLE
Use default values in config file

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -159,6 +159,8 @@ using ``auth_user``. Auth_user's password will be taken from ``auth_file``.
 Direct access to pg_shadow requires admin rights.  It's preferable to
 use non-admin user that calls SECURITY DEFINER function instead.
 
+Default: not set.
+
 pool_mode
 ---------
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -190,14 +190,14 @@ default_pool_size = 20
 ;min_pool_size = 0
 
 ; how many additional connection to allow in case of trouble
-;reserve_pool_size = 5
+;reserve_pool_size = 0
 
 ; if a clients needs to wait more than this many seconds, use reserve pool
-;reserve_pool_timeout = 3
+;reserve_pool_timeout = 5
 
 ; how many total connections to a single database to allow from all pools
-;max_db_connections = 50
-;max_user_connections = 50
+;max_db_connections = 0
+;max_user_connections = 0
 
 ; If off, then server connections are reused in LIFO manner
 ;server_round_robin = 0
@@ -224,18 +224,18 @@ default_pool_size = 20
 ;stats_period = 60
 
 ;; Logging verbosity.  Same as -v switch on command line.
-;verbose=0
+;verbose = 0
 
 ;;;
 ;;; Timeouts
 ;;;
 
 ;; Close server connection if its been connected longer.
-;server_lifetime = 1200
+;server_lifetime = 3600
 
 ;; Close server connection if its not been used in this time.
 ;; Allows to clean unnecessary connections from pool after peak.
-;server_idle_timeout = 60
+;server_idle_timeout = 600
 
 ;; Cancel connection attempt if server does not answer takes longer.
 ;server_connect_timeout = 15
@@ -330,7 +330,7 @@ default_pool_size = 20
 
 ;; Hackish security feature.  Helps against SQL-injection - when PQexec is disabled,
 ;; multi-statement cannot be made.
-;disable_pqexec=0
+;disable_pqexec = 0
 
 ;; Config file to use for next RELOAD/SIGHUP.
 ;; By default contains config file from command line.


### PR DESCRIPTION
Instead of using arbritary values, use the default values. It is to avoid surprises if you just remove comment character (;). I also did some cosmetic changes. While at it, add some default information for
auth_user.