### PR TITLE
Fix crash on loging into the admin database

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -339,7 +339,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 			 * no auth_user is set for the db, see if the
 			 * global auth_user is set and use that.
 			 */
-			if (!client->db->auth_user && cf_auth_user) {
+			if (!client->db->auth_user && cf_auth_user && !client->db->admin) {
 				client->db->auth_user = find_user(cf_auth_user);
 				if (!client->db->auth_user)
 					client->db->auth_user = add_user(cf_auth_user, "");


### PR DESCRIPTION
The admin database is restricted, the global auth_user setting does not apply to it.
Not doing so crashes pgbouncer when an unknown user logs in to the admin db.

fix #568 