### PR TITLE
Support hot reloading of TLS settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 /test/ssl/pgdata/
 /test/ssl/test.log
 /test/ssl/test.pid
-/test/ssl/TestCA1/
+/test/ssl/TestCA[1-9]/
 
 *.html
 *.xml

--- a/include/objects.h
+++ b/include/objects.h
@@ -78,6 +78,7 @@ void change_server_state(PgSocket *server, SocketState newstate);
 int get_active_client_count(void);
 int get_active_server_count(void);
 
+void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
 void tag_autodb_dirty(void);
 void tag_host_addr_dirty(const char *host, const struct sockaddr *sa);

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -42,6 +42,15 @@ typedef enum {
 
 struct tls;
 
+/*
+ * client_accept_sslmode is the currently applied sslmode that is used to
+ * accept client connections. This is usually the same as
+ * cf_client_tls_sslmode, except when changing the TLS configuration failed for
+ * some reason (e.g. cert file not found). In this exceptional case,
+ * cf_client_tls_sslmode will be the new sslmode, which is not actually
+ * applied. And client_accept_sslmode is the still applied previous version. So
+ * usually you should use this variable over cf_client_tls_sslmode.
+ */
 extern int client_accept_sslmode;
 
 /* fwd def */

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -93,7 +93,7 @@ void sbuf_init(SBuf *sbuf, sbuf_cb_t proto_fn);
 bool sbuf_accept(SBuf *sbuf, int read_sock, bool is_unix)  _MUSTCHECK;
 bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_t timeout_sec)  _MUSTCHECK;
 
