### PR TITLE
Set minimum pool size per database

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -932,6 +932,11 @@ Override of the global `auth_user` setting, if specified.
 Set the maximum size of pools for this database.  If not set,
 the `default_pool_size` is used.
 
+### min_pool_size
+
+Set the minimum pool size for this database. If not set, the `min_pool_size` is
+used.
+
 ### reserve_pool
 
 Set additional connections for this database. If not set, `reserve_pool_size` is

--- a/doc/config.md
+++ b/doc/config.md
@@ -934,7 +934,7 @@ the `default_pool_size` is used.
 
 ### min_pool_size
 
-Set the minimum pool size for this database. If not set, the `min_pool_size` is
+Set the minimum pool size for this database. If not set, the global `min_pool_size` is
 used.
 
 ### reserve_pool

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -464,6 +464,9 @@ force_user
 pool_size
 :   Maximum number of server connections.
 
+min_pool_size
+:   Minimum number of server connections.
+
 reserve_pool
 :   Maximum number of additional connections for this database.
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -343,6 +343,7 @@ struct PgDatabase {
 	int port;
 
 	int pool_size;		/* max server connections in one pool */
+	int min_pool_size;	/* min server connections in one pool */
 	int res_pool_size;	/* additional server connections in case of trouble */
 	int pool_mode;		/* pool mode for this database */
 	int max_db_connections;	/* max server connections between all pools */

--- a/src/admin.c
+++ b/src/admin.c
@@ -492,9 +492,9 @@ static bool admin_show_databases(PgSocket *admin, const char *arg)
 		return true;
 	}
 
-	pktbuf_write_RowDescription(buf, "ssissiisiiii",
+	pktbuf_write_RowDescription(buf, "ssissiiisiiii",
 				    "name", "host", "port",
-				    "database", "force_user", "pool_size", "reserve_pool",
+				    "database", "force_user", "pool_size", "min_pool_size", "reserve_pool",
 				    "pool_mode", "max_connections", "current_connections", "paused", "disabled");
 	statlist_for_each(item, &database_list) {
 		db = container_of(item, PgDatabase, head);
@@ -504,10 +504,11 @@ static bool admin_show_databases(PgSocket *admin, const char *arg)
 		cv.value_p = &db->pool_mode;
 		if (db->pool_mode != POOL_INHERIT)
 			pool_mode_str = cf_get_lookup(&cv);
-		pktbuf_write_DataRow(buf, "ssissiisiiii",
+		pktbuf_write_DataRow(buf, "ssissiiisiiii",
 				     db->name, db->host, db->port,
 				     db->dbname, f_user,
 				     db->pool_size,
+					 db->min_pool_size,
 				     db->res_pool_size,
 				     pool_mode_str,
 				     database_max_connections(db),

--- a/src/admin.c
+++ b/src/admin.c
@@ -508,7 +508,7 @@ static bool admin_show_databases(PgSocket *admin, const char *arg)
 				     db->name, db->host, db->port,
 				     db->dbname, f_user,
 				     db->pool_size,
-					 db->min_pool_size,
+				     db->min_pool_size,
 				     db->res_pool_size,
 				     pool_mode_str,
 				     database_max_connections(db),

--- a/src/loader.c
+++ b/src/loader.c
@@ -178,6 +178,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	PgDatabase *db;
 	struct CfValue cv;
 	int pool_size = -1;
+	int min_pool_size = -1;
 	int res_pool_size = -1;
 	int max_db_connections = -1;
 	int dbname_ofs;
@@ -240,6 +241,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			timezone = val;
 		} else if (strcmp("pool_size", key) == 0) {
 			pool_size = atoi(val);
+		} else if (strcmp("min_pool_size", key) == 0) {
+			min_pool_size = atoi(val);
 		} else if (strcmp("reserve_pool", key) == 0) {
 			res_pool_size = atoi(val);
 		} else if (strcmp("max_db_connections", key) == 0) {
@@ -319,6 +322,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 
 	/* if pool_size < 0 it will be set later */
 	db->pool_size = pool_size;
+	db->min_pool_size = min_pool_size;
 	db->res_pool_size = res_pool_size;
 	db->pool_mode = pool_mode;
 	db->max_db_connections = max_db_connections;

--- a/src/objects.c
+++ b/src/objects.c
@@ -358,6 +358,8 @@ PgDatabase *register_auto_database(const char *name)
 		/* do not forget to check pool_size like in config_postprocess */
 		if (db->pool_size < 0)
 			db->pool_size = cf_default_pool_size;
+		if (db->min_pool_size < 0)
+			db->min_pool_size = cf_min_pool_size;
 		if (db->res_pool_size < 0)
 			db->res_pool_size = cf_res_pool_size;
 	}


### PR DESCRIPTION
This feature allows to set min_pool_size per database. The current
behavior uses the same min_pool_size setting for all databases. It could
not be suitable for some databases that has a different access pattern.

Let's say one database need a minimum number of connections to handle a
burst of connections in order to not increase the response time.
However, the other databases doesn't need such requirement. Hence, this
feature reduces the number of connections open by pgbouncer.

Closes #91