### PR TITLE
Adding a information in a log about a link of client and server at a moment of a connect.

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -677,6 +677,8 @@ bool find_server(PgSocket *client)
 		client->link = server;
 		server->link = client;
 		change_server_state(server, SV_ACTIVE);
+		slog_info(client, "linked client and server S-%p db=%s user=%s",
+                                   client->link, client->db->name, client->login_user->name);
 		if (varchange) {
 			server->setting_vars = 1;
 			server->ready = 0;


### PR DESCRIPTION
Adding a information in a log about a link of client and server at a moment of a connect.
Will info like:
2020-12-08 19:22:38.655 MSK [5508] LOG C-0x2485130: pg11/postgres@192.168.155.95:45254 login attempt: db=pg11 user=postgres tls=no
2020-12-08 19:22:38.655 MSK [5508] LOG S-0x248c040: pg11/postgres@192.168.155.95:5411 new connection to server (from 192.168.155.95:44568)
**2020-12-08 19:22:44.231 MSK [5508] LOG C-0x2485130: pg11/postgres@192.168.155.95:45254 linked client and server S-0x248c040 db=pg11 user=postgres**