### PR TITLE
Log when fails loading the hba file

### DIFF
--- a/src/hba.c
+++ b/src/hba.c
@@ -626,8 +626,10 @@ struct HBA *hba_load_rules(const char *fn)
 	list_init(&hba->rules);
 
 	f = fopen(fn, "r");
-	if (!f)
+	if (!f) {
+		log_error("could not open hba config file %s: %s", fn, strerror(errno));
 		goto out;
+	}
 
 	for (linenr = 1; ; linenr++) {
 		len = getline(&ln, &lnbuf, f);


### PR DESCRIPTION
If fails to load the HBA fails logs the error explicitly 