### PR TITLE
Add unhealthy database client debouncer

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -250,6 +250,14 @@ pool.
 
 Default: 0 (unlimited)
 
+### unhealthy_login_count
+
+How many bad logins have to take place before a database is considered unhealthy.
+New logins will be disallowed for `unhealthy_login_count_timeout` seconds. When the
+timeout happens, the counter is reset back to 0.
+
+Default: 5
+
 ### server_round_robin
 
 By default, PgBouncer reuses server connections in LIFO (last-in, first-out) manner,
@@ -727,6 +735,13 @@ How many seconds to wait for buffer flush during SUSPEND or reboot (-R).
 A connection is dropped if the flush does not succeed.
 
 Default: 10
+
+### unhealthy_login_count_timeout
+
+How many seconds to wait before allowing new client logins after a database
+has been decided to be unhealthy.
+
+Default: 5
 
 
 ## Low-level network settings

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -203,6 +203,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; If off, then server connections are reused in LIFO manner
 ;server_round_robin = 0
 
+;; Dangerous. If the database seems unhealthy, prevent new logins after this many
+;; login attempts for a period of time.
+;unhealthy_login_count = 0
+
 ;;;
 ;;; Logging
 ;;;
@@ -275,6 +279,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; How long SUSPEND/-R waits for buffer flush before closing
 ;; connection.
 ;suspend_timeout = 10
+
+;; Dangerous. Reset the unhealthy login count for a database after this many seconds.
+;unhealthy_login_count_timeout = 5
 
 ;;;
 ;;; Low-level tuning options

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -338,6 +338,9 @@ struct PgDatabase {
 	int connection_count;	/* total connections for this database in all pools */
 
 	struct AATree user_tree;	/* users that have been queried on this database */
+
+	int unhealthy_login_count; /* The number of unhealthy logins */
+	usec_t first_unhealthy_login; /* The first time this happened */
 };
 
 
@@ -522,6 +525,10 @@ extern char *cf_server_tls_ca_file;
 extern char *cf_server_tls_cert_file;
 extern char *cf_server_tls_key_file;
 extern char *cf_server_tls_ciphers;
+
+
+extern int cf_unhealthy_login_count;
+extern usec_t cf_unhealthy_login_count_timeout;
 
 extern const struct CfLookup pool_mode_map[];
 

--- a/src/client.c
+++ b/src/client.c
@@ -268,6 +268,20 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		return false;
 	}
 
+	/* debounce clients while database recovers from a problem, if enabled */
+	if (cf_unhealthy_login_count > 0) {
+		if (client->db->unhealthy_login_count >= cf_unhealthy_login_count) {
+			/* unhealthy timeout expired, reset the counter and allow loing */
+			if (get_cached_time() - client->db->first_unhealthy_login >= cf_unhealthy_login_count_timeout) {
+				client->db->first_unhealthy_login = 0;
+				client->db->unhealthy_login_count = 0;
+			} else {
+				disconnect_client(client, true, "try again later, database unhealthy: %s", dbname);
+				return false;
+			}
+		}
+	}
+
 	if (client->db->admin) {
 		if (admin_pre_login(client, username))
 			return finish_set_pool(client, takeover);

--- a/src/client.c
+++ b/src/client.c
@@ -271,7 +271,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	/* debounce clients while database recovers from a problem, if enabled */
 	if (cf_unhealthy_login_count > 0) {
 		if (client->db->unhealthy_login_count >= cf_unhealthy_login_count) {
-			/* unhealthy timeout expired, reset the counter and allow loing */
+			/* unhealthy timeout expired, reset the counter and allow login */
 			if (get_cached_time() - client->db->first_unhealthy_login >= cf_unhealthy_login_count_timeout) {
 				client->db->first_unhealthy_login = 0;
 				client->db->unhealthy_login_count = 0;

--- a/src/loader.c
+++ b/src/loader.c
@@ -289,6 +289,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	/* assuming not an autodb */
 	db->db_auto = 0;
 	db->inactive_time = 0;
+	db->unhealthy_login_count = 0;
+	db->first_unhealthy_login = 0;
 
 	/* if updating old db, check if anything changed */
 	if (db->dbname) {

--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,7 @@ int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
 int cf_max_user_connections;
+int cf_unhealthy_login_count;
 
 char *cf_server_reset_query;
 int cf_server_reset_query_always;
@@ -137,6 +138,7 @@ usec_t cf_client_idle_timeout;
 usec_t cf_client_login_timeout;
 usec_t cf_idle_transaction_timeout;
 usec_t cf_suspend_timeout;
+usec_t cf_unhealthy_login_count_timeout;
 
 usec_t g_suspend_start;
 
@@ -268,6 +270,9 @@ CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
 CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
 CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
+
+CF_ABS("unhealthy_login_count", CF_INT, cf_unhealthy_login_count, 0, "0"),
+CF_ABS("unhealthy_login_count_timeout", CF_TIME_USEC, cf_unhealthy_login_count_timeout, 0, "5"),
 
 CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),
 CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -917,9 +917,11 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 			} else {
 				server->link = NULL;
 				client->link = NULL;
-				client->pool->db->unhealthy_login_count++; /* if too many of these, we'll disallow client connections for a while */
-				if (!client->pool->db->first_unhealthy_login) {
-					client->pool->db->first_unhealthy_login = get_cached_time();
+				if (cf_unhealthy_login_count > 0) {
+					client->pool->db->unhealthy_login_count++; /* if too many of these, we'll disallow client connections for a while */
+					if (!client->pool->db->first_unhealthy_login) {
+						client->pool->db->first_unhealthy_login = get_cached_time();
+					}
 				}
 				disconnect_server(server, true, "unclean server");
 			}

--- a/src/objects.c
+++ b/src/objects.c
@@ -917,6 +917,10 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 			} else {
 				server->link = NULL;
 				client->link = NULL;
+				client->pool->db->unhealthy_login_count++; /* if too many of these, we'll disallow client connections for a while */
+				if (!client->pool->db->first_unhealthy_login) {
+					client->pool->db->first_unhealthy_login = get_cached_time();
+				}
 				disconnect_server(server, true, "unclean server");
 			}
 		}


### PR DESCRIPTION
### Problem
Database becomes unhealthy because of storage latency problems (or other problem). Clients connect, attempt to login but fail because the database can't process the login; Pgbouncer disconnects the client and closes the server connection because it's in an unclean state. Clients reconnect and the situation repeats. This leads to connection thrashing and prolongs the database recovery time by adding load to the database server.

### Solution
Debounce client logins for a period of time to allow the database time to recover from a bad state.

Two configs are added:
- `unhealthy_login_count`: how many failed logins before Pgbouncer considers the database unhealthy and disconnects all new clients; default 5 logins.
- `unhealthy_login_count_timeout`: how many seconds before Pgbouncer resets the above counter and allows new client logins; default 5 seconds.

### Why
We've experienced several failures while running our databases on a certain Cloud relational database provider and we noticed that, when running many thousands of clients and several thousand of requests per second, clients will thrash server connections if their login attempts fail. We believe this thrashing led to CPU spikes and prolonged database recovery time.