-void sbuf_tls_setup(void);
+bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
 

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -42,6 +42,8 @@ typedef enum {
 
 struct tls;
 
+int client_accept_sslmode;
+
 /* fwd def */
 typedef struct SBuf SBuf;
 typedef struct SBufIO SBufIO;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -42,7 +42,7 @@ typedef enum {
 
 struct tls;
 
-int client_accept_sslmode;
+extern int client_accept_sslmode;
 
 /* fwd def */
 typedef struct SBuf SBuf;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -42,17 +42,6 @@ typedef enum {
 
 struct tls;
 
-/*
- * client_accept_sslmode is the currently applied sslmode that is used to
- * accept client connections. This is usually the same as
- * cf_client_tls_sslmode, except when changing the TLS configuration failed for
- * some reason (e.g. cert file not found). In this exceptional case,
- * cf_client_tls_sslmode will be the new sslmode, which is not actually
- * applied. And client_accept_sslmode is the still applied previous version. So
- * usually you should use this variable over cf_client_tls_sslmode.
- */
-extern int client_accept_sslmode;
-
 /* fwd def */
 typedef struct SBuf SBuf;
 typedef struct SBufIO SBufIO;
@@ -103,6 +92,22 @@ struct SBuf {
 void sbuf_init(SBuf *sbuf, sbuf_cb_t proto_fn);
 bool sbuf_accept(SBuf *sbuf, int read_sock, bool is_unix)  _MUSTCHECK;
 bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_t timeout_sec)  _MUSTCHECK;
+
+/*
+ * client_accept_sslmode is the currently applied sslmode that is used to
+ * accept client connections. This is usually the same as
+ * cf_client_tls_sslmode, except when changing the TLS configuration failed for
+ * some reason (e.g. cert file not found). In this exceptional case,
+ * cf_client_tls_sslmode will be the new sslmode, which is not actually
+ * applied. And client_accept_sslmode is the still applied previous version. So
+ * usually you should use this variable over cf_client_tls_sslmode.
+ */
+extern int client_accept_sslmode;
+/*
+ * Same as client_accept_sslmode, but for server connections.
+ */
+extern int server_connect_sslmode;
+
 
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;

--- a/src/admin.c
+++ b/src/admin.c
@@ -234,8 +234,13 @@ static bool admin_set(PgSocket *admin, const char *key, const char *val)
 	if (admin->admin_user) {
 		ok = set_config_param(key, val);
 		if (ok) {
+			PktBuf *buf = pktbuf_dynamic(256);
+			if (strstr(key, "_tls_") != NULL) {
+				if (!sbuf_tls_setup())
+					pktbuf_write_Notice(buf, "TLS settings could not be applied, still using old configuration");
+			}
 			snprintf(tmp, sizeof(tmp), "SET %s=%s", key, val);
-			return admin_ready(admin, tmp);
+			return admin_flush(admin, buf, tmp);
 		} else {
 			return admin_error(admin, "SET failed");
 		}

--- a/src/admin.c
+++ b/src/admin.c
@@ -976,6 +976,8 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
 
 	log_info("RELOAD command issued");
 	load_config();
+	if (!sbuf_tls_setup())
+		log_error("TLS configuration could not be reloaded, keeping old configuration");
 	return admin_ready(admin, "RELOAD");
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -718,7 +718,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			disconnect_client(client, false, "SSL req inside SSL");
 			return false;
 		}
-		if (cf_client_tls_sslmode != SSLMODE_DISABLED && !is_unix) {
+		if (client_accept_sslmode != SSLMODE_DISABLED && !is_unix) {
 			slog_noise(client, "P: SSL ack");
 			if (!sbuf_answer(&client->sbuf, "S", 1)) {
 				disconnect_client(client, false, "failed to ack SSL");
@@ -751,7 +751,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 		return false;
 	case PKT_STARTUP:
 		/* require SSL except on unix socket */
-		if (cf_client_tls_sslmode >= SSLMODE_REQUIRE && !client->sbuf.tls && !is_unix) {
+		if (client_accept_sslmode >= SSLMODE_REQUIRE && !client->sbuf.tls && !is_unix) {
 			disconnect_client(client, true, "SSL required");
 			return false;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -277,12 +277,12 @@ CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 CF_ABS("server_reset_query", CF_STR, cf_server_reset_query, 0, "DISCARD ALL"),
 CF_ABS("server_reset_query_always", CF_INT, cf_server_reset_query_always, 0, "0"),
 CF_ABS("server_round_robin", CF_INT, cf_server_round_robin, 0, "0"),
-CF_ABS("server_tls_ca_file", CF_STR, cf_server_tls_ca_file, CF_NO_RELOAD, ""),
-CF_ABS("server_tls_cert_file", CF_STR, cf_server_tls_cert_file, CF_NO_RELOAD, ""),
-CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, CF_NO_RELOAD, "fast"),
-CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, CF_NO_RELOAD, ""),
-CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, CF_NO_RELOAD, "secure"),
-CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, CF_NO_RELOAD, "disable"),
+CF_ABS("server_tls_ca_file", CF_STR, cf_server_tls_ca_file, 0, ""),
+CF_ABS("server_tls_cert_file", CF_STR, cf_server_tls_cert_file, 0, ""),
+CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, 0, "fast"),
+CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, 0, ""),
+CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, 0, "secure"),
+CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, 0, "disable"),
 #ifdef WIN32
 CF_ABS("service_name", CF_STR, cf_jobname, CF_NO_RELOAD, NULL), /* alias for job_name */
 #endif
@@ -498,7 +498,8 @@ static void handle_sighup(int sock, short flags, void *arg)
 	log_info("got SIGHUP, re-reading config");
 	sd_notify(0, "RELOADING=1");
 	load_config();
-	sbuf_tls_setup();
+	if (!sbuf_tls_setup())
+		log_error("TLS configuration could not be reloaded, keeping old configuration");
 	sd_notify(0, "READY=1");
 }
 #endif
@@ -921,9 +922,8 @@ int main(int argc, char *argv[])
 	init_caches();
 	logging_prefix_cb = log_socket_prefix;
 
-	if (!sbuf_tls_setup()) {
+	if (!sbuf_tls_setup())
 		die("TLS setup failed");
-	}
 
 	/* prefer cmdline over config for username */
 	if (arg_username) {

--- a/src/main.c
+++ b/src/main.c
@@ -228,14 +228,14 @@ CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),
 CF_ABS("client_idle_timeout", CF_TIME_USEC, cf_client_idle_timeout, 0, "0"),
 CF_ABS("client_login_timeout", CF_TIME_USEC, cf_client_login_timeout, 0, "60"),
-CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, CF_NO_RELOAD, ""),
-CF_ABS("client_tls_cert_file", CF_STR, cf_client_tls_cert_file, CF_NO_RELOAD, ""),
-CF_ABS("client_tls_ciphers", CF_STR, cf_client_tls_ciphers, CF_NO_RELOAD, "fast"),
-CF_ABS("client_tls_dheparams", CF_STR, cf_client_tls_dheparams, CF_NO_RELOAD, "auto"),
-CF_ABS("client_tls_ecdhcurve", CF_STR, cf_client_tls_ecdhecurve, CF_NO_RELOAD, "auto"),
-CF_ABS("client_tls_key_file", CF_STR, cf_client_tls_key_file, CF_NO_RELOAD, ""),
-CF_ABS("client_tls_protocols", CF_STR, cf_client_tls_protocols, CF_NO_RELOAD, "secure"),
-CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, CF_NO_RELOAD, "disable"),
+CF_ABS("client_tls_ca_file", CF_STR, cf_client_tls_ca_file, 0, ""),
+CF_ABS("client_tls_cert_file", CF_STR, cf_client_tls_cert_file, 0, ""),
+CF_ABS("client_tls_ciphers", CF_STR, cf_client_tls_ciphers, 0, "fast"),
+CF_ABS("client_tls_dheparams", CF_STR, cf_client_tls_dheparams, 0, "auto"),
+CF_ABS("client_tls_ecdhcurve", CF_STR, cf_client_tls_ecdhecurve, 0, "auto"),
+CF_ABS("client_tls_key_file", CF_STR, cf_client_tls_key_file, 0, ""),
+CF_ABS("client_tls_protocols", CF_STR, cf_client_tls_protocols, 0, "secure"),
+CF_ABS("client_tls_sslmode", CF_LOOKUP(sslmode_map), cf_client_tls_sslmode, 0, "disable"),
 CF_ABS("conffile", CF_STR, cf_config_file, 0, NULL),
 CF_ABS("default_pool_size", CF_INT, cf_default_pool_size, 0, "20"),
 CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),
@@ -498,6 +498,7 @@ static void handle_sighup(int sock, short flags, void *arg)
 	log_info("got SIGHUP, re-reading config");
 	sd_notify(0, "RELOADING=1");
 	load_config();
+	sbuf_tls_setup();
 	sd_notify(0, "READY=1");
 }
 #endif
@@ -920,7 +921,9 @@ int main(int argc, char *argv[])
 	init_caches();
 	logging_prefix_cb = log_socket_prefix;
 
