### PR TITLE
test: shorten lifetime of certificates to avoid overflowing 32bit time_t

### DIFF
--- a/test/ssl/newsite.sh
+++ b/test/ssl/newsite.sh
@@ -12,7 +12,7 @@ test -f "$1/ca.key" || {
   exit 1
 }
 
-days=10240
+days=1024
 
 . ./lib.sh
 


### PR DESCRIPTION
If the test certs expire later than 2038, the conversion to time_t
overflows on 32bit and we get spurious handshake failures.

Fixes: #434