### PR TITLE
introduce a generation to a server connection

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -407,6 +407,7 @@ struct PgSocket {
 	usec_t wait_start;	/* waiting start moment */
 
 	uint8_t cancel_key[BACKENDKEY_LEN]; /* client: generated, server: remote */
+	uint64_t generation;	/* server: number of commands sent, client: number of commands sent to the server on cancelation request */
 	PgAddr remote_addr;	/* ip:port for remote endpoint */
 	PgAddr local_addr;	/* ip:port for local endpoint */
 

--- a/src/client.c
+++ b/src/client.c
@@ -952,6 +952,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	/* tag the server as dirty */
 	client->link->ready = false;
 	client->link->idle_tx = false;
+	client->link->generation++; /* TODO figure out what happens on overflow */
 
 	/* forward the packet */
 	sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);


### PR DESCRIPTION
As described in #245 this is the first patch in a series of patches to improve the cancelation of a backend when pgbouncer is involved.

This patch is most experimental and would require more testing and help from a maintainer.

The goal of this patch is to add the notion of a generation to a `Server` socket. The generation should be incremented every time a command is dispatched to the server. By keeping this generation we could compare the generation (and thus the command sent) at the moment of a cancelation being received by pgbouncer to the generation at the moment of the forward of the cancelation. As described and observed in #245, there can be a delay between pgbouncer receiving the cancelation and the moment a cancelation is processed on a new socket.