### PR TITLE
add application_name_disable setting

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -298,6 +298,14 @@ pgbouncer does not change it again.
 
 Default: 0
 
+application_name_disable
+------------------------
+
+Disable setting the application name from pgbouncer.  Setting application name can be
+expensive in some situations.
+
+Default: 0
+
 conffile
 --------
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -178,6 +178,9 @@ server_reset_query = DISCARD ALL
 ;; Use <appname - host> as application_name on server.
 ;application_name_add_host = 0
 
+;; Disable setting application_name on server
+;application_name_disable = 0
+
 ;;;
 ;;; Connection limits
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -467,6 +467,7 @@ extern int cf_log_connections;
 extern int cf_log_disconnections;
 extern int cf_log_pooler_errors;
 extern int cf_application_name_add_host;
+extern int cf_application_name_disable;
 
 extern int cf_client_tls_sslmode;
 extern char *cf_client_tls_protocols;

--- a/src/client.c
+++ b/src/client.c
@@ -406,6 +406,8 @@ static void set_appname(PgSocket *client, const char *app_name)
 	char buf[400], abuf[300];
 	const char *details;
 
+	if (cf_application_name_disable) return;
+
 	if (cf_application_name_add_host) {
 		/* give app a name */
 		if (!app_name)

--- a/src/main.c
+++ b/src/main.c
@@ -143,6 +143,7 @@ int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
 int cf_application_name_add_host;
+int cf_application_name_disable;
 
 int cf_client_tls_sslmode;
 char *cf_client_tls_protocols;
@@ -274,6 +275,7 @@ CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
+CF_ABS("application_name_disable", CF_INT, cf_application_name_disable, 0, "0"),
 
 CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, CF_NO_RELOAD, "disable"),
 CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, CF_NO_RELOAD, ""),


### PR DESCRIPTION
The calls pgbouncer makes to `SET application_name = ` consume about 5% of our database execution time. We'd like an option to disable them.