### PR TITLE
Add 'min_pool_size_requires_clients' setting.

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -202,6 +202,14 @@ of total inactivity.
 
 Default: 0 (disabled)
 
+### min_pool_size_requires_clients
+
+Only maintain `min_pool_size` server connections while there are clients connected to the pool. 
+
+If `min_pool_size` is disabled, this setting has no effect.
+
+Default: 1 (enabled)
+
 ### reserve_pool_size
 
 How many additional connections to allow to a pool. 0 disables.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -187,6 +187,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Minimum number of server connections to keep in pool.
 ;min_pool_size = 0
 
+;; Require clients to be connected in order to maintain min_pool_size.
+;min_pool_size_requires_clients = 1
+
 ; how many additional connection to allow in case of trouble
 ;reserve_pool_size = 0
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -436,6 +436,7 @@ extern int cf_pool_mode;
 extern int cf_max_client_conn;
 extern int cf_default_pool_size;
 extern int cf_min_pool_size;
+extern int cf_min_pool_size_requires_clients;
 extern int cf_res_pool_size;
 extern usec_t cf_res_pool_timeout;
 extern int cf_max_db_connections;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -485,7 +485,8 @@ static void check_pool_size(PgPool *pool)
 	    cur < pool->db->pool_size &&
 	    cf_pause_mode == P_NONE &&
 	    cf_reboot == 0 &&
-	    pool_client_count(pool) > 0)
+		(cf_min_pool_size_requires_clients == 0 || (cf_min_pool_size_requires_clients == 1
+				&& pool_client_count(pool) > 0)))
 	{
 		log_debug("launching new connection to satisfy min_pool_size");
 		launch_new_connection(pool);
@@ -743,5 +744,10 @@ void config_postprocess(void)
 			db->pool_size = cf_default_pool_size;
 		if (db->res_pool_size < 0)
 			db->res_pool_size = cf_res_pool_size;
+		if (db->forced_user != NULL) {
+			// Initialize pool object for each database that has a forced user.
+			// Only creates data structures. Does not create connections.
+			get_pool(db, db->forced_user);
+		}
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,7 @@ char *cf_auth_query;
 int cf_max_client_conn;
 int cf_default_pool_size;
 int cf_min_pool_size;
+int cf_min_pool_size_requires_clients;
 int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
@@ -227,6 +228,7 @@ CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
 CF_ABS("max_client_conn", CF_INT, cf_max_client_conn, 0, "100"),
 CF_ABS("default_pool_size", CF_INT, cf_default_pool_size, 0, "20"),
 CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
+CF_ABS("min_pool_size_requires_clients", CF_INT, cf_min_pool_size_requires_clients, 0, "1"),
 CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -368,6 +368,8 @@ PgDatabase *register_auto_database(const char *name)
 			db->pool_size = cf_default_pool_size;
 		if (db->res_pool_size < 0)
 			db->res_pool_size = cf_res_pool_size;
+		if (db->forced_user != NULL)
+			get_pool(db, db->forced_user);
 	}
 
 	return db;


### PR DESCRIPTION
The default behaviour of PGBouncer requires that clients be connected
to a pool before it is initialized. There is no way to toggle this
behaviour to ensure that a pool is initialized immediately by PGBouncer.

This means that 'min_pool_size' will only be respected if clients are
connected. If all clients disconnect, then the pool can drop below the
'min_pool_size' setting to 0 ('server_lifetime' will eventually close
all connections). This can cause performance problems when a client
finally reconnects since all of the pool connections have to be
recreated.

By adding an explicit 'min_pool_size_requires_clients' setting that
defaults to 1 (original PGBouncer behaviour) users can decide on what
behaviour they prefer. If set to 0, PGBouncer will always maintain
the 'min_pool_size'.

Issue #426 