### PR TITLE
Raise errors from log_debug to either warning or error.

### DIFF
--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -891,7 +891,7 @@ static void xares_host_cb(void *arg, int status, int timeouts, struct hostent *h
 		res = convert_hostent(h);
 		got_result_gai(0, res, req);
 	} else {
-		log_debug("DNS lookup failed: %s - %s", req->name, ares_strerror(status));
+		log_error("DNS lookup failed: %s - %s", req->name, ares_strerror(status));
 		got_result_gai(0, res, req);
 	}
 }
@@ -1601,7 +1601,7 @@ static void got_zone_serial(struct DNSContext *ctx, uint32_t *serial)
 			log_debug("zone '%s' unchanged: serial=%u", z->zonename, *serial);
 		}
 	} else {
-		log_debug("failure to get zone '%s' serial", z->zonename);
+		log_error("failure to get zone '%s' serial", z->zonename);
 	}
 
 	el = z->lnode.next;

--- a/src/pam.c
+++ b/src/pam.c
@@ -243,7 +243,7 @@ static void* pam_auth_worker(void *arg)
 		 * sockets and thus save some time.
 		 */
 		if (!is_valid_socket(request)) {
-			log_debug("pam_auth_worker(): invalid socket in slot %d", current_slot);
+			log_error("pam_auth_worker(): invalid socket in slot %d", current_slot);
 			request->status = PAM_STATUS_FAILED;
 			continue;
 		}
@@ -297,7 +297,7 @@ static int pam_conversation(int msgc,
 	int i, rc;
 
 	if (msgc < 1 || msgv == NULL || request == NULL) {
-		log_debug(
+		log_error(
 			"pam_conversation(): wrong input, msgc=%d, msgv=%p, authdata=%p",
 			msgc, msgv, authdata);
 		return PAM_CONV_ERR;
@@ -337,7 +337,7 @@ static int pam_conversation(int msgc,
 			break;
 
 		default:
-			log_debug(
+			log_error(
 				"pam_conversation(): unhandled message, msg_style=%d",
 				msgv[i]->msg_style);
 			break;

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -101,7 +101,7 @@ bool pktbuf_send_immediate(PktBuf *buf, PgSocket *sk)
 		return false;
 	res = sbuf_op_send(&sk->sbuf, pos, amount);
 	if (res < 0) {
-		log_debug("pktbuf_send_immediate: %s", strerror(errno));
+		log_error("pktbuf_send_immediate: %s", strerror(errno));
 	}
 	return res == amount;
 }

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -780,13 +780,13 @@ static bool sbuf_after_connect_check(SBuf *sbuf)
 
 	err = getsockopt(sbuf->sock, SOL_SOCKET, SO_ERROR, (void*)&optval, &optlen);
 	if (err < 0) {
-		log_debug("sbuf_after_connect_check: getsockopt: %s",
-			  strerror(errno));
+		log_error("sbuf_after_connect_check: getsockopt: %s",
+				  strerror(errno));
 		return false;
 	}
 	if (optval != 0) {
-		log_debug("sbuf_after_connect_check: pending error: %s",
-			  strerror(optval));
+		log_error("sbuf_after_connect_check: pending error: %s",
+				  strerror(optval));
 		return false;
 	}
 	return true;
@@ -821,9 +821,9 @@ bool sbuf_answer(SBuf *sbuf, const void *buf, unsigned len)
 		return false;
 	res = sbuf_op_send(sbuf, buf, len);
 	if (res < 0) {
-		log_debug("sbuf_answer: error sending: %s", strerror(errno));
+		log_error("sbuf_answer: error sending: %s", strerror(errno));
 	} else if ((unsigned)res != len) {
-		log_debug("sbuf_answer: partial send: len=%d sent=%d", len, res);
+		log_error("sbuf_answer: partial send: len=%d sent=%d", len, res);
 	}
 	return (unsigned)res == len;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -253,7 +253,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (client->expect_rfq_count > 0) {
 				client->expect_rfq_count--;
 			} else if (server->state == SV_ACTIVE) {
-				slog_debug(client, "unexpected ReadyForQuery - expect_rfq_count=%d", client->expect_rfq_count);
+				slog_error(client, "unexpected ReadyForQuery - expect_rfq_count=%d", client->expect_rfq_count);
 			}
 		}
 		break;


### PR DESCRIPTION
Some errors would be logged only in the debug log level, which means
production setups won't see them. Those error messages are very useful when
debugging corner cases, some of them might look like pgbouncer outages
without the full story.

This patch doesn't add new logs, only raises the chatter up to a level where
it's possible to relate strange behaviors with pgbouncer internal activity.