### PR TITLE
Fix help

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -40,7 +40,7 @@ static void usage(const char *exe)
 	printf("\nOptions:\n");
 	printf("  -d, --daemon         run in background (as a daemon)\n");
 	printf("  -q, --quiet          run quietly\n");
-	printf("  -R, --restart        do an online restart\n");
+	printf("  -R, --reboot         do an online reboot\n");
 	printf("  -u, --user=USERNAME  assume identity of USERNAME\n");
 	printf("  -v, --verbose        increase verbosity\n");
 	printf("  -V, --version        show version, then exit\n");


### PR DESCRIPTION
Although help says that restart option exists, option is called reboot.
It is like this since commit 93a7546144c0f58efa7b8e25674a2cb09131cbdb.
Variables and documentation use word "reboot", let's keep the author's
original idea.