### PR TITLE
Extend max password length from 128 to 2048

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -110,7 +110,7 @@ extern int cf_sbuf_len;
 /* to avoid allocations will use static buffers */
 #define MAX_DBNAME	64
 #define MAX_USERNAME	64
-#define MAX_PASSWORD	128
+#define MAX_PASSWORD	2048
 
 /* no-auth modes */
 #define AUTH_ANY	-1 /* same as trust but without username check */

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -144,6 +144,6 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 	SEND_wrap(16, pktbuf_write_CancelRequest, res, sk, key)
 
 #define SEND_PasswordMessage(res, sk, psw) \
-	SEND_wrap(512, pktbuf_write_PasswordMessage, res, sk, psw)
+	SEND_wrap(MAX_PASSWORD, pktbuf_write_PasswordMessage, res, sk, psw)
 
 void pktbuf_cleanup(void);


### PR DESCRIPTION
When using AWS postgres RDS or Aurora it is possible to authenticate using a cryptographically signed token using IAM credentials. The password generated for connection is between typically about 800 characters long.

The current buffer of 128 is inadequate and results in 
>`WARNING bug in src/objects.c:461 - string truncated`

https://github.com/pgbouncer/pgbouncer/blob/dc226613ca023246684efc24b755e00b61ca6d84/src/objects.c#L449-L464


Passwords can be generated for AWS postgres using the [aws cli](https://docs.aws.amazon.com/cli/latest/reference/rds/generate-db-auth-token.html)

```
aws rds generate-db-auth-token  \
  --hostname clustername.cluster-identifierus-west-2.rds.amazonaws.com \
  --port 5432 \
  --username db_user \
  --region us-west-2
```

Further reading on [AWS IAM authentication for Postgres](https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-aurora-postgresql-supports-iam-authentication/)