### PR TITLE
Change `SHOW version` from a NOTICE to a query

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1297,13 +1297,18 @@ static bool admin_show_help(PgSocket *admin, const char *arg)
 
 static bool admin_show_version(PgSocket *admin, const char *arg)
 {
-	bool res;
-	SEND_generic(res, admin, 'N',
-		"ssss", "SNOTICE", "C00000",
-		"M" FULLVER, "");
-	if (res)
-		res = admin_ready(admin, "SHOW");
-	return res;
+	PktBuf *buf;
+
+	buf = pktbuf_dynamic(128);
+	if (!buf) {
+		admin_error(admin, "no mem");
+		return true;
+	}
+
+	pktbuf_write_RowDescription(buf, "s", "version");
+	pktbuf_write_DataRow(buf, "s", FULLVER);
+	admin_flush(admin, buf, "SHOW");
+	return true;
 }
 
 static bool admin_show_stats(PgSocket *admin, const char *arg)


### PR DESCRIPTION
There's not really a good reason why this SHOW should give its output in
the form of a NOTICE where everything else returns a result set.