### PR TITLE
Avoid 'unexpected response from login query' after a postgres reload

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -374,6 +374,8 @@ bool handle_auth_response(PgSocket *client, PktHdr *pkt) {
 		break;
 	case '2':	/* BindComplete */
 		break;
+	case 'S': /* ParameterStatus */
+		break;
 	case 'Z':	/* ReadyForQuery */
 		sbuf_prepare_skip(&client->link->sbuf, pkt->len);
 		if (!client->auth_user) {


### PR DESCRIPTION
After a PostgreSQL reload, the backend could inform the frontend about configuration changes by sending some ParameterStatus messages together with the usual login query response. These messages can be safely ignored in the login query response handler.

Closes: #220