### PR TITLE
Make PAUSE return when canceled by interrupt, signal, or other resume command.

### DIFF
--- a/include/admin.h
+++ b/include/admin.h
@@ -26,3 +26,4 @@ bool admin_flush(PgSocket *admin, PktBuf *buf, const char *desc) /* _MUSTCHECK *
 bool admin_ready(PgSocket *admin, const char *desc)  _MUSTCHECK;
 void admin_handle_cancel(PgSocket *client);
 void admin_cleanup(void);
+void admin_cancel_all_pauses(PgDatabase *db);

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -88,6 +88,12 @@ enum SSLMode {
 	SSLMODE_VERIFY_FULL
 };
 
+enum WaitCommand {
+	WAIT_CMD_NONE = 0,
+	WAIT_CMD_PAUSE = 1,
+	WAIT_CMD_WAIT_CLOSE = 2
+};
+
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
 
 
@@ -100,6 +106,7 @@ typedef union PgAddr PgAddr;
 typedef enum SocketState SocketState;
 typedef struct PktHdr PktHdr;
 typedef struct ScramState ScramState;
+typedef enum WaitCommand WaitCommand;
 
 extern int cf_sbuf_len;
 
@@ -394,7 +401,8 @@ struct PgSocket {
 
 	bool admin_user:1;	/* console client: has admin rights */
 	bool own_user:1;	/* console client: client with same uid on unix socket */
-	bool wait_for_response:1;/* console client: waits for completion of PAUSE/SUSPEND cmd */
+	WaitCommand wait_for_response:2; /* console client: waits for completion of PAUSE/SUSPEND cmd */
+	PgDatabase *wait_for_db; /* console client: target related to wait_for_response */
 
 	bool wait_sslchar:1;	/* server: waiting for ssl response: S/N */
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -1205,41 +1205,41 @@ static bool admin_cmd_wait_close(PgSocket *admin, const char *arg)
 	if (!admin->admin_user)
 		return admin_error(admin, "admin access needed");
 
-       if (!arg[0]) {
-	       struct List *item;
-	       PgPool *pool;
-	       int active = 0;
+	if (!arg[0]) {
+		struct List *item;
+		PgPool *pool;
+		int active = 0;
 
-	       log_info("WAIT_CLOSE command issued");
-	       statlist_for_each(item, &pool_list) {
-		       PgDatabase *db;
+		log_info("WAIT_CLOSE command issued");
+		statlist_for_each(item, &pool_list) {
+			PgDatabase *db;
 
-		       pool = container_of(item, PgPool, head);
-		       db = pool->db;
-		       db->db_wait_close = 1;
-		       active += count_db_active(db);
-	       }
-	       if (active > 0)
-		       admin->wait_for_response = 1;
-	       else
-		       return admin_ready(admin, "WAIT_CLOSE");
-       } else {
-	       PgDatabase *db;
+			pool = container_of(item, PgPool, head);
+			db = pool->db;
+			db->db_wait_close = 1;
+			active += count_db_active(db);
+		}
+		if (active > 0)
+			admin->wait_for_response = 1;
+		else
+			return admin_ready(admin, "WAIT_CLOSE");
+	} else {
+		PgDatabase *db;
 
-	       log_info("WAIT_CLOSE '%s' command issued", arg);
-	       db = find_or_register_database(admin, arg);
-	       if (db == NULL)
-		       return admin_error(admin, "no such database: %s", arg);
-	       if (db == admin->pool->db)
-		       return admin_error(admin, "cannot wait in admin db: %s", arg);
-	       db->db_wait_close = 1;
-	       if (count_db_active(db) > 0)
-		       admin->wait_for_response = 1;
-	       else
-		       return admin_ready(admin, "WAIT_CLOSE");
-       }
+		log_info("WAIT_CLOSE '%s' command issued", arg);
+		db = find_or_register_database(admin, arg);
+		if (db == NULL)
+			return admin_error(admin, "no such database: %s", arg);
+		if (db == admin->pool->db)
+			return admin_error(admin, "cannot wait in admin db: %s", arg);
+		db->db_wait_close = 1;
+		if (count_db_active(db) > 0)
+			admin->wait_for_response = 1;
+		else
+			return admin_ready(admin, "WAIT_CLOSE");
+	}
 
-       return true;
+	return true;
 }
 
 /* extract substring from regex group */

--- a/src/admin.c
+++ b/src/admin.c
@@ -1080,6 +1080,8 @@ static bool admin_cmd_pause(PgSocket *admin, const char *arg)
 			return admin_error(admin, "no such database: %s", arg);
 		if (db == admin->pool->db)
 			return admin_error(admin, "cannot pause admin db: %s", arg);
+		if (db->db_paused)
+			return admin_error(admin, "already suspended/paused: %s", arg);
 		db->db_paused = 1;
 		if (count_db_active(db) == 0)
 			return admin_ready(admin, "PAUSE");

--- a/src/main.c
+++ b/src/main.c
@@ -477,10 +477,12 @@ static void handle_sigusr2(int sock, short flags, void *arg)
 		log_info("got SIGUSR2, continuing from SUSPEND");
 		resume_all();
 		cf_pause_mode = P_NONE;
+		admin_cancel_all_pauses(NULL);
 		break;
 	case P_PAUSE:
 		log_info("got SIGUSR2, continuing from PAUSE");
 		cf_pause_mode = P_NONE;
+		admin_cancel_all_pauses(NULL);
 		break;
 	case P_NONE:
 		log_info("got SIGUSR2, but not paused/suspended");


### PR DESCRIPTION
This PR makes interrupting a `PAUSE` or `WAIT_CLOSE` request work a little better and it improves the tracking of those requests to reduce the likelihood of interference between concurrent commands.

