### PR TITLE
Fix a double-free and a NULL pointer deref

### DIFF
--- a/src/hba.c
+++ b/src/hba.c
@@ -359,7 +359,6 @@ static bool parse_namefile(struct HBAName *hname, const char *fn, bool is_db)
 
 	f = fopen(fn, "r");
 	if (!f) {
-		free(fn);
 		return false;
 	}
 	for (linenr = 1; ; linenr++) {

--- a/src/hba.c
+++ b/src/hba.c
@@ -524,7 +524,7 @@ static bool parse_line(struct HBA *hba, struct TokParser *tp, int linenr, const 
 	rule = calloc(sizeof *rule, 1);
 	if (!rule) {
 		log_warning("hba: no mem for rule");
-		goto failed;
+		return false;
 	}
 	rule->rule_type = rtype;
 


### PR DESCRIPTION
This addresses two bugs which are perhaps not terribly likely to happen:

* If the `fopen()` call fails `parse_namefile()` frees the filename buffer `fn`, and the caller does the same. Avoid freeing in `parse_namefile()` and leave the cleanup to the caller.
* If we fail to `calloc()` the `rule` buffer, going to `failed:` will dereference `rule` via the `rule_free()` call. Avoid by returning `false` directly and bypass the `failed:` block.