### PR TITLE
Log as warning in case of fail due to full connection pool on launch_new_connection

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1129,7 +1129,7 @@ void launch_new_connection(PgPool *pool)
 				}
 			}
 		}
-		log_debug("launch_new_connection: pool full (%d >= %d)",
+		log_warning("launch_new_connection: pool full (%d >= %d)",
 				total, pool->db->pool_size);
 		return;
 	}
@@ -1144,7 +1144,7 @@ allow_new:
 			}
 		}
 		if (pool->db->connection_count >= total) {
-			log_debug("launch_new_connection: database full (%d >= %d)",
+			log_warning("launch_new_connection: database full (%d >= %d)",
 					pool->db->connection_count, total);
 			return;
 		}
@@ -1159,7 +1159,7 @@ allow_new:
 			}
 		}
 		if (pool->user->connection_count >= total) {
-			log_debug("launch_new_connection: user full (%d >= %d)",
+			log_warning("launch_new_connection: user full (%d >= %d)",
 					pool->user->connection_count, total);
 			return;
 		}
@@ -1168,7 +1168,7 @@ allow_new:
 	/* get free conn object */
 	server = slab_alloc(server_cache);
 	if (!server) {
-		log_debug("launch_new_connection: no memory");
+		log_warning("launch_new_connection: no memory");
 		return;
 	}
 


### PR DESCRIPTION
For example if we have pool_size greater than max_db_connection, than we will not be notified if launch_new_connection cannot create new one(of cause if we haven't verbosity level set to 2). So we need set log level in warning to see these important messages.