### PR TITLE
launch new connections when cancel requests are queued

### DIFF
--- a/src/janitor.c
+++ b/src/janitor.c
@@ -174,6 +174,12 @@ static void per_loop_activate(PgPool *pool)
 	PgSocket *client;
 	int sv_tested, sv_used;
 
+	/* if there is a cancelation request waiting, open a new socket */
+	if (!statlist_empty(&pool->cancel_req_list)) {
+		launch_new_connection(pool);
+		return;
+	}
+
 	/* see if any server have been freed */
 	sv_tested = statlist_count(&pool->tested_server_list);
 	sv_used = statlist_count(&pool->used_server_list);

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -174,7 +174,7 @@ static void per_loop_activate(PgPool *pool)
 	PgSocket *client;
 	int sv_tested, sv_used;
 
-	/* if there is a cancelation request waiting, open a new socket */
+	/* if there is a cancel request waiting, open a new connection */
 	if (!statlist_empty(&pool->cancel_req_list)) {
 		launch_new_connection(pool);
 		return;


### PR DESCRIPTION
As described in #245 this is the first patch in a series of patches to improve the cancelation of a backend when pgbouncer is involved.

In this patch we introduce the launching of a new connection when cancelations are queued. There already was a loop that would calculate if a new connection should be launched if there was a client waiting for a backend. By not launching connections for cancelations we have observed very chaotic behaviour where a bunch (1200) of cancelations are flushed at once when a new connection was established. These cancelations came to pgbouncer at a moment when no new connections could be launched as other wise they would have been consumed from the queue directly after the connection gets established.

cancelation queueing and connection launch: https://github.com/pgbouncer/pgbouncer/blob/14331ba97f99ed8063363f1a40e6b00634e14428/src/objects.c#L1351-L1354

connection assigned to cancelation:
https://github.com/pgbouncer/pgbouncer/blob/ad6b5af4e27c8e9059b7a1e7dd541ea3b7c72624/src/server.c#L407-L414

Given that cancelations are handled first I propose we launch new connections directly when we have a non-empty cancelation list. There is a back pressure mechanism in `launch_new_connection` that will prevent multiple connections from being started at the same time: https://github.com/pgbouncer/pgbouncer/blob/14331ba97f99ed8063363f1a40e6b00634e14428/src/objects.c#L1139-L1143