### PR TITLE
Improve logging when per-user connection limit is hit

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -61,6 +61,7 @@ enum SocketState {
 	CL_LOGIN,		/* login_client_list */
 	CL_WAITING,		/* pool->waiting_client_list */
 	CL_WAITING_LOGIN,	/*   - but return to CL_LOGIN instead of CL_ACTIVE */
+	CL_WAITING_SLOT,	/*   - notify on transition in and out of this state */
 	CL_ACTIVE,		/* pool->active_client_list */
 	CL_CANCEL,		/* pool->cancel_req_list */
 
@@ -71,6 +72,16 @@ enum SocketState {
 	SV_ACTIVE,		/* pool->active_server_list */
 	SV_USED,		/* pool->used_server_list */
 	SV_TESTED		/* pool->tested_server_list */
+};
+
+enum LaunchResult {
+	LAUNCH_SUCCESS = 0,	/* launched a new connection */
+	LAUNCH_THROTTLED,	/* we allow only small number of connection attempts at a time */
+	LAUNCH_RETRY_WAIT,	/* if server bounces, don't retry too fast */
+	LAUNCH_POOL_FULL,	/* reached maximum total connections in pool */
+	LAUNCH_DATABASE_FULL,	/* reached maximum connections for this database */
+	LAUNCH_USER_FULL,	/* reached maximum connections for this user */
+	LAUNCH_OUT_OF_MEMORY,	/* out of memory: slab_alloc from server_cache failed */
 };
 
 enum PauseMode {

--- a/include/objects.h
+++ b/include/objects.h
@@ -55,7 +55,7 @@ PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
 void accept_cancel_request(PgSocket *req);
 void forward_cancel_request(PgSocket *server);
 
-void launch_new_connection(PgPool *pool);
+enum LaunchResult launch_new_connection(PgPool *pool);
 
 bool use_client_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,

--- a/src/client.c
+++ b/src/client.c
@@ -1010,6 +1010,8 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 				res = handle_client_work(client, &pkt);
 			break;
 		case CL_WAITING:
+		case CL_WAITING_LOGIN:
+		case CL_WAITING_SLOT:
 			fatal("why waiting client in client_proto()");
 		default:
 			fatal("bad client state: %d", client->state);

--- a/src/objects.c
+++ b/src/objects.c
@@ -160,6 +160,7 @@ void change_client_state(PgSocket *client, SocketState newstate)
 			newstate = CL_LOGIN;
 		/* fallthrough */
 	case CL_WAITING:
+	case CL_WAITING_SLOT:
 		statlist_remove(&pool->waiting_client_list, &client->head);
 		break;
 	case CL_ACTIVE:
@@ -188,6 +189,7 @@ void change_client_state(PgSocket *client, SocketState newstate)
 		break;
 	case CL_WAITING:
 	case CL_WAITING_LOGIN:
+	case CL_WAITING_SLOT:
 		client->wait_start = get_cached_time();
 		statlist_append(&pool->waiting_client_list, &client->head);
 		break;
@@ -554,11 +556,16 @@ static void pause_client(PgSocket *client)
 /* wake client from wait */
 void activate_client(PgSocket *client)
 {
-	Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);
+	Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN ||
+		client->state == CL_WAITING_SLOT);
+
+	if(client->state == CL_WAITING_SLOT) {
+		slog_info(client, "activate_client: finally got a connection");
+	}
 
 	Assert(client->wait_start > 0);
 
-	/* acount for time client spent waiting for server */
+	/* account for time client spent waiting for server */
 	client->pool->stats.wait_time += (get_cached_time() - client->wait_start);
 
 	slog_debug(client, "activate_client");
@@ -921,6 +928,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 		}
 	case CL_WAITING:
 	case CL_WAITING_LOGIN:
+	case CL_WAITING_SLOT:
 	case CL_CANCEL:
 		break;
 	default:
@@ -1128,8 +1136,8 @@ bool evict_user_connection(PgUser *user)
 	return false;
 }
 
