### PR TITLE
Don't create an auth_user if auth_query returned no result [fixes #290]

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -336,6 +336,10 @@ bool handle_auth_response(PgSocket *client, PktHdr *pkt) {
 			disconnect_server(server, false, "bad packet");
 			return false;
 		}
+		if (length == (uint32_t)-1) {
+			slog_debug(client, "auth_query returned empty result");
+			break;
+		}
 		if (sizeof(user.name) - 1 < length)
 			length = sizeof(user.name) - 1;
 		memcpy(user.name, username, length);


### PR DESCRIPTION
Checks that the username field of the DataRow packet actually contains
some data before blindly copying its contents around.  Prevents ugly
log messages and, potentially, other more serious problems.