### PR TITLE
Set client->wait_start for CL_WAITING_LOGIN

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -186,9 +186,8 @@ void change_client_state(PgSocket *client, SocketState newstate)
 		statlist_append(&login_client_list, &client->head);
 		break;
 	case CL_WAITING:
-		client->wait_start = get_cached_time();
-		/* fallthrough */
 	case CL_WAITING_LOGIN:
+		client->wait_start = get_cached_time();
 		statlist_append(&pool->waiting_client_list, &client->head);
 		break;
 	case CL_ACTIVE:


### PR DESCRIPTION
Without this change, wait_start is not set when entering the
CL_WAITING_LOGIN state.  This results in a failed assertion in
activate_client() or, when assertions are not enabled, massively
inflated total wait times.