### PR TITLE
Set USER if unset

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # System configuration checks
-if ! grep -q "^\"${USER}\"" userlist.txt; then
+if ! grep -q "^\"${USER:=$(id -un)}\"" userlist.txt; then
 	cp userlist.txt userlist.txt.bak
 	echo "\"${USER}\" \"01234\"" >> userlist.txt
 fi


### PR DESCRIPTION
Some CI environments run without $USER set. Fix by defaulting to `id -un`.
(Seen on salsa.debian.org.)