### PR TITLE
wait_time is already in microseconds

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -70,7 +70,7 @@ static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
 	if (xact_count > 0)
 		avg->xact_time = (cur->xact_time - old->xact_time) / xact_count;
 
-	avg->wait_time = USEC * (cur->wait_time - old->wait_time) / dur;
+	avg->wait_time = (cur->wait_time - old->wait_time) / dur;
 }
 
 static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)


### PR DESCRIPTION
There is an oversight in the average math (cf 350a0b57). In
calc_average(), wait_time and dur are in microseconds. Hence, the
average does not need to be multiplied by USEC.

This issue was reported by Fabrizio Mello (@fabriziomello).