### PR TITLE
fix rejected connection on pause

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -41,8 +41,7 @@ bool finish_client_login(PgSocket *client)	_MUSTCHECK;
 bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
-void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
-void disconnect_server_noblame(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
+void disconnect_server(PgSocket *server, bool notify, bool suspect_server_fault, const char *reason, ...) _PRINTF(4, 5);
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _PRINTF(3, 4);
 
 PgDatabase * add_database(const char *name) _MUSTCHECK;

--- a/include/objects.h
+++ b/include/objects.h
@@ -42,6 +42,7 @@ bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
+void disconnect_server_noblame(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _PRINTF(3, 4);
 
 PgDatabase * add_database(const char *name) _MUSTCHECK;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -34,7 +34,7 @@ static void close_server_list(struct StatList *sk_list, const char *reason)
 
 	statlist_for_each_safe(item, sk_list, tmp) {
 		server = container_of(item, PgSocket, head);
-		disconnect_server(server, true, "%s", reason);
+		disconnect_server_noblame(server, true, "%s", reason);
 	}
 }
 
@@ -63,7 +63,7 @@ bool suspend_socket(PgSocket *sk, bool force_suspend)
 		return sk->suspended;
 
 	if (is_server_socket(sk))
-		disconnect_server(sk, true, "suspend_timeout");
+		disconnect_server_noblame(sk, true, "suspend_timeout");
 	else
 		disconnect_client(sk, true, "suspend_timeout");
 	return true;
@@ -435,21 +435,21 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
 		idle = now - server->request_time;
 
 		if (server->close_needed) {
-			disconnect_server(server, true, "database configuration changed");
+			disconnect_server_noblame(server, true, "database configuration changed");
 		} else if (server->state == SV_IDLE && !server->ready) {
 			disconnect_server(server, true, "SV_IDLE server got dirty");
 		} else if (server->state == SV_USED && !server->ready) {
 			disconnect_server(server, true, "SV_USED server got dirty");
 		} else if (cf_server_idle_timeout > 0 && idle > cf_server_idle_timeout
 			   && (cf_min_pool_size == 0 || pool_connected_server_count(pool) > cf_min_pool_size)) {
-			disconnect_server(server, true, "server idle timeout");
+			disconnect_server_noblame(server, true, "server idle timeout");
 		} else if (age >= cf_server_lifetime) {
 			if (pool->last_lifetime_disconnect + lifetime_kill_gap <= now) {
-				disconnect_server(server, true, "server lifetime over");
+				disconnect_server_noblame(server, true, "server lifetime over");
 				pool->last_lifetime_disconnect = now;
 			}
 		} else if (cf_pause_mode == P_PAUSE) {
-			disconnect_server(server, true, "pause mode");
+			disconnect_server_noblame(server, true, "pause mode");
 		} else if (idle_test && *cf_server_check_query) {
 			if (idle > cf_server_check_delay)
 				change_server_state(server, SV_USED);
@@ -475,7 +475,7 @@ static void check_pool_size(PgPool *pool)
 			server = first_socket(&pool->idle_server_list);
 		if (!server)
 			break;
-		disconnect_server(server, true, "too many servers in the pool");
+		disconnect_server_noblame(server, true, "too many servers in the pool");
 		many--;
 		cur--;
 	}
@@ -510,7 +510,7 @@ static void pool_server_maint(PgPool *pool)
 			server = container_of(item, PgSocket, head);
 			Assert(server->state == SV_ACTIVE);
 			if (server->ready && server->close_needed)
-				disconnect_server(server, true, "database configuration changed");
+				disconnect_server_noblame(server, true, "database configuration changed");
 		}
 	}
 
@@ -536,12 +536,12 @@ static void pool_server_maint(PgPool *pool)
 			age_server = now - server->request_time;
 
 			if (cf_query_timeout > 0 && age_client > cf_query_timeout) {
-				disconnect_server(server, true, "query timeout");
+				disconnect_server_noblame(server, true, "query timeout");
 			} else if (cf_idle_transaction_timeout > 0 &&
 				   server->idle_tx &&
 				   age_server > cf_idle_transaction_timeout)
 			{
-				disconnect_server(server, true, "idle transaction timeout");
+				disconnect_server_noblame(server, true, "idle transaction timeout");
 			}
 		}
 	}

--- a/src/objects.c
+++ b/src/objects.c
@@ -795,25 +795,8 @@ bool release_server(PgSocket *server)
 	return true;
 }
 
-static void disconnect_server_ext(PgSocket *server, bool notify, bool noblame, const char *reason, va_list ap);
-
 /* drop server connection */
-void disconnect_server(PgSocket *server, bool notify, const char *reason, ...)
-{
-	va_list ap;
-	va_start(ap, reason);
-	disconnect_server_ext(server, notify, false, reason, ap);
-	va_end(ap);
-}
-
-void disconnect_server_noblame(PgSocket *server, bool notify, const char *reason, ...)
-{
-	va_list ap;
-	va_start(ap, reason);
-	disconnect_server_ext(server, notify, true, reason, ap);
-	va_end(ap);
-}
-
+_PRINTF(4, 0)
 static void disconnect_server_ext(PgSocket *server, bool notify, bool noblame, const char *reason, va_list ap)
 {
 	PgPool *pool = server->pool;
@@ -893,6 +876,22 @@ static void disconnect_server_ext(PgSocket *server, bool notify, bool noblame, c
 	change_server_state(server, SV_JUSTFREE);
 	if (!sbuf_close(&server->sbuf))
 		log_noise("sbuf_close failed, retry later");
+}
+
+void disconnect_server(PgSocket *server, bool notify, const char *reason, ...)
+{
+	va_list ap;
+	va_start(ap, reason);
+	disconnect_server_ext(server, notify, false, reason, ap);
+	va_end(ap);
+}
+
+void disconnect_server_noblame(PgSocket *server, bool notify, const char *reason, ...)
+{
+	va_list ap;
+	va_start(ap, reason);
+	disconnect_server_ext(server, notify, true, reason, ap);
+	va_end(ap);
 }
 
 /* drop client connection */

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -55,7 +55,7 @@ void takeover_finish(void)
 			fatal_perror("sky is falling - error while waiting result from SHUTDOWN");
 	}
 
-	disconnect_server(old_bouncer, false, "disko over");
+	disconnect_server(old_bouncer, false, true, "disko over");
 	old_bouncer = NULL;
 
 	if (cf_pidfile && cf_pidfile[0]) {


### PR DESCRIPTION
Sometimes, when executing PAUSE command, a connection may be refused. It turned out to happen when PAUSE finds a server connection in a login state. In this situation the server connection, according to PAUSE semantics, is closed, but it also marks the pool as `last_login_failed` and `last_connect_failed`. This may sometimes prevent reconnecting to a server, resulting in a client connection rejected.

To reproduce: make frequent random connections, disconnections and simple query executions with pgboucner concurrently (I can provide a python script if needed). In another console do `psql -p 5433 -d pgbouncer -c 'pause'; psql -p 5433 -d pgbouncer -c 'resume';`. From time to time the python script gets connection rejected.

The patch is to fix it. For now it's mostly a proof of concept, and a request for comments to the idea. Perhaps it's worth joining `disconnect_server` and `disconnect_server_noblame` into a single function with an extra argument, as well as tidying up the code a bit.