### PR TITLE
applicationname_add_host options for set application name

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -280,7 +280,7 @@ Default: 0
 
 ### application_name_add_host
 
-Add the client hostname or host address and port to the application name setting set on connection start.
+Add pgbouncer server hostname or client host address and port to the application name setting set on connection start.
 This helps in identifying the source of bad queries etc.  This logic applies
 only on start of connection.  If `application_name` is later changed with SET,
 PgBouncer does not change it again.
@@ -289,7 +289,7 @@ address
 :   Add client host address and port to the application name setting.
 
 hostname
-:   Add hostname to the application name setting. gethostname() is called once at the start.
+:   Add pgbouncer server hostname to the application name setting. gethostname() is called once at the start.
 
 both
 :   Add both options. Example: `appname - ip:port [hostname]`

--- a/doc/config.md
+++ b/doc/config.md
@@ -280,12 +280,22 @@ Default: 0
 
 ### application_name_add_host
 
-Add the client host address and port to the application name setting set on connection start.
+Add the client hostname or host address and port to the application name setting set on connection start.
 This helps in identifying the source of bad queries etc.  This logic applies
 only on start of connection.  If `application_name` is later changed with SET,
 PgBouncer does not change it again.
 
-Default: 0
+address
+:   Add client host address and port to the application name setting.
+
+hostname
+:   Add hostname to the application name setting. gethostname() is called once at the start.
+
+both
+:   Add both options. Example: `appname - ip:port [hostname]`
+
+none
+:   Install the client application name without any changes. Default.
 
 ### conffile
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -167,7 +167,8 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;server_fast_close = 0
 
 ;; Use <appname - host> as application_name on server.
-;application_name_add_host = 0
+;; address, hostname, both, none
+;application_name_add_host = none
 
 ;; Period for updating aggregated stats.
 ;stats_period = 60

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -164,6 +164,11 @@ extern int cf_sbuf_len;
 #define POOL_STMT	2
 #define POOL_INHERIT	3
 
+#define APPHOST_NONE	0
+#define APPHOST_ADDRESS	1
+#define APPHOST_HOSTNAME	2
+#define APPHOST_BOTH	3
+
 #define BACKENDKEY_LEN	8
 
 /* buffer size for startup noise */
@@ -204,6 +209,7 @@ bool pga_pton(PgAddr *a, const char *s, int port);
 const char *pga_ntop(const PgAddr *a, char *dst, int dstlen);
 const char *pga_str(const PgAddr *a, char *dst, int dstlen);
 const char *pga_details(const PgAddr *a, char *dst, int dstlen);
+const char *cached_hostname(void);
 int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
 
 /*

--- a/src/client.c
+++ b/src/client.c
@@ -439,14 +439,25 @@ static void set_appname(PgSocket *client, const char *app_name)
 	char buf[400], abuf[300];
 	const char *details;
 
-	if (cf_application_name_add_host) {
+	if (cf_application_name_add_host != APPHOST_NONE) {
 		/* give app a name */
 		if (!app_name)
 			app_name = "app";
 
 		/* add details */
-		details = pga_details(&client->remote_addr, abuf, sizeof(abuf));
-		snprintf(buf, sizeof(buf), "%s - %s", app_name, details);
+		switch (cf_application_name_add_host) {
+		case APPHOST_HOSTNAME:
+			snprintf(buf, sizeof(buf), "%s [%s]", app_name, cached_hostname());
+			break;
+		case APPHOST_ADDRESS:
+			details = pga_details(&client->remote_addr, abuf, sizeof(abuf));
+			snprintf(buf, sizeof(buf), "%s - %s", app_name, details);
+			break;
+		case APPHOST_BOTH:
+			details = pga_details(&client->remote_addr, abuf, sizeof(abuf));
+			snprintf(buf, sizeof(buf), "%s - %s [%s]", app_name, details, cached_hostname());
+			break;
+		}
 		app_name = buf;
 	}
 	if (app_name) {

--- a/src/main.c
+++ b/src/main.c
@@ -151,7 +151,7 @@ int cf_log_stats;
 int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
-int cf_application_name_add_host;
+int cf_application_name_add_host = APPHOST_NONE;
 
 int cf_client_tls_sslmode;
 char *cf_client_tls_protocols;
@@ -204,6 +204,14 @@ const struct CfLookup sslmode_map[] = {
 	{ "require", SSLMODE_REQUIRE },
 	{ "verify-ca", SSLMODE_VERIFY_CA },
 	{ "verify-full", SSLMODE_VERIFY_FULL },
+	{ NULL }
+};
+
+const struct CfLookup application_name_add_host_map[] = {
+	{ "none", APPHOST_NONE },
+	{ "address", APPHOST_ADDRESS },
+	{ "hostname", APPHOST_HOSTNAME },
+	{ "both", APPHOST_BOTH },
 	{ NULL }
 };
 
@@ -286,7 +294,7 @@ CF_ABS("log_stats", CF_INT, cf_log_stats, 0, "1"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
-CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
+CF_ABS("application_name_add_host", CF_LOOKUP(application_name_add_host_map), cf_application_name_add_host, 0, "none"),
 
 CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, CF_NO_RELOAD, "disable"),
 CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, CF_NO_RELOAD, ""),

--- a/src/util.c
+++ b/src/util.c
@@ -420,7 +420,7 @@ const char *pga_str(const PgAddr *a, char *dst, int dstlen)
 	return dst;
 }
 
-static const char *cached_hostname(void)
+const char *cached_hostname(void)
 {
 	static char cache[256];
 	int err;


### PR DESCRIPTION
Add an address or hostname to the application name. This is useful when using a connection to a bouncer on a localhost or a scheme with several pgbouncer.