### PR TITLE
Add server_max_requests configuration parameter

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -468,6 +468,14 @@ then closed. [seconds]
 
 Default: 3600.0
 
+server_max_requests
+-------------------
+
+The pooler will try to close server connections after they have serviced this many requests.
+Setting it to 0 means there is no limit.
+
+Default: 0
+
 server_idle_timeout
 -------------------
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -355,7 +355,8 @@ struct PgSocket {
 	bool wait_sslchar:1;	/* server: waiting for ssl response: S/N */
 
 	int expect_rfq_count;	/* client: count of ReadyForQuery packets client should see */
-
+	int server_requests;	/* count of server requests processed so far */
+	
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */
 	usec_t query_start;	/* query start moment */
@@ -408,6 +409,7 @@ extern int cf_res_pool_size;
 extern usec_t cf_res_pool_timeout;
 extern int cf_max_db_connections;
 extern int cf_max_user_connections;
+extern int cf_server_max_requests;
 
 extern char * cf_autodb_connstr;
 extern usec_t cf_autodb_idle_timeout;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -400,6 +400,8 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
 				disconnect_server(server, true, "server lifetime over");
 				pool->last_lifetime_disconnect = now;
 			}
+		} else if (cf_server_max_requests && server->server_requests >= cf_server_max_requests) {
+			disconnect_server(server, true, "server max requests");
 		} else if (cf_pause_mode == P_PAUSE) {
 			disconnect_server(server, true, "pause mode");
 		} else if (idle_test && *cf_server_check_query) {

--- a/src/main.c
+++ b/src/main.c
@@ -116,8 +116,9 @@ char *cf_ignore_startup_params;
 
 char *cf_autodb_connstr; /* here is "" different from NULL */
 
-usec_t cf_autodb_idle_timeout;
+int cf_server_max_requests;
 
+usec_t cf_autodb_idle_timeout;
 usec_t cf_server_lifetime;
 usec_t cf_server_idle_timeout;
 usec_t cf_server_connect_timeout;
@@ -244,6 +245,7 @@ CF_ABS("client_idle_timeout", CF_TIME_USEC, cf_client_idle_timeout, 0, "0"),
 CF_ABS("client_login_timeout", CF_TIME_USEC, cf_client_login_timeout, 0, "60"),
 CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
+CF_ABS("server_max_requests", CF_INT, cf_server_max_requests, 0, "0"),
 CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
 CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
 CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),


### PR DESCRIPTION
PostgreSQL worker processes cache information about every relationship (table) for each schema that a connection has referenced.  In a large multi-tenant database, perhaps with hundreds of schemas each of which contains hundreds of tables, this "relcache" can grow to unmanageable sizes and cause an unacceptable amount of virtual memory page swapping. The recommended solution is to periodically close the connections, thus freeing the memory allocated to the relcache.

The server lifetime configuration parameter isn't quite satisfactory for this purpose, since the paging problem is related to the number of different schemas that have been processed through each connection, not the length of time the connection has been open.

This pull request adds a new configuration parameter "server_max_requests".  After a connection has serviced the configured number of requests it will be closed, allowing a replacement connection to be opened and added to the pool.  The default value for this parameter is 0, which means no request limit will be enforced -- so the default behavior of the application is unchanged.

In our environment, we find that setting max_server_requests to values in the range of 25 to 100 avoids the problem of page swapping caused by huge worker relcaches without impacting performance in any significant way.