### PR TITLE
Limit pgbouncer statistics to what the wire protocol supports.

### DIFF
--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -391,8 +391,8 @@ void pktbuf_write_RowDescription(PktBuf *buf, const char *tupdesc, ...)
  * send DataRow.
  *
  * tupdesc keys:
- * 'i' - int4
- * 'q' - int8
+ * 'i' - int4, limited to 2^31
+ * 'q' - int8, limited to 2^63
  * 's' - string
  * 'T' - usec_t to date
  */
@@ -409,10 +409,10 @@ void pktbuf_write_DataRow(PktBuf *buf, const char *tupdesc, ...)
 	va_start(ap, tupdesc);
 	for (i = 0; i < ncol; i++) {
 		if (tupdesc[i] == 'i') {
-			snprintf(tmp, sizeof(tmp), "%d", va_arg(ap, int));
+			snprintf(tmp, sizeof(tmp), "%d", va_arg(ap, int) & 0x7fffffff);
 			val = tmp;
 		} else if (tupdesc[i] == 'q') {
-			snprintf(tmp, sizeof(tmp), "%" PRIu64, va_arg(ap, uint64_t));
+			snprintf(tmp, sizeof(tmp), "%" PRIu64, va_arg(ap, uint64_t) & 0x7fffffffffffffff);
 			val = tmp;
 		} else if (tupdesc[i] == 's') {
 			val = va_arg(ap, char *);


### PR DESCRIPTION
Pgbouncer internal statistics are uint8 (64 bit), but the pg protocol is int8;
pgbouncer doesn't roll over the value it writes, instead assuming that the
wire protocol is uint when in fact it's int: see https://www.postgresql.org/docs/9.3/datatype-numeric.html .

To address this, the simplest fix is to force a modulus on what we serialize for uint8
values to limit them to int8 space.

It may be worth refactoring the internals of stats.c/admin.c rather than the
fix I'm proposing here- what is implemented here should cover all stats, but
it feels fragile in the sense that it's a duct tape fix tucked into an internal-
any consuming code that directly uses the underlying pktbuf functions can
bypass and reintroduce a variant of this bug.

I don't see a clean way to address this beyond vigilance combined w/ this
patch, thus proposing this fix.

Backing ticket for this is #350 