### PR TITLE
auth_dbname option for database definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /test/test.log
 /test/test.pid
 
+# Visual Studio Code
+.vscode/
+
 *.html
 *.xml
 *.exe

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -295,6 +295,7 @@ struct PgDatabase {
 
 	PgUser *forced_user;	/* if not NULL, the user/psw is forced */
 	PgUser *auth_user;	/* if not NULL, users not in userlist.txt will be looked up on the server */
+	const char *auth_dbname; /* is the database used for authentication */
 
 	const char *host;	/* host or unix socket name */
 	int port;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -697,6 +697,9 @@ void kill_database(PgDatabase *db)
 
 	pktbuf_free(db->startup_params);
 	free(db->host);
+	if(db->auth_dbname) {
+		free(db->auth_dbname);
+	}
 
 	if (db->forced_user)
 		slab_free(user_cache, db->forced_user);

--- a/src/loader.c
+++ b/src/loader.c
@@ -194,6 +194,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	char *username = NULL;
 	char *password = "";
 	char *auth_username = cf_auth_user;
+	char *auth_dbname = NULL;
 	char *client_encoding = NULL;
 	char *datestyle = NULL;
 	char *timezone = NULL;
@@ -236,6 +237,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			password = val;
 		} else if (strcmp("auth_user", key) == 0) {
 			auth_username = val;
+		} else if (strcmp("auth_dbname", key) == 0) {
+			auth_dbname = val;
 		} else if (strcmp("client_encoding", key) == 0) {
 			client_encoding = val;
 		} else if (strcmp("datestyle", key) == 0) {
@@ -377,6 +380,12 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	} else if (db->auth_user) {
 		db->auth_user = NULL;
 	}
+
+	if (db->auth_dbname)
+		free(db->auth_dbname);
+	db->auth_dbname = NULL;
+	if(auth_dbname != NULL)
+		db->auth_dbname = strdup(auth_dbname);
 
 	/* if user is forced, create fake object for it */
 	if (username != NULL) {

--- a/test/test.ini
+++ b/test/test.ini
@@ -6,7 +6,7 @@ p1 = port=6666 host=127.0.0.1 dbname=p1 user=bouncer
 p2 = port=6668 host=127.0.0.1 dbname=p2 user=bouncer
 p3 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_mode=session
 
-authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
+authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck auth_dbname=p0
 
 ;; Configuation section
 [pgbouncer]


### PR DESCRIPTION
Now you can specify an database's entry name for authentication.
If auth_dbname is set, auth_query is sended to that database.
This is util were we want use only one database for all users
authentications, i.e

   p0 = host=127.0.0.1 dbname=pgbench auth_dbname=authdb auth_user=pswcheck
   authdb = host=127.0.0.1 dbname=pgbouncer

If there isn't an entry named as the value specified in auth_dbname,
the database specified in dbname will be used instead.