### PR TITLE
Don't log anything if client disconnects immediately

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -920,7 +920,14 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 	case SBUF_EV_CONNECT_FAILED:
 		/* ^ those should not happen */
 	case SBUF_EV_RECV_FAILED:
-		disconnect_client(client, false, "client unexpected eof");
+		/*
+		 * Don't log error if client disconnects right away,
+		 * could be monitoring probe.
+		 */
+		if (client->state == CL_LOGIN && mbuf_avail_for_read(data) == 0)
+			disconnect_client(client, false, NULL);
+		else
+			disconnect_client(client, false, "client unexpected eof");
 		break;
 	case SBUF_EV_SEND_FAILED:
 		disconnect_server(client->link, false, "server connection closed");

--- a/src/objects.c
+++ b/src/objects.c
@@ -892,16 +892,19 @@ void disconnect_server(PgSocket *server, bool notify, const char *reason, ...)
 /* drop client connection */
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 {
-	char buf[128];
-	va_list ap;
 	usec_t now = get_cached_time();
 
-	va_start(ap, reason);
-	vsnprintf(buf, sizeof(buf), reason, ap);
-	va_end(ap);
-	reason = buf;
+	if (reason) {
+		char buf[128];
+		va_list ap;
 
-	if (cf_log_disconnections)
+		va_start(ap, reason);
+		vsnprintf(buf, sizeof(buf), reason, ap);
+		va_end(ap);
+		reason = buf;
+	}
+
+	if (cf_log_disconnections && reason)
 		slog_info(client, "closing because: %s (age=%" PRIu64 "s)", reason,
 			  (now - client->connect_time) / USEC);
 


### PR DESCRIPTION
This avoids log spam when monitoring systems just open a TCP/IP
connection but don't send anything before disconnecting.

closes #323