### PR TITLE
add server_shuffle_hosts

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -243,6 +243,14 @@ achieving uniform load.
 
 Default: 0
 
+### server_shuffle_hosts
+
+This feature shuffles the host list returned from DNS. If DNS load balancing or
+round robin DNS is not used, this setting can provide a simple way to distribute
+connections across PostgreSQL servers.
+
+Default: 0
+
 ### ignore_startup_parameters
 
 By default, PgBouncer allows only parameters it can keep track of in startup

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -202,6 +202,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; If off, then server connections are reused in LIFO manner
 ;server_round_robin = 0
 
+; Whether to shuffle the host list returned from DNS.
+;server_shuffle_hosts = 0
+
 ;;;
 ;;; Logging
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -460,6 +460,7 @@ extern usec_t cf_client_idle_timeout;
 extern usec_t cf_client_login_timeout;
 extern usec_t cf_idle_transaction_timeout;
 extern int cf_server_round_robin;
+extern int cf_server_shuffle_hosts;
 extern int cf_disable_pqexec;
 extern usec_t cf_dns_max_ttl;
 extern usec_t cf_dns_nxdomain_ttl;

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -1387,8 +1387,6 @@ static void check_req_result_changes(struct DNSRequest *req)
 }
 
 /* shuffle the order of the addrinfo linked list */
-/* RFC 3493: The freeaddrinfo() function must support the freeing of arbitrary
-   sublists of an addrinfo list originally returned by getaddrinfo(). */
 static struct addrinfo * shuffle_addrinfo(struct addrinfo *ai)
 {
 	int i, j, n;
@@ -1440,7 +1438,7 @@ static void got_result_gai(int result, struct addrinfo *res, void *arg)
 
 	if (result == 0 && res) {
 		if (cf_server_shuffle_hosts) {
-			log_info("DNS: %s shuffled addrinfo", req->name);
+			log_noise("DNS: shuffled addrinfo: %s", req->name);
 			res = shuffle_addrinfo(res);
 		}
 		req->result = res;

--- a/src/main.c
+++ b/src/main.c
@@ -108,6 +108,7 @@ char *cf_server_check_query;
 usec_t cf_server_check_delay;
 int cf_server_fast_close;
 int cf_server_round_robin;
+int cf_server_shuffle_hosts;
 int cf_disable_pqexec;
 usec_t cf_dns_max_ttl;
 usec_t cf_dns_nxdomain_ttl;
@@ -255,6 +256,7 @@ CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
 CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
 CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 CF_ABS("server_round_robin", CF_INT, cf_server_round_robin, 0, "0"),
+CF_ABS("server_shuffle_hosts", CF_INT, cf_server_shuffle_hosts, 0, "0"),
 CF_ABS("suspend_timeout", CF_TIME_USEC, cf_suspend_timeout, 0, "10"),
 CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),


### PR DESCRIPTION
This feature shuffles the host list returned from DNS, providing a simple way to balance connections to postgres servers.

This feature was motivated by a DNS server that always returns results in the same order, resulting in one postgres server overloaded and others not being used. This shuffling feature might be useful if the DNS server does not support or is not configured to do round robin, or in lieu of a load balancer.

It may be useful to combine with server_round_robin, which cycles clients through all postgres server connections. Also server_lifetime might be reduced from its default of 3600 (1 hour) to 600 (10 minutes) to more quickly adjust to infrastructure changes.

The implementation shuffles the order of the linked list of addrinfo returned by getaddrinfo. We think that reordering the linked list is a safe operation based on RFC 3493: "The freeaddrinfo() function must support the freeing of arbitrary sublists of an addrinfo list originally returned by getaddrinfo()." We also reviewed several implementations of freeaddrinfo and all we examined traverse the linked list and free memory for each addrinfo independently.
