### PR TITLE
Fix to be able to connect to a newly created database

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -598,12 +598,12 @@ bool check_fast_fail(PgSocket *client)
 	cnt = pool_server_count(pool) - statlist_count(&pool->new_server_list);
 	if (cnt)
 		return true;
-	disconnect_client(client, true, "pgbouncer cannot connect to server");
+//	disconnect_client(client, true, "pgbouncer cannot connect to server");
 
 	/* usual relaunch won't work, as there are no waiting clients */
 	launch_new_connection(pool);
 
-	return false;
+	return true;
 }
 
 /* link if found, otherwise put into wait queue */


### PR DESCRIPTION
This fix is to be able to connect to a newly created database without raising the error: "pgbouncer cannot connect to server"

I wanna get some inputs about how we could handle this better covering all the scenarios that could be still needing the error raising
