### PR TITLE
support for server_idle_timeout at db level

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -879,6 +879,11 @@ the default pool_mode is used.
 Configure a database-wide maximum (i.e. all pools within the database will
 not have more than this many server connections).
 
+### server_idle_timeout
+
+Set the server idle timeout for this database. If not set,
+the default server_idle_timeout is used.
+
 ### client_encoding
 
 Ask specific `client_encoding` from server.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -320,6 +320,7 @@ struct PgDatabase {
 	int res_pool_size;	/* additional server connections in case of trouble */
 	int pool_mode;		/* pool mode for this database */
 	int max_db_connections;	/* max server connections between all pools */
+	int server_idle_timeout; /* server idle timeout for this database */
 
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -320,7 +320,7 @@ struct PgDatabase {
 	int res_pool_size;	/* additional server connections in case of trouble */
 	int pool_mode;		/* pool mode for this database */
 	int max_db_connections;	/* max server connections between all pools */
-	int server_idle_timeout; /* server idle timeout for this database */
+	usec_t server_idle_timeout; /* server idle timeout for this database */
 
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
 

--- a/include/server.h
+++ b/include/server.h
@@ -20,5 +20,5 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
 void kill_pool_logins(PgPool *pool, const char *msg);
 int pool_pool_mode(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
-int database_idle_timeout(PgDatabase *db) _MUSTCHECK;
+usec_t database_idle_timeout(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgUser *user) _MUSTCHECK;

--- a/include/server.h
+++ b/include/server.h
@@ -20,4 +20,5 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
 void kill_pool_logins(PgPool *pool, const char *msg);
 int pool_pool_mode(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
+int database_idle_timeout(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgUser *user) _MUSTCHECK;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -440,7 +440,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
 			disconnect_server(server, true, "SV_IDLE server got dirty");
 		} else if (server->state == SV_USED && !server->ready) {
 			disconnect_server(server, true, "SV_USED server got dirty");
-		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
+		} else if (database_idle_timeout(pool->db) > 0 && idle > database_idle_timeout(pool->db)
 			   && (cf_min_pool_size == 0 || pool_connected_server_count(pool) > cf_min_pool_size)) {
 			disconnect_server(server, true, "server idle timeout");
 		} else if (age >= cf_server_lifetime) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -184,6 +184,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	int pool_size = -1;
 	int res_pool_size = -1;
 	int max_db_connections = -1;
+	int server_idle_timeout = -1;
 	int dbname_ofs;
 	int pool_mode = POOL_INHERIT;
 
@@ -248,6 +249,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			res_pool_size = atoi(val);
 		} else if (strcmp("max_db_connections", key) == 0) {
 			max_db_connections = atoi(val);
+		} else if (strcmp("server_idle_timeout", key) == 0) {
+			server_idle_timeout = atoi(val);
 		} else if (strcmp("pool_mode", key) == 0) {
 			if (!cf_set_lookup(&cv, val)) {
 				log_error("skipping database %s because"
@@ -326,6 +329,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	db->res_pool_size = res_pool_size;
 	db->pool_mode = pool_mode;
 	db->max_db_connections = max_db_connections;
+	db->server_idle_timeout = server_idle_timeout;
 
 	if (db->host)
 		free(db->host);

--- a/src/loader.c
+++ b/src/loader.c
@@ -184,7 +184,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	int pool_size = -1;
 	int res_pool_size = -1;
 	int max_db_connections = -1;
-	int server_idle_timeout = -1;
+	usec_t server_idle_timeout = 0;
 	int dbname_ofs;
 	int pool_mode = POOL_INHERIT;
 
@@ -250,7 +250,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		} else if (strcmp("max_db_connections", key) == 0) {
 			max_db_connections = atoi(val);
 		} else if (strcmp("server_idle_timeout", key) == 0) {
-			server_idle_timeout = atoi(val);
+			server_idle_timeout = atol(val);
 		} else if (strcmp("pool_mode", key) == 0) {
 			if (!cf_set_lookup(&cv, val)) {
 				log_error("skipping database %s because"

--- a/src/server.c
+++ b/src/server.c
@@ -210,6 +210,15 @@ int database_max_connections(PgDatabase *db)
 	}
 }
 
+int database_idle_timeout(PgDatabase *db)
+{
+	if (db->server_idle_timeout <= 0) {
+		return cf_server_idle_timeout;
+        } else {
+		return db->server_idle_timeout;
+	}
+}
+
 int user_max_connections(PgUser *user)
 {
 	if (user->max_user_connections <= 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -210,7 +210,7 @@ int database_max_connections(PgDatabase *db)
 	}
 }
 
-int database_idle_timeout(PgDatabase *db)
+usec_t database_idle_timeout(PgDatabase *db)
 {
 	if (db->server_idle_timeout <= 0) {
 		return cf_server_idle_timeout;


### PR DESCRIPTION
This supports following use case:
- small number of frequently used db's where larger server_idle_timeout is beneficial (per db setting)
- large number of infrequently used db's where single connection is sufficient and shorter server_idle_timeout helps reduce overall number of server connections and memory use (global setting).