### PR TITLE
Add query_wait_timeout to user settings

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -298,6 +298,7 @@ struct PgUser {
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
+	usec_t query_wait_timeout; /* how much a user is allowed to wait for a query to be assigned to a backend */
 };
 
 /*

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -395,8 +395,7 @@ static void pool_client_maint(PgPool *pool)
 			} else if (pool->user->query_wait_timeout > 0 && age > pool->user->query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
 			}
-			else if (pool->user->query_wait_timeout <= 0 && cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
-				/* user-set query_wait_timeout overrides global query_wait_timeout */
+			else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
 			}
 		}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -394,8 +394,7 @@ static void pool_client_maint(PgPool *pool)
 				disconnect_client(client, true, "query_timeout");
 			} else if (pool->user->query_wait_timeout > 0 && age > pool->user->query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
-			}
-			else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
+			} else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
 			}
 		}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -379,7 +379,7 @@ static void pool_client_maint(PgPool *pool)
 	}
 
 	/* force timeouts for waiting queries */
-	if (cf_query_timeout > 0 || cf_query_wait_timeout > 0) {
+	if (cf_query_timeout > 0 || cf_query_wait_timeout > 0 || pool->user->query_wait_timeout > 0) {
 		statlist_for_each_safe(item, &pool->waiting_client_list, tmp) {
 			client = container_of(item, PgSocket, head);
 			Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);
@@ -392,7 +392,10 @@ static void pool_client_maint(PgPool *pool)
 
 			if (cf_query_timeout > 0 && age > cf_query_timeout) {
 				disconnect_client(client, true, "query_timeout");
-			} else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
+			} else if (pool->user->query_wait_timeout > 0 && age > pool->user->query_wait_timeout) {
+				disconnect_client(client, true, "query_wait_timeout");
+			}
+			else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
 			}
 		}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -395,7 +395,8 @@ static void pool_client_maint(PgPool *pool)
 			} else if (pool->user->query_wait_timeout > 0 && age > pool->user->query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
 			}
-			else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
+			else if (pool->user->query_wait_timeout <= 0 && cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
+				/* user-set query_wait_timeout overrides global query_wait_timeout */
 				disconnect_client(client, true, "query_wait_timeout");
 			}
 		}

--- a/src/loader.c
+++ b/src/loader.c
@@ -429,9 +429,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 			max_user_connections = atoi(val);
 		} else if (strcmp("query_wait_timeout", key) == 0) {
 			query_wait_timeout = ((usec_t)atoi(val)) * USEC; /* Connection age is in usec while setting is in sec. */
-		}
-
-		else {
+		} else {
 			log_error("skipping user %s because"
 				  " of unknown parameter in settings: %s", name, key);
 			goto fail;

--- a/src/loader.c
+++ b/src/loader.c
@@ -398,7 +398,8 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	PgUser *user;
 	struct CfValue cv;
 	int pool_mode = POOL_INHERIT;
-	int max_user_connections = -1, query_wait_timeout = -1;
+	int max_user_connections = -1;
+	usec_t query_wait_timeout = 0;
 
 
 	cv.value_p = &pool_mode;

--- a/src/loader.c
+++ b/src/loader.c
@@ -398,7 +398,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	PgUser *user;
 	struct CfValue cv;
 	int pool_mode = POOL_INHERIT;
-	int max_user_connections = -1;
+	int max_user_connections = -1, query_wait_timeout = -1;
 
 
 	cv.value_p = &pool_mode;
@@ -426,7 +426,11 @@ bool parse_user(void *base, const char *name, const char *connstr)
 			}
 		} else if (strcmp("max_user_connections", key) == 0) {
 			max_user_connections = atoi(val);
-		} else {
+		} else if (strcmp("query_wait_timeout", key) == 0) {
+			query_wait_timeout = ((usec_t)atoi(val)) * USEC; /* Connection age is in usec while setting is in sec. */
+		}
+
+		else {
 			log_error("skipping user %s because"
 				  " of unknown parameter in settings: %s", name, key);
 			goto fail;
@@ -444,6 +448,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user->pool_mode = pool_mode;
 	user->max_user_connections = max_user_connections;
+	user->query_wait_timeout = query_wait_timeout;
 
 fail:
 	free(tmp_connstr);


### PR DESCRIPTION
### Change
Add `query_wait_timeout` to user settings.

### Why
Given two (2) or more read replicas, we want to force the client to failover to a different replica if the replica it's currently trying to use is unresponsive.

This is added because PostgreSQL protocol does not support read timeouts: the client will wait forever until the server answers or TCP keep-alive will break the connection.

Why not use the global `query_wait_timeout` setting? We have two different kind of users, foreground traffic user and background traffic user. The foreground traffic user needs to failover as quickly as is reasonable/possible. The background user can and should wait until replica recovers. The background user tends to run heavier queries as well, so we don't want to move all that expensive traffic to a different read replica: we are prioritizing the foreground traffic.

Why not implement `query_timeout` as well/instead? The assumption is if we can assign a query to a server, the server is healthy and will eventually return a result.

### Tests
Will write tests if proposed change is acceptable.