### PR TITLE
Fix a bunch of issues around auth_user

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -316,6 +316,12 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	} else {
 		/* the user clients wants to log in as */
 		client->auth_user = find_user(username);
+		if (!client->auth_user && !client->db->auth_user && cf_auth_user) {
+			client->db->auth_user = find_user(cf_auth_user);
+			if (!client->db->auth_user) {
+				client->db->auth_user = add_user(cf_auth_user, "");
+			}
+		}
 		if (!client->auth_user && client->db->auth_user) {
 			if (takeover) {
 				client->auth_user = add_db_user(client->db, username, password);

--- a/src/loader.c
+++ b/src/loader.c
@@ -189,7 +189,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	char *port = "5432";
 	char *username = NULL;
 	char *password = "";
-	char *auth_username = cf_auth_user;
+	char *auth_username = NULL;
 	char *client_encoding = NULL;
 	char *datestyle = NULL;
 	char *timezone = NULL;


### PR DESCRIPTION
When switching a pgbouncer configuration from using userlist.txt files to using auth_query/auth_user, I encountered several issues, all fixed in this PR.

1. the wait_start field is not always initialized when using auth_query, displaying weird random stats
Example:
```
2019-06-14 15:41:07.500 26350 LOG stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 9 B/s, xact 0 us, query 0 us, wait 183224844063 us
```

2. the global auth_user configuration variable is mis-handled: it has to be defined before the databases in the .ini file, it can not be defined using the pgbouncer shell unless a reload is applied… This is fixed here by simply not using it from parse_database and instead having it be checked when needed.

3. when removing users from userlist.txt, the corresponding objects are not removed from memory. Instead, their passwords are emptied. This prevents auth_query from being called since the if is valid only for non-existing users.

close #391 
