### PR TITLE
Do not crash during mock authentication without auth_file

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -238,9 +238,11 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		ok = finish_client_login(client);
 		break;
 	case AUTH_TRUST:
-		if (client->login_user->mock_auth)
+		if (client->login_user->mock_auth) {
 			disconnect_client(client, true, "\"trust\" authentication failed");
-		ok = finish_client_login(client);
+			ok = false;
+		} else
+			ok = finish_client_login(client);
 		break;
 	case AUTH_PLAIN:
 	case AUTH_MD5:
@@ -263,8 +265,6 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 
 bool set_pool(PgSocket *client, const char *dbname, const char *username, const char *password, bool takeover)
 {
-	bool ret;
-
 	Assert((password && takeover) || (!password && !takeover));
 
 	/* find database */
@@ -348,14 +348,12 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		}
 	}
 
-	ret = finish_set_pool(client, takeover);
-
 	if (client->login_user->mock_auth) {
 		if (cf_log_connections)
 			slog_info(client, "login failed: db=%s user=%s", dbname, username);
 	}
 
-	return ret;
+	return finish_set_pool(client, takeover);
 }
 
 bool handle_auth_query_response(PgSocket *client, PktHdr *pkt) {


### PR DESCRIPTION
During mock authentication, pgbouncer should not emmit any connection errors.
Also it should avoid to create a pool. Before this patch, a pool would not be
created, however it would attempt to use one, leading to a crash.

Co-authored-by: Daniel Gustafsson <daniel@yesql.se>