### PR TITLE
Fix typo in handle_sigusr2()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -473,7 +473,7 @@ static void handle_sigusr2(int sock, short flags, void *arg)
 		cf_pause_mode = P_NONE;
 		break;
 	case P_NONE:
-		log_info("got SIGUSR1, but not paused/suspended");
+		log_info("got SIGUSR2, but not paused/suspended");
 	}
 
 	/* avoid surprise later if cf_shutdown stays set */


### PR DESCRIPTION
This fixes a simple typo in the log output where it says SIGUSR1 instead of SIGUSR2.