### PR TITLE
Authentication for admin database

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,3 +32,4 @@ on_failure:
   - set HOME=.
   - sh -l -c "test -f config.status || cat config.log"
   - sh -l -c "find test/ -name '*.log' | xargs tail -n40 -v"
+  - ls -l / && ls -l /tmp

--- a/doc/config.md
+++ b/doc/config.md
@@ -141,6 +141,14 @@ is used, it needs to be installed into each database.
 
 Default: `SELECT usename, passwd FROM pg_shadow WHERE usename=$1`
 
+### default_auth_db
+
+Default database to connect to for authentication purposes. Used for
+authentication of `stats_users` connecting to admin database.
+
+Default: `postgres`
+
+
 ### auth_user
 
 If `auth_user` is set, then any user not specified in `auth_file` will be

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -122,6 +122,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; must have 2 columns - username and password hash.
 ;auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1
 
+;; Default database to connect to for authentication purposes. Used for
+;; authentication of stats_users connecting to admin database.
+;default_auth_db = postgres
+
 ;;;
 ;;; Users allowed into database 'pgbouncer'
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -498,6 +498,7 @@ extern int cf_auth_type;
 extern char *cf_auth_file;
 extern char *cf_auth_query;
 extern char *cf_auth_user;
+extern char *cf_default_auth_db;
 extern char *cf_auth_hba_file;
 
 extern char *cf_pidfile;

--- a/src/main.c
+++ b/src/main.c
@@ -106,6 +106,7 @@ char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_user;
 char *cf_auth_query;
+char *cf_default_auth_db;
 
 int cf_max_client_conn;
 int cf_default_pool_size;
@@ -223,6 +224,7 @@ CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"
 CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
+CF_ABS("default_auth_db", CF_STR, cf_default_auth_db, 0, "postgres"),
 CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),
@@ -815,6 +817,7 @@ static void cleanup(void)
 	xfree(&cf_auth_file);
 	xfree(&cf_auth_hba_file);
 	xfree(&cf_auth_query);
+	xfree(&cf_default_auth_db);
 	xfree(&cf_auth_user);
 	xfree(&cf_server_reset_query);
 	xfree(&cf_server_check_query);


### PR DESCRIPTION
Hi,

From what I understand, if `stats_users` specified in configuration, it needs
to be present in `auth_file` to be able to connect to the admin db. This is the
case even if `stats_users` could be authenticated via `auth_user` +
`auth_query` for all other "regular" databases. Looks like it happens because
the admin db is a special "fake" database without an `auth_user`. If pgbouncer
would be able to authenticate `stats_users` connecting to the admin db using
`auth_query` as well, this will be helpful because one doesn't need to maintain
another set of credentials for a monitoring user.

From the first glance there are just few bits missing to implement this. E.g. a
`default_auth_db` to connect to for authentication purposes in case of admin
db. Does this implementation make sense?

This idea also partially intersects with #569, but instead of restricting this
patch for admin databases it handles them differently.