### PR TITLE
Add support for prepared statements to "transaction" mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ pgbouncer_SOURCES = \
 	src/pktbuf.c \
 	src/pooler.c \
 	src/proto.c \
+	src/ps.c \
 	src/sbuf.c \
 	src/scram.c \
 	src/server.c \
@@ -42,6 +43,7 @@ pgbouncer_SOURCES = \
 	include/pktbuf.h \
 	include/pooler.h \
 	include/proto.h \
+	include/ps.h \
 	include/sbuf.h \
 	include/scram.h \
 	include/server.h \

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module pgbouncer
+
+go 1.13
+
+require github.com/lib/pq v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -123,6 +123,7 @@ extern int cf_sbuf_len;
 #include "janitor.h"
 #include "hba.h"
 #include "pam.h"
+#include "ps.h"
 
 #ifndef WIN32
 #define DEFAULT_UNIX_SOCKET_DIR "/tmp"
@@ -397,6 +398,8 @@ struct PgSocket {
 	bool wait_for_response:1;/* console client: waits for completion of PAUSE/SUSPEND cmd */
 
 	bool wait_sslchar:1;	/* server: waiting for ssl response: S/N */
+	
+	int ps_anon_active:1;	/* client: state of anonymous prepared statement */
 
 	int expect_rfq_count;	/* client: count of ReadyForQuery packets client should see */
 
@@ -434,6 +437,9 @@ struct PgSocket {
 	VarCache vars;		/* state of interesting server parameters */
 
 	SBuf sbuf;		/* stream buffer, must be last */
+
+	/* struct HashTab *prepared_statements; */ /* named prepared statements (maintained on client connection) */
+	struct PSList prepared_statements; /* named prepared statements (maintained on client connection) */
 };
 
 #define RAW_IOBUF_SIZE	offsetof(IOBuf, buf)
@@ -468,6 +474,7 @@ extern int cf_res_pool_size;
 extern usec_t cf_res_pool_timeout;
 extern int cf_max_db_connections;
 extern int cf_max_user_connections;
+extern int cf_prepared_statement_lock;
 
 extern char * cf_autodb_connstr;
 extern usec_t cf_autodb_idle_timeout;
@@ -528,6 +535,8 @@ extern int cf_tcp_user_timeout;
 extern int cf_log_connections;
 extern int cf_log_disconnections;
 extern int cf_log_pooler_errors;
+extern int cf_log_event_stream;
+extern int cf_log_prepared_statements;
 extern int cf_application_name_add_host;
 
 extern int cf_client_tls_sslmode;

--- a/include/ps.h
+++ b/include/ps.h
@@ -1,0 +1,28 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+struct PSList {
+	char** elem;
+	unsigned len;
+	unsigned cap;
+};
+
+void ps_register(PgSocket *client, const char* ps);
+void ps_unregister(PgSocket *client, const char* ps);
+unsigned ps_size(PgSocket *client);
+void ps_free(PgSocket *client);

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -4,7 +4,8 @@ enum VarCacheIdx {
 	VTimeZone,
 	VStdStr,
 	VAppName,
-	NumVars
+	VExtraFloatDigits,
+	NumVars,
 };
 
 typedef struct VarCache VarCache;

--- a/src/main.c
+++ b/src/main.c
@@ -108,6 +108,7 @@ int cf_res_pool_size;
 usec_t cf_res_pool_timeout;
 int cf_max_db_connections;
 int cf_max_user_connections;
+int cf_prepared_statement_lock;
 
 char *cf_server_reset_query;
 int cf_server_reset_query_always;
@@ -152,6 +153,8 @@ int cf_log_stats;
 int cf_log_connections;
 int cf_log_disconnections;
 int cf_log_pooler_errors;
+int cf_log_event_stream;
+int cf_log_prepared_statements;
 int cf_application_name_add_host;
 
 int cf_client_tls_sslmode;
@@ -238,6 +241,7 @@ CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),
 CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
+CF_ABS("prepared_statement_lock", CF_INT, cf_prepared_statement_lock, 0, "0"),
 CF_ABS("syslog", CF_INT, cf_syslog, 0, "0"),
 CF_ABS("syslog_facility", CF_STR, cf_syslog_facility, 0, "daemon"),
 CF_ABS("syslog_ident", CF_STR, cf_syslog_ident, 0, "pgbouncer"),
