### PR TITLE
Patches pgbouncer to add TCP_USER_TIMEOUT option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -787,6 +787,12 @@ Default: 45 on Linux, otherwise 0
 
 Default: not set
 
+### tcp_user_timeout
+
+Enables socket-level timeout in milliseconds. This solves the situation where a database server on the end of a connection fails to kill a TCP connectionn properly after a shutdown or crash. TCP connections then get stuck and need clearing out. The Linux kernel setting `tcp_retries2` default value means stuck TCP connections get cleaned up after about 15 minutes. Setting `tcp_user_timeout` to a lower value means the connections get cleaned up more quickly if they're stuck.
+
+This setting works alongside the below keep alive settings. Read more about specifics here: https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
+
 ### tcp_keepalive
 
 Turns on basic keepalive with OS defaults.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -304,6 +304,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; In-kernel buffer size (Linux default: 4096)
 ;tcp_socket_buffer = 0
 
+;; Close TCP connections that are falsely stuck in "ESTABLISHED" state
+;; after this much time in milliseconds
+;;tcp_user_timeout = 0
+
 ;; whether tcp keepalive should be turned on (0/1)
 ;tcp_keepalive = 1
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -494,6 +494,7 @@ extern int cf_tcp_keepidle;
 extern int cf_tcp_keepintvl;
 extern int cf_tcp_socket_buffer;
 extern int cf_tcp_defer_accept;
+extern int cf_tcp_user_timeout;
 
 extern int cf_log_connections;
 extern int cf_log_disconnections;

--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,7 @@ int cf_sbuf_len;
 int cf_sbuf_loopcnt;
 int cf_so_reuseport;
 int cf_tcp_socket_buffer;
+int cf_tcp_user_timeout;
 #if defined(TCP_DEFER_ACCEPT) || defined(SO_ACCEPTFILTER)
 int cf_tcp_defer_accept = 1;
 #else
@@ -272,6 +273,7 @@ CF_ABS("tcp_keepalive", CF_INT, cf_tcp_keepalive, 0, "1"),
 CF_ABS("tcp_keepcnt", CF_INT, cf_tcp_keepcnt, 0, "0"),
 CF_ABS("tcp_keepidle", CF_INT, cf_tcp_keepidle, 0, "0"),
 CF_ABS("tcp_keepintvl", CF_INT, cf_tcp_keepintvl, 0, "0"),
+CF_ABS("tcp_user_timeout", CF_INT, cf_tcp_user_timeout, 0, "0"),
 CF_ABS("verbose", CF_INT, cf_verbose, 0, NULL),
 CF_ABS("admin_users", CF_STR, cf_admin_users, 0, ""),
 CF_ABS("stats_users", CF_STR, cf_stats_users, 0, ""),

--- a/src/util.c
+++ b/src/util.c
@@ -142,6 +142,17 @@ bool tune_socket(int sock, bool is_unix)
 		goto fail;
 
 	/*
+	 * TCP user timeout
+	 */
+#ifdef TCP_USER_TIMEOUT
+	val = cf_tcp_user_timeout;
+	errpos = "setsockopt/TCP_USER_TIMEOUT";
+	res = setsockopt(sock, SOL_TCP, TCP_USER_TIMEOUT, &val, sizeof(val));
+	if (res < 0)
+		goto fail;
+#endif
+
+	/*
 	 * set in-kernel socket buffer size
 	 */
 	if (cf_tcp_socket_buffer) {

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -15,6 +15,7 @@ int cf_tcp_keepcnt;
 int cf_tcp_keepintvl;
 int cf_tcp_keepidle;
 int cf_tcp_keepalive;
+int cf_tcp_user_timeout;
 int cf_tcp_socket_buffer;
 int cf_listen_port;
 


### PR DESCRIPTION
### The issue:
TCP connections that are in the `ESTABLISHED` state to a Postgres server don't get closed properly if the Postgres server dies and doesn't send back any TCP closing packets. This means that PgBouncer ends up holding onto dud connections, and they won't be closed until the Linux kernel level setting `tcp_retries2` kicks in _(at around 15 minutes)_.

### Description of changes:
This change introduces the TCP socket-level setting `TCP_USER_TIMEOUT`, which acts the same as `tcp_retries2` but at the socket level, instead of being OS-wide. It kicks in after the specified keep alive probes, explanation here:

>... We mentioned the TCP_USER_TIMEOUT option before. It sets the maximum amount of time that transmitted data may remain unacknowledged before the kernel forcefully closes the connection. On its own, it doesn't do much in the case of idle connections. The sockets will remain ESTABLISHED even if the connectivity is dropped. However, this socket option does change the semantics of TCP keepalives. The tcp(7) manpage is somewhat confusing:
...
>For the user timeout to have any effect, the icsk_probes_out must not be zero. The check for user timeout is done only after the first probe went out. Let's check it out. Our connection settings:

>TCP_USER_TIMEOUT = 5*1000 - 5 seconds
>SO_KEEPALIVE = 1 - enable keepalives
>TCP_KEEPIDLE = 1 - send first probe quickly - 1 second idle
>TCP_KEEPINTVL = 11 - subsequent probes every 11 seconds
>TCP_KEEPCNT = 3 - send three probes before timing out


#### Note:
`TCP_USER_TIMEOUT` interacts with `keepalive` settings in a particular way: https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/

### Steps to test:
**1.** Set the following config options for PgBouncer:
```
tcp_user_timeout = 12500
tcp_keepalive = 1
tcp_keepidle = 1
tcp_keepintvl = 11
tcp_keepcnt = 3
```
this will ensure that dead TCP connections are killed after 12.5s.
**2.** Start PgBouncer and connect to Postgres, make sure there are some server connections open
**3.** psql to PgBouncer and run `SHOW SERVERS;`, make sure there's a connection and monitor it's `connect_time` value.
**4.** Block packets from getting to Postgres, assuming Postgres is running on port `5432`
```
iptables -A OUTPUT -p tcp --dport 5432 -j REJECT
```
**5.** After 12.5s you should see that the connection is killed via `SHOW SERVERS;`
**6.** To show the issue, repeat the above but remove the `tcp_user_timeout` config, and the server connection should hang for about 15mins.


_P.S_ I'm not a C developer so please excuse any wrong includes– commit a fix if you see obvious issues 😃 