### PR TITLE
Add PAM support to hba.conf

### DIFF
--- a/src/hba.c
+++ b/src/hba.c
@@ -590,6 +590,10 @@ static bool parse_line(struct HBA *hba, struct TokParser *tp, int linenr, const 
 		rule->rule_method = AUTH_CERT;
 	} else if (eat_kw(tp, "scram-sha-256")) {
 		rule->rule_method = AUTH_SCRAM_SHA_256;
+#ifdef HAVE_PAM
+	} else if (eat_kw(tp, "pam")) {
+		rule->rule_method = AUTH_PAM;
+#endif
 	} else {
 		log_warning("hba line %d: unsupported method: buf=%s", linenr, tp->buf);
 		goto failed;


### PR DESCRIPTION
I have included this change as a patch in a custom version since the beginning of 2018, and it has run without problems in a production environment of over 80 servers (See issue # 276). I am requesting this change to be included in the next version of pgbouncer