### PR TITLE
Add option to disable printing stats to log

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -318,6 +318,13 @@ job_name
 
 Alias for `service_name`_.
 
+stats_period
+------------
+
+Period for writing aggregated stats into log.
+
+Default: 60
+
 
 Log settings
 ============
@@ -366,12 +373,12 @@ Log error messages pooler sends to clients.
 
 Default: 1
 
-stats_period
-------------
+log_stats
+-----------------
 
-Period for writing aggregated stats into log.
+Log statistics.
 
-Default: 60
+Default: 1
 
 verbose
 -------

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -445,6 +445,8 @@ extern char *cf_ignore_startup_params;
 extern char *cf_admin_users;
 extern char *cf_stats_users;
 extern int cf_stats_period;
+extern int cf_log_stats;
+
 
 extern int cf_pause_mode;
 extern int cf_shutdown;

--- a/src/main.c
+++ b/src/main.c
@@ -137,6 +137,7 @@ char *cf_jobname;
 char *cf_admin_users;
 char *cf_stats_users;
 int cf_stats_period;
+int cf_log_stats;
 
 int cf_log_connections;
 int cf_log_disconnections;
@@ -268,6 +269,7 @@ CF_ABS("verbose", CF_INT, cf_verbose, 0, NULL),
 CF_ABS("admin_users", CF_STR, cf_admin_users, 0, ""),
 CF_ABS("stats_users", CF_STR, cf_stats_users, 0, ""),
 CF_ABS("stats_period", CF_INT, cf_stats_period, 0, "60"),
+CF_ABS("log_stats", CF_INT, cf_log_stats, 0, "1"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),

--- a/src/stats.c
+++ b/src/stats.c
@@ -353,18 +353,20 @@ static void refresh_stats(int s, short flags, void *arg)
 		stat_add(&old_total, &pool->older_stats);
 	}
 	calc_average(&avg, &cur_total, &old_total);
-	/* send totals to logfile */
-	log_info("Stats: %" PRIu64 " xacts/s,"
-		 " %" PRIu64 " queries/s,"
-		 " in %" PRIu64 " B/s,"
-		 " out %" PRIu64 " B/s,"
-		 " xact %" PRIu64 " us,"
-		 " query %" PRIu64 " us"
-		 " wait time %" PRIu64 " us",
-		 avg.xact_count, avg.query_count,
-		 avg.client_bytes, avg.server_bytes,
-		 avg.xact_time, avg.query_time,
-		 avg.wait_time);
+	if (cf_log_stats) {
+		/* send totals to logfile */
+		log_info("Stats: %" PRIu64 " xacts/s,"
+			" %" PRIu64 " queries/s,"
+			" in %" PRIu64 " B/s,"
+			" out %" PRIu64 " B/s,"
+			" xact %" PRIu64 " us,"
+			" query %" PRIu64 " us"
+			" wait time %" PRIu64 " us",
+			avg.xact_count, avg.query_count,
+			avg.client_bytes, avg.server_bytes,
+			avg.xact_time, avg.query_time,
+			avg.wait_time);
+	}
 
 	safe_evtimer_add(&ev_stats, &period);
 }


### PR DESCRIPTION
Currently many of users of pgbouncer don't use logs to monitor it. For example we are using influxdb+grafana+custom-plugin to collect stats and display it to dashboard. So we absolutely don't need printing stats to log. So I added ability to disable this behavior(by default printing is on). Doc has been updated to. Additionally stats_period was moved from "Log settings" to "General setting" to reflect that this property means stats refreshing period - not only period of writing info to log.