### PR TITLE
Convert all stats from INT8 -> NUMERIC(20, 0)

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -52,6 +52,10 @@
 #define INT8OID 20
 #define INT4OID 23
 #define TEXTOID 25
+#define NUMERICOID 1700
+
+/* NUMERIC(20, 0) */
+#define NUMERIC_TYPEMOD 0x140005
 
 /*
  * libc compat functions.

--- a/include/system.h
+++ b/include/system.h
@@ -54,8 +54,13 @@
 #define TEXTOID 25
 #define NUMERICOID 1700
 
-/* NUMERIC(20, 0) */
-#define NUMERIC_TYPEMOD 0x140005
+#define VARHDRSZ 4
+/*
+   For numerics, typmod is calculated via:
+   typmod = VARHDRSZ + (precision << 16) + (scale & 0xffff)
+   https://github.com/postgres/postgres/blob/REL_11_4/src/backend/utils/adt/numeric.c#L977-L978
+*/
+#define NUMERIC_TYPMOD ((20 << 16) + VARHDRSZ)  /* NUMERIC(20, 0) */
 
 /*
  * libc compat functions.

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -348,6 +348,7 @@ void pktbuf_write_RowDescription(PktBuf *buf, const char *tupdesc, ...)
 	va_list ap;
 	char *name;
 	int i, ncol = strlen(tupdesc);
+	uint64_t typemod;
 
 	log_noise("write RowDescription");
 
@@ -358,12 +359,12 @@ void pktbuf_write_RowDescription(PktBuf *buf, const char *tupdesc, ...)
 	va_start(ap, tupdesc);
 	for (i = 0; i < ncol; i++) {
 		name = va_arg(ap, char *);
+		typemod = 0;
 
 		/* Fields: name, reloid, colnr, oid, typsize, typmod, fmt */
 		pktbuf_put_string(buf, name);
 		pktbuf_put_uint32(buf, 0);
 		pktbuf_put_uint16(buf, 0);
-		uint64_t typemod = 0;
 
 		if (tupdesc[i] == 's') {
 			pktbuf_put_uint32(buf, TEXTOID);

--- a/src/stats.c
+++ b/src/stats.c
@@ -77,7 +77,7 @@ static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
 {
 	PgStats avg;
 	calc_average(&avg, stat, old);
-	pktbuf_write_DataRow(buf, "sqqqqqqqqqqqqqq", dbname,
+	pktbuf_write_DataRow(buf, "snnnnnnnnnnnnnn", dbname,
 			     stat->xact_count, stat->query_count,
 			     stat->client_bytes, stat->server_bytes,
 			     stat->xact_time, stat->query_time,
@@ -108,7 +108,7 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 		return true;
 	}
 
-	pktbuf_write_RowDescription(buf, "sqqqqqqqqqqqqqq", "database",
+	pktbuf_write_RowDescription(buf, "snnnnnnnnnnnnnn", "database",
 				    "total_xact_count", "total_query_count",
 				    "total_received", "total_sent",
 				    "total_xact_time", "total_query_time",
@@ -152,7 +152,7 @@ static void write_stats_totals(PktBuf *buf, PgStats *stat, PgStats *old, char *d
 {
 	PgStats avg;
 	calc_average(&avg, stat, old);
-	pktbuf_write_DataRow(buf, "sqqqqqqq", dbname,
+	pktbuf_write_DataRow(buf, "snnnnnnn", dbname,
 			     stat->xact_count, stat->query_count,
 			     stat->client_bytes, stat->server_bytes,
 			     stat->xact_time, stat->query_time,
@@ -179,7 +179,7 @@ bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list)
 		return true;
 	}
 
-	pktbuf_write_RowDescription(buf, "sqqqqqqq", "database",
+	pktbuf_write_RowDescription(buf, "snnnnnnn", "database",
 				    "xact_count", "query_count",
 				    "bytes_received", "bytes_sent",
 				    "xact_time", "query_time",
@@ -219,7 +219,7 @@ static void write_stats_averages(PktBuf *buf, PgStats *stat, PgStats *old, char 
 {
 	PgStats avg;
 	calc_average(&avg, stat, old);
-	pktbuf_write_DataRow(buf, "sqqqqqqq", dbname,
+	pktbuf_write_DataRow(buf, "snnnnnnn", dbname,
 			     avg.xact_count, avg.query_count,
 			     avg.client_bytes, avg.server_bytes,
 			     avg.xact_time, avg.query_time,
@@ -246,7 +246,7 @@ bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list)
 		return true;
 	}
 
-	pktbuf_write_RowDescription(buf, "sqqqqqqq", "database",
+	pktbuf_write_RowDescription(buf, "snnnnnnn", "database",
 				    "xact_count", "query_count",
 				    "bytes_received", "bytes_sent",
 				    "xact_time", "query_time",


### PR DESCRIPTION
Internally these statistics are stored as unsigned 64-bit values,
but the PostgreSQL INT8 types can only express signed 64-bit values.
Convert all the stats to NUMERIC(20, 0) to avoid losing data.

Closes #360