### PR TITLE
Add stats query_timeout_count, query_wait_timeout_count

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -190,6 +190,8 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
 struct PgStats {
 	uint64_t xact_count;
 	uint64_t query_count;
+	uint64_t query_timeout_count;
+	uint64_t query_wait_timeout_count;
 	uint64_t server_bytes;
 	uint64_t client_bytes;
 	usec_t xact_time;	/* total transaction time in us */

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -392,8 +392,10 @@ static void pool_client_maint(PgPool *pool)
 
 			if (cf_query_timeout > 0 && age > cf_query_timeout) {
 				disconnect_client(client, true, "query_timeout");
+				pool->stats.query_timeout_count++;
 			} else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
+				pool->stats.query_wait_timeout_count++;
 			}
 		}
 	}
@@ -524,6 +526,7 @@ static void pool_server_maint(PgPool *pool)
 			age = now - server->link->request_time;
 			if (cf_query_timeout > 0 && age > cf_query_timeout) {
 				disconnect_server(server, true, "query timeout");
+				pool->stats.query_timeout_count++;
 			} else if (cf_idle_transaction_timeout > 0 &&
 				   server->idle_tx &&
 				   age > cf_idle_transaction_timeout)


### PR DESCRIPTION
#270
Currently not writing them to info log, let me know if we want to
Also i was thinking about new cmd for error-related metrics instead of appending new columns to existing ones, what are your thoughts?