### PR TITLE
Add Kerberos token based GSSAPI authentication

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Hiroshi Saito
 Hubert Depesz Lubaczewski
 Jacob Coby
 James Pye
+Joakim Ekblad
 Jørgen Austvik
 Lou Picciano
 Magne Mæhre
@@ -49,4 +50,5 @@ Rich Schaaf
 Robert Gogolok
 Sam McLeod
 Teodor Sigaev
+Vricon Systems AB
 William Grant

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PgBouncer depends on few things to get compiled:
 * [OpenSSL] 1.0.1+ for TLS support
 * (optional) [c-ares] as alternative to Libevent's evdns
 * (optional) PAM libraries
+* (optional) GSSAPI libraries
 
 [GNU Make]: https://www.gnu.org/software/make/
 [Libevent]: http://libevent.org/
@@ -73,6 +74,26 @@ PAM authentication
 To enable PAM authentication, `./configure` has a flag `--with-pam`
 (default value is no).  When compiled with PAM support, a new global
 authentication type `pam` is available to validate users through PAM.
+
+GSSAPI authentication
+---------------------
+
+To enable GSSAPI authentication, `./configure` has a flag `--with-gss`
+(default value is no).  When compiled with GSSAPI support a new global
+authentication type 'gss' is available to validate users through GSSAPI
+and Kerberos. This require a correctly configured Kerberized environment.
+
+To enable GSSAPI in run-time the `auth_type` should be set to `gss` and
+the `krb_server_keyfile` should be assigned the full path to the service
+keytab (usually the 'postgres' service). It can be accessed using
+PGBouncer directly, given that the process user has read access to that
+file, or if GSSProxy is configured properly it should be able to protect
+against privilege escalation.
+
+This authentication does not delegate the user identity to PostgreSQL, but
+if the connections between PGBouncer and PostgreSQL are set-up in safe
+enough way a trust relationship could enable an end-to-end user identity
+propagation.
 
 Building from Git
 -----------------

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,22 @@ AC_ARG_WITH(pam,
     fi
   ], [])
 
+dnl Check for GSSAPI authentication support
+gss_support=no
+AC_ARG_WITH(gss,
+  AC_HELP_STRING([--with-gss], [build with GSSAPI support]),
+  [ GSS=
+    if test "$withval" != no; then
+      # Look for GSSAPI header and lib
+      AC_CHECK_HEADERS(gssapi.h, [have_gss_header=y])
+      AC_SEARCH_LIBS(gss_accept_sec_context, [gssapi_krb5 gssapi], [have_libgss=t])
+      if test x"${have_gss_header}" != x -a x"${have_libgss}" != x; then
+        gss_support=yes
+        AC_DEFINE(HAVE_GSS, 1, [GSSAPI support])
+      fi
+    fi
+  ], [])
+
 ##
 ## DNS backend
 ##
@@ -212,5 +228,6 @@ else
   echo "  adns = compat"
 fi
 echo "  pam  = $pam_support"
+echo "  gss  = $gss_support"
 echo "  tls  = $tls_support"
 echo ""

--- a/doc/config.md
+++ b/doc/config.md
@@ -61,6 +61,12 @@ Group name to use for Unix socket.
 
 Default: not set
 
+### krb_server_keyfile
+
+Path to the Kerberos service keytab.
+
+Default: /etc/krb5.keytab
+
 ### user
 
 If set, specifies the Unix user to change to after startup. Works only if
@@ -113,6 +119,12 @@ scram-sha-256
     can only be used for verifying the password of a client but not
     for logging into a server.  To be able to use SCRAM on server
     connections, use plain-text passwords.
+
+gss
+:   Use GSSAPI to authenticate. `auth_file` has to contain usnernames, but
+    can have empty passwords. Note that GSSAPI can only be used for
+    authenticating users, and will not be forwared to authenticate users in
+    PostgreSQL.
 
 plain
 :   The clear-text password is sent over the wire.  Deprecated.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -111,12 +111,14 @@ listen_port = 6432
 ;;; Authentication settings
 ;;;
 
-;; any, trust, plain, md5, cert, hba, pam
+;; any, trust, plain, md5, cert, hba, gss, pam
 auth_type = trust
 auth_file = /etc/pgbouncer/userlist.txt
 
 ;; Path to HBA-style auth config
 ;auth_hba_file =
+
+;krb_server_keyfile =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/src/hba.c
+++ b/src/hba.c
@@ -590,6 +590,10 @@ static bool parse_line(struct HBA *hba, struct TokParser *tp, int linenr, const 
 		rule->rule_method = AUTH_CERT;
 	} else if (eat_kw(tp, "scram-sha-256")) {
 		rule->rule_method = AUTH_SCRAM_SHA_256;
+#ifdef HAVE_GSS
+        } else if (eat_kw(tp, "gss")) {
+                rule->rule_method = AUTH_GSS;
+#endif
 	} else {
 		log_warning("hba line %d: unsupported method: buf=%s", linenr, tp->buf);
 		goto failed;

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
  *
- * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÃœ
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -93,6 +93,7 @@ char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_user;
 char *cf_auth_query;
+char *cf_krb_server_keyfile;
 
 int cf_max_client_conn;
 int cf_default_pool_size;
@@ -181,6 +182,9 @@ static const struct CfLookup auth_type_map[] = {
 	{ "pam", AUTH_PAM },
 #endif
 	{ "scram-sha-256", AUTH_SCRAM_SHA_256 },
+#ifdef HAVE_GSS
+        { "gss", AUTH_GSS },
+#endif
 	{ NULL }
 };
 
@@ -221,6 +225,9 @@ CF_ABS("unix_socket_group", CF_STR, cf_unix_socket_group, CF_NO_RELOAD, ""),
 CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
+#ifdef HAVE_GSS
+CF_ABS("krb_server_keyfile", CF_STR, cf_krb_server_keyfile, 0, "/etc/krb5.keytab"),
+#endif
 CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
 CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1,7 +1,7 @@
 /*
  * PgBouncer - Lightweight connection pooler for PostgreSQL.
  *
- * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÃœ
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -895,6 +895,16 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 	char buf[128];
 	va_list ap;
 	usec_t now = get_cached_time();
+#ifdef HAVE_GSS
+        OM_uint32 min_stat;
+        /* Server credentials (keytab context) might be better to store once globally
+         * but this encapsulation feels safer, currently */
+        if ((GSS_C_NO_CREDENTIAL != client->gss.server_credentials) &&
+            (client->client_auth_type == AUTH_GSS)) {
+                slog_debug(client, "Cleaning up GSSAPI server credentials");
+                gss_release_cred(&min_stat, &client->gss.server_credentials);
+        }
+#endif
 
 	va_start(ap, reason);
 	vsnprintf(buf, sizeof(buf), reason, ap);


### PR DESCRIPTION
This feature does only allow for clients to connect to PGBouncer and
authenticate using GSSAPI. The token is not forwarded to authenticate
the user in PostgreSQL.

GSSAPI authentication was implemented on behalf of Vricon Systems AB.

This is one solution for issue #318