### PR TITLE
Make the client connection behave more like the Postgres server for SSL

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -606,7 +606,9 @@ Default: ``all``
 client_tls_ciphers
 ------------------
 
-Default: ``fast``
+Default is the same as the Postgres default
+
+Default: ``HIGH:MEDIUM:+3DES:!aNULL``
 
 client_tls_ecdhcurve
 --------------------

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -65,8 +65,8 @@ listen_port = 6432
 ;client_tls_key_file =
 ;client_tls_cert_file =
 
-;; fast, normal, secure, legacy, <ciphersuite string>
-;client_tls_ciphers = fast
+;; same setting as default for Postgres
+;client_tls_ciphers = HIGH:MEDIUM:+3DES:!aNULL
 
 ;; all, secure, tlsv1.0, tlsv1.1, tlsv1.2
 ;client_tls_protocols = all

--- a/src/main.c
+++ b/src/main.c
@@ -278,7 +278,7 @@ CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, CF_NO_RELOAD, ""),
 CF_ABS("client_tls_cert_file", CF_STR, cf_client_tls_cert_file, CF_NO_RELOAD, ""),
 CF_ABS("client_tls_key_file", CF_STR, cf_client_tls_key_file, CF_NO_RELOAD, ""),
 CF_ABS("client_tls_protocols", CF_STR, cf_client_tls_protocols, CF_NO_RELOAD, "all"),
-CF_ABS("client_tls_ciphers", CF_STR, cf_client_tls_ciphers, CF_NO_RELOAD, "fast"),
+CF_ABS("client_tls_ciphers", CF_STR, cf_client_tls_ciphers, CF_NO_RELOAD, "HIGH:MEDIUM:+3DES:!aNULL"),
 CF_ABS("client_tls_dheparams", CF_STR, cf_client_tls_dheparams, CF_NO_RELOAD, "auto"),
 CF_ABS("client_tls_ecdhcurve", CF_STR, cf_client_tls_ecdhecurve, CF_NO_RELOAD, "auto"),
 

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -931,6 +931,8 @@ static void setup_tls(struct tls_config *conf, const char *pfx, int sslmode,
 		} else {
 			tls_config_verify_client_optional(conf);
 		}
+		/* prefer our cipher set if we're a server */
+		tls_config_prefer_ciphers_server(conf);
 	}
 }
 


### PR DESCRIPTION
Change the default cipher set to be the same as Postgres' default cipher
set, and have pgbouncer prefer the server's cipher set (i.e. its cipher
set) to the client's, like modern Postgres does by default.