### PR TITLE
Lower severity of protocol errors produced by npgsql

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -361,7 +361,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 				server->pool->stats.query_time += total;
 				slog_debug(client, "query time: %d us", (int)total);
 			} else if ((ready || idle_tx) && !async_response) {
-				slog_warning(client, "FIXME: query end, but query_start == 0");
+				slog_debug(client, "FIXME: query end, but query_start == 0");
 			}
 
 			/* statement ending in "idle" ends a transaction */
@@ -372,7 +372,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 				server->pool->stats.xact_time += total;
 				slog_debug(client, "transaction time: %d us", (int)total);
 			} else if (ready && !async_response) {
-				slog_warning(client, "FIXME: transaction end, but xact_start == 0");
+				slog_debug(client, "FIXME: transaction end, but xact_start == 0");
 			}
 		}
 	} else {


### PR DESCRIPTION
There is currently no way to exclude these log warnings from the log file using the verbose parameter when using npgsql as client.
This error message should really be classified as a debug message, as it is not very useful as a warning, but has a lot more value as a debug message.