### PR TITLE
Add support for SO_REUSEPORT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,19 @@ fi # !cares
 
 ## end of DNS
 
+AC_MSG_CHECKING([whether so_reuseport is available])
+AC_LINK_IFELSE([AC_LANG_SOURCE([
+  #include <sys/socket.h>
+  int main(void) {
+    int val = 1;
+    setsockopt(0, SOL_SOCKET, SO_REUSEPORT, &val, 0);
+  } ])],
+[
+  AC_MSG_RESULT([yes])
+  AC_DEFINE(HAVE_SO_REUSEPORT, 1, [SO_REUSEPORT support])
+],
+[AC_MSG_RESULT([no])])
+
 AC_USUAL_TLS
 
 AC_USUAL_DEBUG

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -47,6 +47,13 @@ Which port to listen on. Applies to both TCP and Unix sockets.
 
 Default: 6432
 
+listen_reuseport
+----------------
+
+Whether to enable SO_REUSPORT or not. Applies to only TCP sockets.
+
+Default: 0
+
 unix_socket_dir
 ---------------
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -43,6 +43,7 @@ pidfile = /var/run/pgbouncer/pgbouncer.pid
 ; IP address or * which means all IPs
 listen_addr = 127.0.0.1
 listen_port = 6432
+;listen_reuseport = 0
 
 ; Unix socket is also used for -R.
 ; On Debian it should be /var/run/postgresql

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -401,6 +401,9 @@ extern char *cf_unix_socket_group;
 extern char *cf_listen_addr;
 extern int cf_listen_port;
 extern int cf_listen_backlog;
+#ifdef HAVE_SO_REUSEPORT
+extern int cf_listen_reuseport;
+#endif
 
 extern int cf_pool_mode;
 extern int cf_max_client_conn;

--- a/src/main.c
+++ b/src/main.c
@@ -67,6 +67,9 @@ char *cf_config_file;
 char *cf_listen_addr;
 int cf_listen_port;
 int cf_listen_backlog;
+#ifdef HAVE_SO_REUSEPORT
+int cf_listen_reuseport;
+#endif
 char *cf_unix_socket_dir;
 int cf_unix_socket_mode;
 char *cf_unix_socket_group;
@@ -208,6 +211,9 @@ CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
 CF_ABS("listen_addr", CF_STR, cf_listen_addr, CF_NO_RELOAD, ""),
 CF_ABS("listen_port", CF_INT, cf_listen_port, CF_NO_RELOAD, "6432"),
 CF_ABS("listen_backlog", CF_INT, cf_listen_backlog, CF_NO_RELOAD, "128"),
+#ifdef HAVE_SO_REUSEPORT
+CF_ABS("listen_reuseport", CF_INT, cf_listen_reuseport, CF_NO_RELOAD, "0"),
+#endif
 #ifndef WIN32
 CF_ABS("unix_socket_dir", CF_STR, cf_unix_socket_dir, CF_NO_RELOAD, "/tmp"),
 CF_ABS("unix_socket_mode", CF_INT, cf_unix_socket_mode, CF_NO_RELOAD, "0777"),

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -120,6 +120,16 @@ static bool add_listen(int af, const struct sockaddr *sa, int salen)
 	}
 #endif
 
+#ifdef HAVE_SO_REUSEPORT
+	if (cf_listen_reuseport && af != AF_UNIX) {
+		int val = 1;
+		errpos = "setsockopt/SO_REUSEPORT";
+		res = setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &val, sizeof(val));
+		if (res < 0)
+			goto failed;
+	}
+#endif
+
 	/* bind it */
 	errpos = "bind";
 	res = bind(sock, sa, salen);


### PR DESCRIPTION
SO_REUSEPORT allows multiple applications to listen on the same
address/port.  This allows multiple pgbouncer instances to be started
on the one server and have the operating system load balance requests
between the different instances. pgbouncer is then able to occupy more
than one CPU in a multi CPU environment.