-	sbuf_tls_setup();
+	if (!sbuf_tls_setup()) {
+		die("TLS setup failed");
+	}
 
 	/* prefer cmdline over config for username */
 	if (arg_username) {

--- a/src/objects.c
+++ b/src/objects.c
@@ -1624,6 +1624,14 @@ void tag_pool_dirty(PgPool *pool)
 	struct List *item, *tmp;
 	struct PgSocket *server;
 
+	/*
+	 * Don't tag the admin pool as dirty, since this is not an actual postgres
+	 * server. Marking it as dirty breaks connecting to the pgbouncer admin
+	 * database on future connections.
+	 */
+	if (pool->db->admin)
+		return;
+
 	/* reset welcome msg */
 	if (pool->welcome_msg) {
 		pktbuf_free(pool->welcome_msg);

--- a/src/objects.c
+++ b/src/objects.c
@@ -1619,7 +1619,7 @@ static void tag_dirty(PgSocket *sk)
 	sk->close_needed = true;
 }
 
-static void tag_pool_dirty(PgPool *pool)
+void tag_pool_dirty(PgPool *pool)
 {
 	struct List *item, *tmp;
 	struct PgSocket *server;

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1048,6 +1048,7 @@ bool sbuf_tls_setup(void)
 	client_accept_conf = new_client_accept_conf;
 	server_connect_conf = new_server_connect_conf;
 	client_accept_base = new_client_accept_base;
+	client_accept_sslmode = cf_client_tls_sslmode;
 	return true;
 failed:
 	tls_free(new_client_accept_base);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -864,6 +864,11 @@ static int raw_sbufio_close(struct SBuf *sbuf)
 
 #ifdef USE_TLS
 
+/*
+ * Thes are the currently applied TLS configurations. They might differ from
+ * the current configuration if there was an error applying the configured
+ * parameters (e.g. cert file not found).
+ */
 static struct tls_config *client_accept_conf;
 static struct tls_config *server_connect_conf;
 static struct tls *client_accept_base;
@@ -959,6 +964,12 @@ static bool setup_tls(struct tls_config *conf, const char *pfx, int sslmode,
 bool sbuf_tls_setup(void)
 {
 	int err;
+	/*
+	 * These are the new TLS configurations, based on the latest settings
+	 * provided by the user. Once they have been configured completely without
+	 * errors they are assigned to the globals at the end of this function.
+	 * This way the globals never have partially configured TLS configurations.
+	 */
 	struct tls_config *new_client_accept_conf = NULL;
 	struct tls_config *new_server_connect_conf = NULL;
 	struct tls *new_client_accept_base = NULL;

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -54,8 +54,6 @@ enum WaitType {
 	W_ONCE
 };
 
-int client_accept_sslmode;
-
 #define AssertSanity(sbuf) do { \
 	Assert(iobuf_sane((sbuf)->io)); \
 } while (0)
@@ -869,9 +867,12 @@ static int raw_sbufio_close(struct SBuf *sbuf)
  * They might differ from the current configuration if there was an error
  * applying the configured parameters (e.g. cert file not found).
  */
-static struct tls_config *client_accept_conf;
-static struct tls_config *server_connect_conf;
 static struct tls *client_accept_base;
+static struct tls_config *client_accept_conf;
+int client_accept_sslmode;
+static struct tls_config *server_connect_conf;
+int server_connect_sslmode;
+
 
 /*
  * TLS setup
@@ -1061,10 +1062,11 @@ bool sbuf_tls_setup(void)
 	tls_free(client_accept_base);
 	tls_config_free(client_accept_conf);
 	tls_config_free(server_connect_conf);
-	client_accept_conf = new_client_accept_conf;
-	server_connect_conf = new_server_connect_conf;
 	client_accept_base = new_client_accept_base;
+	client_accept_conf = new_client_accept_conf;
 	client_accept_sslmode = cf_client_tls_sslmode;
+	server_connect_conf = new_server_connect_conf;
+	server_connect_sslmode = cf_server_tls_sslmode;
 	return true;
 failed:
 	tls_free(new_client_accept_base);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1038,7 +1038,11 @@ bool sbuf_tls_setup(void)
 		PgPool *pool;
 		statlist_for_each(item, &pool_list) {
 			pool = container_of(item, PgPool, head);
-			tag_pool_dirty(pool);
+			// Don't tag the pgbouncer pool as dirty, since this is not an
+			// actual postgres server. Marking it as dirty breaks connecting to
+			// the pgbouncer admin database on future connections.
+			if (strcmp(pool->db->name, "pgbouncer") != 0)
+				tag_pool_dirty(pool);
 		}
 	}
 

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1251,6 +1251,9 @@ void sbuf_cleanup(void)
 
 #else
 
+int client_accept_sslmode = SSLMODE_DISABLED;
+int server_connect_sslmode = SSLMODE_DISABLED;
+
 bool sbuf_tls_setup(void) { return true; }
 bool sbuf_tls_accept(SBuf *sbuf) { return false; }
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname) { return false; }

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -54,15 +54,6 @@ enum WaitType {
 	W_ONCE
 };
 
-/*
- * client_accept_sslmode is the currently applied sslmode that is used to
- * accept client connections. This is usually the same as
- * cf_client_tls_sslmode, except when changing the TLS configuration failed for
- * some reason (e.g. cert file not found). In this exceptional case,
- * cf_client_tls_sslmode will be the new sslmode, which is not actually
- * applied. And client_accept_sslmode is the still applied previous version. So
- * usually you should use this variable over cf_client_tls_sslmode.
- */
 int client_accept_sslmode;
 
 #define AssertSanity(sbuf) do { \

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -54,6 +54,15 @@ enum WaitType {
 	W_ONCE
 };
 
+/*
+ * client_accept_sslmode is the currently applied sslmode that is used to
+ * accept client connections. This is usually the same as
+ * cf_client_tls_sslmode, except when changing the TLS configuration failed for
+ * some reason (e.g. cert file not found). In this exceptional case,
+ * cf_client_tls_sslmode will be the new sslmode, which is not actually
+ * applied. And client_accept_sslmode is the still applied previous version. So
+ * usually you should use this variable over cf_client_tls_sslmode.
+ */
 int client_accept_sslmode;
 
 #define AssertSanity(sbuf) do { \

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -54,6 +54,8 @@ enum WaitType {
 	W_ONCE
 };
 
+int client_accept_sslmode;
+
 #define AssertSanity(sbuf) do { \
 	Assert(iobuf_sane((sbuf)->io)); \
 } while (0)

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1036,24 +1036,22 @@ bool sbuf_tls_setup(void)
 		}
 	}
 
