### PR TITLE
Send FATAL when client is disconnected.

### DIFF
--- a/include/proto.h
+++ b/include/proto.h
@@ -40,6 +40,7 @@ struct PktHdr {
 bool get_header(struct MBuf *data, PktHdr *pkt) _MUSTCHECK;
 
 bool send_pooler_error(PgSocket *client, bool send_ready, const char *msg)  /*_MUSTCHECK*/;
+bool send_pooler_fatal(PgSocket *client, bool send_ready, const char *msg)  /*_MUSTCHECK*/;
 void log_server_error(const char *note, PktHdr *pkt);
 void parse_server_error(PktHdr *pkt, const char **level_p, const char **msg_p);
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -934,7 +934,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 		 * don't send Ready pkt here, or client won't notice
 		 * closed connection
 		 */
-		send_pooler_error(client, false, reason);
+		send_pooler_fatal(client, false, reason);
 	}
 
 	free_scram_state(&client->scram_state);

--- a/src/proto.c
+++ b/src/proto.c
@@ -112,7 +112,7 @@ bool get_header(struct MBuf *data, PktHdr *pkt)
 
 
 /*
- * Send error message packet to client.
+ * Send ERROR message packet to client.
  */
 
 bool send_pooler_error(PgSocket *client, bool send_ready, const char *msg)
@@ -126,6 +126,26 @@ bool send_pooler_error(PgSocket *client, bool send_ready, const char *msg)
 	pktbuf_static(&buf, tmpbuf, sizeof(tmpbuf));
 	pktbuf_write_generic(&buf, 'E', "cscscsc",
 			     'S', "ERROR", 'C', "08P01", 'M', msg, 0);
+	if (send_ready)
+		pktbuf_write_ReadyForQuery(&buf);
+	return pktbuf_send_immediate(&buf, client);
+}
+
+/*
+ * Send FATAL message packet to client.
+ */
+
+bool send_pooler_fatal(PgSocket *client, bool send_ready, const char *msg)
+{
+	uint8_t tmpbuf[512];
+	PktBuf buf;
+
+	if (cf_log_pooler_errors)
+		slog_warning(client, "pooler error: %s", msg);
+
+	pktbuf_static(&buf, tmpbuf, sizeof(tmpbuf));
+	pktbuf_write_generic(&buf, 'E', "cscscsc",
+			     'S', "FATAL", 'C', "08P01", 'M', msg, 0);
 	if (send_ready)
 		pktbuf_write_ReadyForQuery(&buf);
 	return pktbuf_send_immediate(&buf, client);


### PR DESCRIPTION
Some drivers do not recognize ERRORs when they are followed by a disconnect.
If drivers receive FATAL - it's prepared for unexpected EOF.