### PR TITLE
add launch_new_connection in disconnect_client function

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -905,6 +905,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 				server->link = NULL;
 				client->link = NULL;
 				disconnect_server(server, true, "unclean server");
+				launch_new_connection(server->pool);
 			}
 		}
 	case CL_WAITING:


### PR DESCRIPTION
I was experience some issue that disappeared server connection when client connection terminated. our application server using python + django 1.4.22. the client connection terminated('X' code) and server connection show "unclean server" message when our source does not clearly use transaction. 

the simply test query is as follow:
```
psql -P pager=off -h 127.0.0.1 -Uservice -p 6543 test
psql (9.6.15)
Type "help" for help.
 
pg@test=>begin;
BEGIN
pg@test=>*\q
```
if i terminate client connection using "Quick" command, the server connection don't change from sv_active to sv_idle. i knew that the terminate query cause "server->ready" is false. and then, the pgbouncer execute disconnect_server function due to ready value is false.

**Even if the client connection ends abnormally, i want to reuse the server connection.**

so, i was add one line about "launch_new_connection" below "disconnect_server" for maintaining server connection. i checked when i use launch_new_connection below disconnect_server, the aborted client connection is disconnected, and new server connection created to SV_IDLE.

```
-- client connection terminated (using \q)
2019-08-30 16:42:53.517 23758 NOISE resync: done=0, parse=0, recv=0
2019-08-30 16:42:53.517 23758 NOISE C-0x1f3bd90: test/service@127.0.0.1:44552 pkt='X' len=5
2019-08-30 16:42:53.517 23758 NOISE Eddie | handle_client_work | ready : 0
2019-08-30 16:42:53.517 23758 NOISE Eddie | handle_client_work | link_ready : 0 | state : 11
 
-- pgbouncer started to try to disconnect client connection
2019-08-30 16:42:53.517 23758 LOG C-0x1f3bd90: test/service@127.0.0.1:44552 Eddie | disconnect_client | client_type : 5
2019-08-30 16:42:53.517 23758 LOG C-0x1f3bd90: test/service@127.0.0.1:44552 closing because: client close request (age=15)
 
-- server connection is not released due to ready is false.
2019-08-30 16:42:53.517 23758 NOISE Eddie | disconnect_client | ready : 0 | sbuf_is_empty : 1
2019-08-30 16:42:53.517 23758 LOG S-0x1f41090: test/service@127.0.0.1:5432 closing because: unclean server (age=14)
2019-08-30 16:42:53.517 23758 LOG C-0x1f3bd90: test/service@127.0.0.1:44552 Eddie | disconnect_client | server_type : 8
 
-- try to launch_new_connection function (in my source)
2019-08-30 16:42:53.517 23758 NOISE S-0x1f40bc8: test/service@(bad-af):0 inet socket: 127.0.0.1
2019-08-30 16:42:53.517 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 launching new connection to server
2019-08-30 16:42:53.517 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: connect ok
2019-08-30 16:42:53.517 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 P: startup
 
2019-08-30 16:42:53.518 23758 NOISE resync: done=0, parse=0, recv=0
 
-- to try login to postgresql server(using md5)
2019-08-30 16:42:53.518 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'R', len=13
2019-08-30 16:42:53.518 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 calling login_answer
2019-08-30 16:42:53.518 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: req md5-crypted psw
2019-08-30 16:42:53.518 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 P: send md5 password
2019-08-30 16:42:53.518 23758 NOISE resync: done=13, parse=13, recv=13
2019-08-30 16:42:53.519 23758 NOISE resync: done=0, parse=0, recv=0
 
-- pgbouncer retry for create new connection
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'R', len=9
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 calling login_answer
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: auth ok
 
-- to set environment values
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=23
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: application_name =
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=26
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: client_encoding = UTF8
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=24
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: DateStyle = ISO, MDY
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=26
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: integer_datetimes = on
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=28
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: IntervalStyle = postgres
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=22
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: is_superuser = off
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=26
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: server_encoding = UTF8
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=27
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: server_version = 9.6.15
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=47
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: session_authorization = service
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=36
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: standard_conforming_strings = on
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'S', len=25
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 S: param: TimeZone = Asia/Seoul

-- BackendKeyData
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'K', len=13
 
-- pooling decisions will be based on this packet
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 S: pkt 'Z', len=6
2019-08-30 16:42:53.519 23758 DEBUG S-0x1f40bc8: test/service@127.0.0.1:5432 server login ok, start accepting queries
 
-- server connection status changes to SV_IDLE
2019-08-30 16:42:53.519 23758 NOISE S-0x1f40bc8: test/service@127.0.0.1:5432 release_server: new state=10
2019-08-30 16:42:53.519 23758 NOISE resync: done=338, parse=338, recv=338
```

i think that if i use launch_new_connection function in disconnect_client function for maintaining server connection, it's not cause any other problem, because of the Sbuf and link value of  PgSocket struct for server connection is empty.

if you know to maintain server connection when client connection terminated, please let me know.
i want to maintain server connection for serving our service using the pgbouncer.

Thanks,