-	// To change server TLS settings all connections are marked as dirty. This
-	// way they are recycled and the new TLS settings will be used. Otherwise
-	// old TLS settings, possibly less secure, could be used for old
-	// connections indefinitly. If TLS is disabled, and it was disabled before
-	// as well then recycling connections is not necessary, since we know none
-	// of the settings have changed. In all other cases we recycle the
-	// connections to be on the safe side, even though it's possible nothing
-	// has changed.
+	/*
+	 * To change server TLS settings all connections are marked as dirty. This
+	 * way they are recycled and the new TLS settings will be used. Otherwise
+	 * old TLS settings, possibly less secure, could be used for old
+	 * connections indefinitly. If TLS is disabled, and it was disabled before
+	 * as well then recycling connections is not necessary, since we know none
+	 * of the settings have changed. In all other cases we recycle the
+	 * connections to be on the safe side, even though it's possible nothing
+	 * has changed.
+	 */
 	if (server_connect_conf || new_server_connect_conf) {
 		struct List *item;
 		PgPool *pool;
 		statlist_for_each(item, &pool_list) {
 			pool = container_of(item, PgPool, head);
-			// Don't tag the pgbouncer pool as dirty, since this is not an
-			// actual postgres server. Marking it as dirty breaks connecting to
-			// the pgbouncer admin database on future connections.
-			if (strcmp(pool->db->name, "pgbouncer") != 0)
-				tag_pool_dirty(pool);
+			tag_pool_dirty(pool);
 		}
 	}
 

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -865,9 +865,9 @@ static int raw_sbufio_close(struct SBuf *sbuf)
 #ifdef USE_TLS
 
 /*
- * Thes are the currently applied TLS configurations. They might differ from
- * the current configuration if there was an error applying the configured
- * parameters (e.g. cert file not found).
+ * These global variables contain the currently applied TLS configurations.
+ * They might differ from the current configuration if there was an error
+ * applying the configured parameters (e.g. cert file not found).
  */
 static struct tls_config *client_accept_conf;
 static struct tls_config *server_connect_conf;
