### PR TITLE
feat: extend max username length to 128

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Robert Gogolok
 Sam McLeod
 Teodor Sigaev
 William Grant
+Eduardo Alonso

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([PgBouncer],
-        [1.11.0],
+        [1.11.0-1],
         [https://github.com/pgbouncer/pgbouncer/issues], [],
         [https://pgbouncer.github.io/])
 AC_CONFIG_SRCDIR(src/janitor.c)

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -110,7 +110,7 @@ extern int cf_sbuf_len;
 
 /* to avoid allocations will use static buffers */
 #define MAX_DBNAME	64
-#define MAX_USERNAME	64
+#define MAX_USERNAME	128
 /* typical SCRAM-SHA-256 verifier takes at least 133 bytes */
 #define MAX_PASSWORD	160
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -109,7 +109,7 @@ extern int cf_sbuf_len;
 #include "pam.h"
 
 /* to avoid allocations will use static buffers */
-#define MAX_DBNAME	64
+#define MAX_DBNAME	160
 #define MAX_USERNAME	128
 /* typical SCRAM-SHA-256 verifier takes at least 133 bytes */
 #define MAX_PASSWORD	160


### PR DESCRIPTION
The default max value for username allowed for login with pgbouncer is too short in occasions
the problem arise when using azure db as a service that includes an @<server_name> mandatory that makes very easy to arribe to 64 characteres.