@@ -288,6 +292,8 @@ CF_ABS("log_stats", CF_INT, cf_log_stats, 0, "1"),
 CF_ABS("log_connections", CF_INT, cf_log_connections, 0, "1"),
 CF_ABS("log_disconnections", CF_INT, cf_log_disconnections, 0, "1"),
 CF_ABS("log_pooler_errors", CF_INT, cf_log_pooler_errors, 0, "1"),
+CF_ABS("log_event_stream", CF_INT, cf_log_event_stream, 0, "0"),
+CF_ABS("log_prepared_statements", CF_INT, cf_log_prepared_statements, 0, "0"),
 CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
 
 CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, CF_NO_RELOAD, "disable"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -179,6 +179,7 @@ void change_client_state(PgSocket *client, SocketState newstate)
 	case CL_FREE:
 		varcache_clean(&client->vars);
 		slab_free(client_cache, client);
+		ps_free(client);
 		break;
 	case CL_JUSTFREE:
 		statlist_append(&justfree_client_list, &client->head);

--- a/src/ps.c
+++ b/src/ps.c
@@ -1,0 +1,142 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "bouncer.h"
+
+static void ps_free_list(struct PSList* list) {
+	unsigned i;
+	for (i = 0; i < list->len; i++)
+		free(list->elem[i]);
+	free(list->elem);
+	list->elem = NULL;
+	list->len = 0;
+	list->cap = 0;
+}
+
+static void ps_add_to_list(struct PSList* list, const char* s) {
+	unsigned i;
+	unsigned newcap;
+	char** newelem;
+
+	for (i = 0; i < list->len; i++) {
+		if (strcmp(list->elem[i], s) == 0) {
+			/* already exists */
+			return; 
+		}
+	}
+	if (i == list->cap) {
+		/* grow */
+		newcap = list->cap * 2;
+		if (newcap == 0)
+			newcap = 2;
+		newelem = realloc(list->elem, newcap * sizeof(char*));
+		/* TODO: handle realloc failure */
+		list->elem = newelem;
+		list->cap = newcap;
+	}
+
+	list->elem[i] = strdup(s);
+	/* TODO: handle strdup failure */
+	list->len++;
+}
+
+static void ps_remove_from_list(struct PSList* list, const char* s) {
+	unsigned i;
+	for (i = 0; i < list->len; i++) {
+		if (strcmp(list->elem[i], s) == 0) {
+			free(list->elem[i]);
+			memmove(&list->elem[i], &list->elem[i + 1], list->len - 1 - i);
+			list->len--;
+			return;
+		}
+	}
+}
+
+void ps_register(PgSocket *client, const char* ps) {
+	ps_add_to_list(&client->prepared_statements, ps);
+
+	if (cf_log_prepared_statements)
+		slog_debug(client, "Register prepared statement '%s' (size = %d)", ps, (int) ps_size(client));
+}
+
+void ps_unregister(PgSocket *client, const char* ps) {
+	ps_remove_from_list(&client->prepared_statements, ps);
+
+	if (cf_log_prepared_statements)
+		slog_debug(client, "Unregister prepared statement '%s' (size = %d)", ps, (int) ps_size(client));
+}
+
+unsigned ps_size(PgSocket *client) {
+	return client->prepared_statements.len;
+}
+
+void ps_free(PgSocket *client) {
+	ps_free_list(&client->prepared_statements);
+}
+
+/*
+#define HTAB_KEY_T unsigned
+#define HTAB_VAL_T char *
+#include <usual/hashtab-impl.h>
+#include <usual/hashing/xxhash.h>
+
+static bool hash_str_eq(const htab_val_t curval, const void *arg) {
+	const char* s1 = curval;
+	const char* s2 = arg;
+	return strcmp(s1, s2) == 0;
+}
+
+static htab_key_t hash_str(const char* s) {
+	return xxhash(s, strlen(s), 0);
+}
+
+static void ps_unregister_string(PgSocket *client, const char* ps) {
+	if (!client->prepared_statements)
+		return;
+
+	hashtab_delete(client->prepared_statements, hash_str(ps), ps);
+}
+
+static void ps_register(PgSocket *client, const char* ps) {
+	if (!client->prepared_statements)
+		client->prepared_statements = hashtab_create(32, hash_str_eq, NULL);
+
+	hashtab_lookup(client->prepared_statements, hash_str(ps), true, ps);
+}
+
+void ps_register(PgSocket *client, PktHdr *pkt) {
+	if (!client->prepared_statements) {
+		client->prepared_statements = hashtab_create(32, hash_str_eq, NULL);
+	}
+}
+
+void ps_unregister(PgSocket *client, PktHdr *pkt) {
+	if (!client->prepared_statements)
+		return;
+
+	hashtab_delete(client->prepared_statements, hash_str())
+}
+
+void ps_free(PgSocket *client) {
+	if (client->prepared_statements) {
+		hashtab_destroy(client->prepared_statements);
+		client->prepared_statements = NULL;
+	}
+}
+
+*/

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -35,6 +35,7 @@ static const struct var_lookup lookup [] = {
  {"TimeZone",                    VTimeZone },
  {"standard_conforming_strings", VStdStr },
  {"application_name",            VAppName },
+ {"extra_float_digits",          VExtraFloatDigits },
  {NULL},
 };
 