@@ -965,10 +965,11 @@ bool sbuf_tls_setup(void)
 {
 	int err;
 	/*
-	 * These are the new TLS configurations, based on the latest settings
-	 * provided by the user. Once they have been configured completely without
-	 * errors they are assigned to the globals at the end of this function.
-	 * This way the globals never have partially configured TLS configurations.
+	 * These variables store the new TLS configurations, based on the latest
+	 * settings provided by the user. Once they have been configured completely
+	 * without errors they are assigned to the globals at the end of this
+	 * function. This way the globals never contain partially configured TLS
+	 * configurations.
 	 */
 	struct tls_config *new_client_accept_conf = NULL;
 	struct tls_config *new_server_connect_conf = NULL;

--- a/src/server.c
+++ b/src/server.c
@@ -413,7 +413,7 @@ static bool handle_connect(PgSocket *server)
 		disconnect_server(server, false, "sent cancel req");
 	} else {
 		/* proceed with login */
-		if (cf_server_tls_sslmode > SSLMODE_DISABLED && !is_unix) {
+		if (server_connect_sslmode > SSLMODE_DISABLED && !is_unix) {
 			slog_noise(server, "P: SSL request");
 			res = send_sslreq_packet(server);
 			if (res)
@@ -444,7 +444,7 @@ static bool handle_sslchar(PgSocket *server, struct MBuf *data)
 	if (schar == 'S') {
 		slog_noise(server, "launching tls");
 		ok = sbuf_tls_connect(&server->sbuf, server->pool->db->host);
-	} else if (cf_server_tls_sslmode >= SSLMODE_REQUIRE) {
+	} else if (server_connect_sslmode >= SSLMODE_REQUIRE) {
 		disconnect_server(server, false, "server refused SSL");
 		return false;
 	} else {

--- a/test/ssl/lib.sh
+++ b/test/ssl/lib.sh
@@ -46,6 +46,6 @@ run_ca() {
     shift
   done
   if test "$1" = '-out'; then
-    cp "${CaName}/certs/$ser.pem" "$2" 2>/dev/null
+    cp "${CaName}/certs/$ser.pem" "$2"
   fi
 }

--- a/test/ssl/lib.sh
+++ b/test/ssl/lib.sh
@@ -46,6 +46,6 @@ run_ca() {
     shift
   done
   if test "$1" = '-out'; then
-    cp "${CaName}/certs/$ser.pem" "$2"
+    cp "${CaName}/certs/$ser.pem" "$2" 2>/dev/null
   fi
 }

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -108,7 +108,7 @@ reconf_bouncer() {
 	done
 	test -f test.pid && kill `cat test.pid`
 	sleep 1
-	$BOUNCER_EXE -v -v -v -d tmp/test.ini
+	$BOUNCER_EXE -v -v -d tmp/test.ini
 }
 
 reconf_pgsql() {

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -239,7 +239,7 @@ test_client_ssl() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q -d "dbname=p0 sslmode=require" -c "select 'client-ssl-connect'" | tee tmp/test.tmp
+	psql_bouncer -q "dbname=p0 sslmode=require" -c "select 'client-ssl-connect'" | tee tmp/test.tmp
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -253,7 +253,119 @@ test_client_ssl_verify() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_set_disable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_sslmode = require" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	admin "set client_tls_sslmode=disable"
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_set_enable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_sslmode = disable"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
+	admin "set client_tls_key_file='TestCA1/sites/01-localhost.key'"
+	admin "set client_tls_cert_file='TestCA1/sites/01-localhost.crt'"
+	admin "set client_tls_sslmode=require"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_reload_disable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt" \
+		"client_tls_sslmode=require"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	sed 's/client_tls_sslmode=require/client_tls_sslmode=disable/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	admin "reload"
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_reload_enable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt" \
+		"client_tls_sslmode=disable"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
+	sed 's/client_tls_sslmode=disable/client_tls_sslmode=require/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	admin "reload"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_sighup_disable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt" \
+		"client_tls_sslmode=require"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	sed 's/client_tls_sslmode=require/client_tls_sslmode=disable/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	kill -HUP `cat test.pid`
+	sleep 1
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_sighup_enable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt" \
+		"client_tls_sslmode=disable"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
+	sed 's/client_tls_sslmode=disable/client_tls_sslmode=require/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	kill -HUP `cat test.pid`
+	sleep 1
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -268,7 +380,7 @@ test_client_ssl_auth() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q -d "dbname=p0 sslmode=require sslkey=TestCA1/sites/02-bouncer.key sslcert=TestCA1/sites/02-bouncer.crt" \
+	psql_bouncer -q "dbname=p0 sslmode=require sslkey=TestCA1/sites/02-bouncer.key sslcert=TestCA1/sites/02-bouncer.crt" \
 		-c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
@@ -283,7 +395,7 @@ test_client_ssl_scram() {
 		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
 		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -295,6 +407,12 @@ test_server_ssl_verify
 test_server_ssl_pg_auth
 test_client_ssl
 test_client_ssl_verify
+test_client_ssl_set_disable
+test_client_ssl_set_enable
+test_client_ssl_reload_disable
+test_client_ssl_reload_enable
+test_client_ssl_sighup_disable
+test_client_ssl_sighup_enable
 test_client_ssl_auth
 test_client_ssl_scram
 "

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -108,7 +108,7 @@ reconf_bouncer() {
 	done
 	test -f test.pid && kill `cat test.pid`
 	sleep 1
-	$BOUNCER_EXE -v -v -d tmp/test.ini
+	$BOUNCER_EXE -v -v -v -d tmp/test.ini
 }
 
 reconf_pgsql() {

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -9,6 +9,8 @@ rm -rf TestCA1
 ./newsite.sh TestCA1 localhost C=QQ O=Org1 L=computer OU=db
 ./newsite.sh TestCA1 bouncer C=QQ O=Org1 L=computer OU=Dev
 ./newsite.sh TestCA1 random C=QQ O=Org1 L=computer OU=Dev
+./newca.sh TestCA2 C=QQ O=Org2 CN="TestCA2"
+./newsite.sh TestCA2 localhost C=QQ O=Org1 L=computer OU=db
 ) > /dev/null
 
 export PGDATA=$PWD/pgdata
@@ -293,6 +295,25 @@ test_client_ssl_set_enable() {
 	return $rc
 }
 
+test_client_ssl_set_change_ca() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_sslmode = require" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	admin "set client_tls_key_file='TestCA2/sites/01-localhost.key'"
+	admin "set client_tls_cert_file='TestCA2/sites/01-localhost.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+
 test_client_ssl_reload_disable() {
 	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
 		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
@@ -326,6 +347,25 @@ test_client_ssl_reload_enable() {
 	mv tmp/test2.ini tmp/test.ini
 	admin "reload"
 	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
+test_client_ssl_reload_change_ca() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_sslmode = require" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	sed 's/TestCA1/TestCA2/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	admin "reload"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -371,6 +411,26 @@ test_client_ssl_sighup_enable() {
 	return $rc
 }
 
+test_client_ssl_sighup_change_ca() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
+		"client_tls_sslmode = require" \
+		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
+		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
+	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
+	sed 's/TestCA1/TestCA2/g' tmp/test.ini > tmp/test2.ini
+	mv tmp/test2.ini tmp/test.ini
+	kill -HUP `cat test.pid`
+	sleep 1
+	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	grep -q "client-ssl-connect"  tmp/test.tmp
+	rc=$?
+	return $rc
+}
+
 test_client_ssl_auth() {
 	reconf_bouncer "auth_type = cert" "server_tls_sslmode = prefer" \
 		"client_tls_sslmode = verify-full" \
@@ -409,10 +469,13 @@ test_client_ssl
 test_client_ssl_verify
 test_client_ssl_set_disable
 test_client_ssl_set_enable
+test_client_ssl_set_change_ca
 test_client_ssl_reload_disable
 test_client_ssl_reload_enable
+test_client_ssl_reload_change_ca
 test_client_ssl_sighup_disable
 test_client_ssl_sighup_enable
+test_client_ssl_sighup_change_ca
 test_client_ssl_auth
 test_client_ssl_scram
 "

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -2,7 +2,7 @@
 
 cd $(dirname $0)
 
-rm -rf TestCA1
+rm -rf TestCA1 TestCA2
 
 (
 ./newca.sh TestCA1 C=QQ O=Org1 CN="TestCA1"

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -277,7 +277,7 @@ test_client_ssl() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=require" -c "select 'client-ssl-connect'" | tee tmp/test.tmp
+	psql_bouncer -q -d "dbname=p0 sslmode=require" -c "select 'client-ssl-connect'" | tee tmp/test.tmp
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -291,7 +291,7 @@ test_client_ssl_verify() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -305,10 +305,10 @@ test_client_ssl_set_disable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	admin "set client_tls_sslmode=disable"
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -320,12 +320,12 @@ test_client_ssl_set_enable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
 	admin "set client_tls_key_file='TestCA1/sites/01-localhost.key'"
 	admin "set client_tls_cert_file='TestCA1/sites/01-localhost.crt'"
 	admin "set client_tls_sslmode=require"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -339,16 +339,15 @@ test_client_ssl_set_change_ca() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	admin "set client_tls_key_file='TestCA2/sites/01-localhost.key'"
 	admin "set client_tls_cert_file='TestCA2/sites/01-localhost.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
 }
-
 
 test_client_ssl_reload_disable() {
 	reconf_bouncer "auth_type = trust" "server_tls_sslmode = prefer" \
@@ -358,12 +357,12 @@ test_client_ssl_reload_disable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	sed 's/client_tls_sslmode=require/client_tls_sslmode=disable/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	admin "reload"
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -377,12 +376,12 @@ test_client_ssl_reload_enable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
 	sed 's/client_tls_sslmode=disable/client_tls_sslmode=require/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	admin "reload"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -396,12 +395,12 @@ test_client_ssl_reload_change_ca() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	sed 's/TestCA1/TestCA2/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	admin "reload"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -415,13 +414,13 @@ test_client_ssl_sighup_disable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	sed 's/client_tls_sslmode=require/client_tls_sslmode=disable/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	kill -HUP `cat test.pid`
 	sleep 1
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -435,13 +434,13 @@ test_client_ssl_sighup_enable() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=disable" -c "select 'client-ssl-disable'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-disable"  tmp/test.tmp || return 1
 	sed 's/client_tls_sslmode=disable/client_tls_sslmode=require/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	kill -HUP `cat test.pid`
 	sleep 1
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -455,13 +454,13 @@ test_client_ssl_sighup_change_ca() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp || return 1
 	sed 's/TestCA1/TestCA2/g' tmp/test.ini > tmp/test2.ini
 	mv tmp/test2.ini tmp/test.ini
 	kill -HUP `cat test.pid`
 	sleep 1
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA2/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc
@@ -476,7 +475,7 @@ test_client_ssl_auth() {
 	echo "host all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
 	echo "host all all ::1/128 trust" >> pgdata/pg_hba.conf
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=require sslkey=TestCA1/sites/02-bouncer.key sslcert=TestCA1/sites/02-bouncer.crt" \
+	psql_bouncer -q -d "dbname=p0 sslmode=require sslkey=TestCA1/sites/02-bouncer.key sslcert=TestCA1/sites/02-bouncer.crt" \
 		-c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
@@ -491,7 +490,7 @@ test_client_ssl_scram() {
 		"client_tls_key_file = TestCA1/sites/01-localhost.key" \
 		"client_tls_cert_file = TestCA1/sites/01-localhost.crt"
 	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
-	psql_bouncer -q "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
+	psql_bouncer -q -d "dbname=p0 sslmode=verify-full sslrootcert=TestCA1/ca.crt" -c "select 'client-ssl-connect'" | tee tmp/test.tmp 2>&1
 	grep -q "client-ssl-connect"  tmp/test.tmp
 	rc=$?
 	return $rc

--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -203,6 +203,42 @@ test_server_ssl() {
 	return $rc
 }
 
+test_server_ssl_set_disable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = require"
+	echo "hostssl all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "hostssl all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q -d p0 -c "select 'ssl-connect'" | tee tmp/test.tmp0
+	grep -q "ssl-connect"  tmp/test.tmp0 || return 1
+	sed s/ssl/nossl/g pgdata/pg_hba.conf > tmp/pg_hba2.conf
+	mv tmp/pg_hba2.conf pgdata/pg_hba.conf
+	pg_ctl reload
+	admin "reconnect"
+	admin "set server_tls_sslmode=disable"
+	psql_bouncer -q -d p0 -c "select 'ssl-connect'" | tee tmp/test.tmp0
+	grep -q "ssl-connect"  tmp/test.tmp0
+	rc=$?
+	return $rc
+}
+
+test_server_ssl_set_enable() {
+	reconf_bouncer "auth_type = trust" "server_tls_sslmode = disable"
+	echo "hostnossl all all 127.0.0.1/32 trust" > pgdata/pg_hba.conf
+	echo "hostnossl all all ::1/128 trust" >> pgdata/pg_hba.conf
+	reconf_pgsql "ssl=on" "ssl_ca_file='root.crt'"
+	psql_bouncer -q -d p0 -c "select 'ssl-connect'" | tee tmp/test.tmp0
+	grep -q "ssl-connect"  tmp/test.tmp0 || return 1
+	sed s/nossl/ssl/g pgdata/pg_hba.conf > tmp/pg_hba2.conf
+	mv tmp/pg_hba2.conf pgdata/pg_hba.conf
+	pg_ctl reload
+	admin "reconnect"
+	admin "set server_tls_sslmode=require"
+	psql_bouncer -q -d p0 -c "select 'ssl-connect'" | tee tmp/test.tmp0
+	grep -q "ssl-connect"  tmp/test.tmp0
+	rc=$?
+	return $rc
+}
+
 test_server_ssl_verify() {
 	reconf_bouncer "auth_type = trust" \
 		"server_tls_sslmode = verify-full" \
@@ -463,6 +499,8 @@ test_client_ssl_scram() {
 
 testlist="
 test_server_ssl
+test_server_ssl_set_disable
+test_server_ssl_set_enable
 test_server_ssl_verify
 test_server_ssl_pg_auth
 test_client_ssl


### PR DESCRIPTION
This allows rotating TLS certificates without downtime. The reason this
change is so small is because OpenSSL already does reference counting of
the SSL context. All that's needed is load the values from the config
again and build a new SSL context that can be used for newly opened
connections. Any existing connections will continue using the old
context, which will get freed automatically when the reference count
hits zero.

Fixes #380 