-/* the pool needs new connection, if possible */
-void launch_new_connection(PgPool *pool)
+/* the pool needs new connection, if possible. */
+enum LaunchResult launch_new_connection(PgPool *pool)
 {
 	PgSocket *server;
 	int max;
@@ -1137,7 +1145,7 @@ void launch_new_connection(PgPool *pool)
 	/* allow only small number of connection attempts at a time */
 	if (!statlist_empty(&pool->new_server_list)) {
 		log_debug("launch_new_connection: already progress");
-		return;
+		return LAUNCH_THROTTLED;
 	}
 
 	/* if server bounces, don't retry too fast */
@@ -1146,7 +1154,7 @@ void launch_new_connection(PgPool *pool)
 		if (now - pool->last_connect_time < cf_server_login_retry) {
 			log_debug("launch_new_connection: last failed, not launching new connection yet, still waiting %" PRIu64 " s",
 				  (cf_server_login_retry - (now - pool->last_connect_time)) / USEC);
-			return;
+			return LAUNCH_RETRY_WAIT;
 		}
 	}
 
@@ -1166,7 +1174,7 @@ void launch_new_connection(PgPool *pool)
 		}
 		log_debug("launch_new_connection: pool full (%d >= %d)",
 				max, pool->db->pool_size);
-		return;
+		return LAUNCH_POOL_FULL;
 	}
 
 allow_new:
@@ -1181,7 +1189,7 @@ allow_new:
 		if (pool->db->connection_count >= max) {
 			log_debug("launch_new_connection: database '%s' full (%d >= %d)",
 				  pool->db->name, pool->db->connection_count, max);
-			return;
+			return LAUNCH_DATABASE_FULL;
 		}
 	}
 
@@ -1196,7 +1204,7 @@ allow_new:
 		if (pool->user->connection_count >= max) {
 			log_debug("launch_new_connection: user '%s' full (%d >= %d)",
 				  pool->user->name, pool->user->connection_count, max);
-			return;
+			return LAUNCH_USER_FULL;
 		}
 	}
 
@@ -1204,7 +1212,7 @@ allow_new:
 	server = slab_alloc(server_cache);
 	if (!server) {
 		log_debug("launch_new_connection: no memory");
-		return;
+		return LAUNCH_OUT_OF_MEMORY;
 	}
 
 	/* initialize it */
@@ -1217,6 +1225,7 @@ allow_new:
 	pool->user->connection_count++;
 
 	dns_connect(server);
+	return LAUNCH_SUCCESS;
 }
 
 /* new client connection attempt */


### PR DESCRIPTION
See https://github.com/pgbouncer/pgbouncer/issues/166 for rationale.

It's difficult to tell from the log messages when a user is being made to wait
for a free connection in pgBouncer itself.  The logs would normally say:

	C-0x692020: testing2/testuser@1.2.3.4:33034 login attempt: db=testing2 user=testuser tls=no
	S-0x696cd0: testing2/testuser@127.0.0.1:5433 new connection to server (from 127.0.0.1:38388)

Where the second line indicates a new connection to the server. This line would
not appear in one of two cases:

* An existing connection is reused, or
* No connection is available and the user must wait for one to become free.

This patch adds extra logging when a user is made to wait for a connection to
become free. For example:

	C-0x692020: testing2/testuser@1.2.3.4:33034 login attempt: db=testing2 user=testuser tls=no
	S-0x696cd0: testing2/testuser@127.0.0.1:5433 new connection to server (from 127.0.0.1:38388)
	C-0x6921a8: testing2/testuser@1.2.3.4:33038 login attempt: db=testing2 user=testuser tls=no
	C-0x6921a8: testing2/testuser@1.2.3.4:33038 per_loop_activate: reached per-user connection limit, waiting for one to become free
	C-0x691d10: testing2/testuser@1.2.3.4:33026 closing because: client unexpected eof (age=23)
	S-0x6969c0: testing2/testuser@127.0.0.1:5433 closing because: unclean server (age=23)
	S-0x696e58: testing2/testuser@127.0.0.1:5433 new connection to server (from 127.0.0.1:38400)
	C-0x6921a8: testing2/testuser@1.2.3.4:33038 activate_client: finally got a connection

The new lines here are *per_loop_activate: reached per-user connection limit*
and *activate_client: finally got a connection*.

This introduces a fair bit of new code, including a new state in the state
machine (CL_WAITING_SLOT), so please review carefully.

Steve Winfield pointed out that since I've inserted CL_WAITING_SLOT into the SocketState enum, the values of the other existing entries below it will shift by one, which would probably make it unsafe to do an online upgrade across this change, as the client state passed to the new pgBouncer instance over the unix domain socket could have some SocketState values misinterpreted.