--- a/test/ps/README.md
+++ b/test/ps/README.md
@@ -1,0 +1,12 @@
+# Prepared Statement tests
+
+This directory contains specialized tests for the `prepared_statement_lock` configuration option.
+
+## How to run the Go tests
+
+Install Go (version 1.13 or later)
+
+1. `cd pgbouncer`
+3. `test/ps/run-docker-testdb.sh` (in it's own console)
+4. `make -j && ./pgbouncer test/ps/test.ini` (in it's own console)
+5. `go run test/ps/test.go`

--- a/test/ps/run-docker-testdb.sh
+++ b/test/ps/run-docker-testdb.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=kama postgres:12

--- a/test/ps/test.go
+++ b/test/ps/test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// Test Prepared Statements from lib/pq
+
+func check(e error) {
+	if e != nil {
+		msg := fmt.Sprintf("Error: %v", e)
+		panic(msg)
+	}
+}
+
+func assertEqInt(actual, expected int) {
+	if actual != expected {
+		panic(fmt.Sprintf("(actual) %v != %v (expected)", actual, expected))
+	}
+}
+
+func assertEqString(actual, expected string) {
+	if actual != expected {
+		panic(fmt.Sprintf("(actual) %v != %v (expected)", actual, expected))
+	}
+}
+
+func checkExec(db *sql.DB, sql string, args ...interface{}) {
+	_, err := db.Exec(sql, args...)
+	check(err)
+}
+
+func setupDB(db *sql.DB) {
+	// Create two tables with different column orders (and diferent column types), so that
+	// if our prepared statements get swapped around, we'll detect it.
+	checkExec(db, "CREATE TABLE IF NOT EXISTS autotx_a (iv INT, tv TEXT)")
+	checkExec(db, "CREATE TABLE IF NOT EXISTS autotx_b (tv TEXT, iv INT)")
+	checkExec(db, "TRUNCATE autotx_a")
+	checkExec(db, "TRUNCATE autotx_b")
+	checkExec(db, "INSERT INTO autotx_a (iv, tv) VALUES ($1,$2)", 2, "two")
+	checkExec(db, "INSERT INTO autotx_a (iv, tv) VALUES ($1,$2)", 4, "four")
+	checkExec(db, "INSERT INTO autotx_b (tv, iv) VALUES ($1,$2)", "seven", 7)
+	checkExec(db, "INSERT INTO autotx_b (tv, iv) VALUES ($1,$2)", "nine", 9)
+}
+
+func onceOff(db *sql.DB) {
+	iv := 0
+	param := 0
+	db.QueryRow("SELECT iv,$1 FROM autotx_a ORDER BY iv LIMIT 1", 5).Scan(&iv, &param)
+	assertEqInt(iv, 2)
+	assertEqInt(param, 5)
+}
+
+func start(testname string) {
+	fmt.Printf("*** %v ***\n", testname)
+}
+
+func testSimpleStatements(db *sql.DB) {
+	// These blocks of code are useful when doing protocol analysis (ie in combination with the pgbouncer setting log_event_stream)
+	start("Simple anonymous prepared statement executed twice")
+	onceOff(db)
+	onceOff(db)
+}
+
+func testParseFail(db *sql.DB) {
+	start("Parse fail")
+	iv := 0
+	param := 0
+	err := db.QueryRow("SELECT foo,$1 FROM notexist", 5).Scan(&iv, &param)
+	fmt.Printf("(Expected parse to fail) - failure message: %v\n", err)
+	// Verify that a subsequent query succeeds
+	onceOff(db)
+}
+
+func testSingleExplicitPS(db *sql.DB) {
+	start("Single explicit prepared statement")
+	st, err := db.Prepare("SELECT iv FROM autotx_a WHERE tv = $1")
+	check(err)
+	defer st.Close()
+	iv := 0
+	err = st.QueryRow("two").Scan(&iv)
+	check(err)
+	assertEqInt(iv, 2)
+	err = st.QueryRow("four").Scan(&iv)
+	check(err)
+	assertEqInt(iv, 4)
+}
+
+func testDualExplicitPS(db *sql.DB) {
+	start("Dual explicit prepared statement")
+	st1, err := db.Prepare("SELECT iv FROM autotx_a WHERE tv = $1")
+	check(err)
+	st2, err := db.Prepare("SELECT tv FROM autotx_b WHERE iv = $1")
+	check(err)
+
+	iv := 0
+	err = st1.QueryRow("two").Scan(&iv)
+	check(err)
+	assertEqInt(iv, 2)
+
+	tv := ""
+	err = st2.QueryRow(7).Scan(&tv)
+	check(err)
+	assertEqString(tv, "seven")
+
+	st1.Close()
+	st2.Close()
+}
+
+func testConcurrentStatements(db *sql.DB) {
+	start("Concurrent anonymous statements")
+
+	totalExecuted := int64(0)
+	stop := int64(0)
+	exited := make(chan bool)
+	testSeconds := 2
+	nThreads := 5
+
+	poll := func(threadIdx int) {
+		ticker := 0
+		for {
+			//fmt.Printf("%v:%v\n", threadIdx, ticker)
+			iv := 0
+			tv := ""
+			param := 0
+			err := db.QueryRow("SELECT iv,tv,$1 FROM autotx_a ORDER BY iv LIMIT 1", 5).Scan(&iv, &tv, &param)
+			check(err)
+			assertEqInt(iv, 2)
+
+			iv = 0
+			err = db.QueryRow("SELECT tv,iv,$1 FROM autotx_b ORDER BY iv LIMIT 1", 5).Scan(&tv, &iv, &param)
+			check(err)
+			assertEqInt(iv, 7)
+
+			atomic.AddInt64(&totalExecuted, 1)
+			ticker++
+			if atomic.LoadInt64(&stop) == 1 {
+				break
+			}
+		}
+		exited <- true
+	}
+
+	for i := 0; i < nThreads; i++ {
+		go poll(i)
+	}
+
+	for i := 0; i < testSeconds; i++ {
+		time.Sleep(time.Second)
+	}
+
+	atomic.StoreInt64(&stop, 1)
+
+	for i := 0; i < nThreads; i++ {
+		<-exited
+	}
+
+	fmt.Printf("Executed %v statements\n", totalExecuted)
+}
+
+func main() {
+	// Set native to true to execute the tests directly against Postgres,
+	// which is useful when doing a sense check against the tests in here.
+	//
+	// An easy way to craft new tests is to set native = true, then add
+	// your test code, and make sure it's working. Then, set native = false,
+	// and ensure that you still get the same behaviour when running through
+	// pgbouncer.
+	native := false
+
+	conStr := "host=localhost port=6432 user=postgres password=kama dbname=postgres sslmode=disable"
+	if native {
+		strings.Replace(conStr, "6432", "5432", -1)
+	}
+	db, err := sql.Open("postgres", conStr)
+	check(err)
+
+	setupDB(db)
+
+	testParseFail(db)
+	testSingleExplicitPS(db)
+	testDualExplicitPS(db)
+	testSimpleStatements(db)
+	testConcurrentStatements(db)
+}

--- a/test/ps/test.ini
+++ b/test/ps/test.ini
@@ -1,0 +1,18 @@
+[databases]
+* = host=127.0.0.1
+
+[pgbouncer]
+pool_mode = transaction
+listen_port = 6432
+listen_addr = 127.0.0.1
+#server_lifetime = 3600
+#server_idle_timeout = 10
+prepared_statement_lock = 1
+log_event_stream = 1
+log_prepared_statements = 1
+auth_type = md5
+auth_file = test/ps/userlist.txt
+logfile = pgbouncer.log
+pidfile = pgbouncer.pid
+admin_users = bouncer
+stats_users = stat_collector,bouncer

--- a/test/ps/userlist.txt
+++ b/test/ps/userlist.txt
@@ -1,0 +1,1 @@
+"postgres" "kama"


### PR DESCRIPTION
Before doing any more work on this PR, I'd like to just
sense-check if there's some glaring issue that I'm missing here.

We've been running this in beta production for a few months,
so.. "works on my machines"... but I'd love to get this merged,
if it can benefit others too.

-- COMMIT MESSAGE --

This commit adds support for an additional config setting
'prepared_statement_lock = 1', which enables some new locking
mechanisms designed to accomodate the use of prepared
statements, while pgbouncer is operating in
'pool_mode = transaction'.

Our use case for pgbouncer is a lot of mostly-idle
services, each having several DB connections permanently
open. The number of real server connections very quickly rises
to many hundreds. This commit allows use to use pgbouncer
in transaction mode, and by setting a low idle timeout
(eg 5 seconds), we can bring our number of real server
connections down substantially (eg 1000 to 50), which
greatly improves our multi-tenant efficiency.

The prepared_statement_lock feature allows us to write code
naturally, without having to jump through any weird hoops,
and basically work around Postgres' multi-process
architecture without having to change any of our code.

Postgres has two types of prepared statements - the 
"anonymous" statement, and named statements. There is one
implicit anonymous statement bound to every database connection,
but clients are free to create as many named statements as they
wish. Anonymous statements are used by many libraries, such
as Go's lib/pq, often without the programmer's knowledge.

Although it is possible to treat the anonymous statement as
a long-lived entity, in practice it seems like most Postgres
libraries use it for short-lived execution. For example,
if you execute the same statement multiple times from Go code,
then it is theoretically possible that the Go code could
reuse the previous anonymous statement for the 2nd and
subsequent executions. However, in practice, this is not the
case for Go's lib/pq, and I suspect it is also not the case
for a great deal of other libpq clients. What seems to happen
in practice, is that the libpq wrapper library will recreate
the anonymous statement every time the programmer needs to
use it, making the code stateless in this regard.

So if this is true - that client code treats the anonymous
statement as a once-off thing, we still need a way to correctly
detect when it's usage starts and ends. As far as I can tell
from my empirical tests here, it is sufficient to use the
server command 'C' (CommandComplete) to detect when an
anonymous statement is done being used.

Named prepared statements are much easier to track than
anonymous statements, because they come through with explicit
packets that we can decode (both the PREPARE and DEALLOCATE).
In this commit, I do the simplest thing possible, and just
lock the server connection when there is at least one named
statement in existence. There are no doubt cases where this
would cause all connections to be locked, but this doesn't
apply to any of the systems that we build. Also, I use
a simple list data structure to keep track of these, so
any clients that use a ton of prepared statements will hit
scaling issues. I'm guessing that this is rare, and these
clients can simply leave the new prepared statement
config setting switched off, and they won't have to pay
that penalty.

I have only added a small suite of tests from Go, because
this is one of our primary use cases. Internally, we also
have our own C++ libpq wrapper, to which I've added a set
of unit tests, but unfortunately I can't incorporate those
here. What I plan to do is to rewrite those as straight
libpq-based tests, and add them to the test/ps directory.

We have been running this branch of pgbouncer for the last
two months on some beta systems, and so far we are not
aware of any issues.

In order to figure out the feasibility of the methods here,
I added functions log_server_event_stream and
log_client_event_stream, which make it easy to see the
flow of events between client and server. This allowed me
to figure out appropriate signals that could be used to
detect the end of an anonymous statement's usage.