### PR TITLE
Fix application_name_add_host to handle SET application_name

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -19,3 +19,5 @@
 bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
 bool set_pool(PgSocket *client, const char *dbname, const char *username, const char *password, bool takeover) _MUSTCHECK;
 bool handle_auth_query_response(PgSocket *client, PktHdr *pkt);
+void set_appname(PgSocket *client, const char *app_name);
+

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -19,3 +19,4 @@ void varcache_fill_unset(VarCache *src, PgSocket *dst);
 void varcache_clean(VarCache *cache);
 void varcache_add_params(PktBuf *pkt, VarCache *vars);
 void varcache_deinit(void);
+const char *varcache_get(VarCache *cache, const char *lk);

--- a/src/server.c
+++ b/src/server.c
@@ -44,7 +44,11 @@ static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
 
 	if (client) {
 		slog_debug(client, "setting client var: %s='%s'", key, val);
-		varcache_set(&client->vars, key, val);
+		if (cf_application_name_add_host && (strcmp(key, "application_name") == 0)) {
+			set_appname(client, val);
+		} else {
+			varcache_set(&client->vars, key, val);
+		}
 	}
 
 	if (startup) {

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -45,6 +45,25 @@ static inline struct PStr *get_value(VarCache *cache, const struct var_lookup *l
 	return cache->var_list[lk->idx];
 }
 
+const char *varcache_get(VarCache *cache, const char *key)
+{
+	const struct var_lookup *lk;
+	if (!vpool) {
+		return NULL;
+	}
+
+	for (lk = lookup; lk->name; lk++) {
+		if (strcasecmp(lk->name, key) == 0) {
+			struct PStr *pstr = get_value(cache, lk);
+			if (pstr)
+				return pstr->str;
+			else
+				return NULL;
+		}
+	}
+	return NULL;
+}
+
 bool varcache_set(VarCache *cache, const char *key, const char *value)
 {
 	const struct var_lookup *lk;


### PR DESCRIPTION
The PostgreSQL protocol sends us a message when the application_name
is changed. It's thus possible to use this message to add back the
host and port information in the session.


Old behaviour (transaction pooling):
```
test=> show application_name;
   application_name    
------------------------
psql - 127.0.0.1:52396
(1 row)
test=> set application_name to 'toto';
SET
test=> show application_name;
   application_name    
------------------------
toto
(1 row)
```

New behaviour:
```
test=> show application_name;
   application_name    
------------------------
psql - 127.0.0.1:52396
(1 row)
test=> set application_name to 'toto';
SET
test=> show application_name;
   application_name    
------------------------
toto - 127.0.0.1:52396
(1 row)
```