### PR TITLE
Add query_db_wait_timeout configuration option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -728,6 +728,20 @@ If this is disabled, clients will be queued indefinitely.
 
 Default: 120
 
+### query_db_wait_timeout
+
+Maximum time queries are allowed to spend waiting for execution while the underlying
+database is inaccessible. If the query is not assigned to a server during this time
+and pgbouncer is unable to connect to the underlying database, the client is disconnected.
+This is used to prevent unresponsive servers from grabbing up connections. This is effectively
+a relaxed form of `query_wait_timeout`, i.e. if `query_wait_timeout < query_db_wait_timeout`,
+this parameter will have no effect.[seconds]
+
+This is intended to be used in situations where fast-failure is desired when the database is
+down, but some degree of regular connection queueing is expected.
+
+Default: 0 (disabled)
+
 ### client_idle_timeout
 
 Client connections idling longer than this many seconds are closed. This should

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -252,9 +252,15 @@ auth_file = /etc/pgbouncer/userlist.txt
 
 ;; Dangerous.  Client connection is closed if the query is not
 ;; assigned to a server in this time.  Should be used to limit the
-;; number of queued queries in case of a database or network
+;; number of queued queries in case of congestion/query contention.
 ;; failure. (default: 120)
 ;query_wait_timeout = 120
+
+;; Dangerous.  Client connection is closed if the query is not
+;; assigned to a server in this time, and the underying database is
+;; inaccessible.  Should be used to limit the number of queued queries
+;; in case of a database or network failure. (default: 0 - disabled)
+;query_db_wait_timeout = 120
 
 ;; Dangerous.  Client connection is closed if no activity in this
 ;; time.  Should be used to survive network problems. (default: 0)

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -484,6 +484,7 @@ extern usec_t cf_server_connect_timeout;
 extern usec_t cf_server_login_retry;
 extern usec_t cf_query_timeout;
 extern usec_t cf_query_wait_timeout;
+extern usec_t cf_query_db_wait_timeout;
 extern usec_t cf_client_idle_timeout;
 extern usec_t cf_client_login_timeout;
 extern usec_t cf_idle_transaction_timeout;

--- a/include/objects.h
+++ b/include/objects.h
@@ -38,6 +38,7 @@ bool evict_user_connection(PgUser *user)	_MUSTCHECK;
 bool find_server(PgSocket *client)		_MUSTCHECK;
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;
 bool finish_client_login(PgSocket *client)	_MUSTCHECK;
+bool is_pool_failing(PgPool *pool)	_MUSTCHECK;
 bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -400,6 +400,8 @@ static void pool_client_maint(PgPool *pool)
 				disconnect_client(client, true, "query_timeout");
 			} else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
+			} else if (cf_query_db_wait_timeout && age > cf_query_db_wait_timeout && is_pool_failing(client->pool)) {
+				disconnect_client(client, true, "query_db_availability_timeout");
 			}
 		}
 	}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -400,8 +400,8 @@ static void pool_client_maint(PgPool *pool)
 				disconnect_client(client, true, "query_timeout");
 			} else if (cf_query_wait_timeout > 0 && age > cf_query_wait_timeout) {
 				disconnect_client(client, true, "query_wait_timeout");
-			} else if (cf_query_db_wait_timeout && age > cf_query_db_wait_timeout && is_pool_failing(client->pool)) {
-				disconnect_client(client, true, "query_db_availability_timeout");
+			} else if (cf_query_db_wait_timeout > 0 && age > cf_query_db_wait_timeout && is_pool_failing(client->pool)) {
+				disconnect_client(client, true, "query_db_wait_timeout");
 			}
 		}
 	}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -385,7 +385,7 @@ static void pool_client_maint(PgPool *pool)
 	}
 
 	/* force timeouts for waiting queries */
-	if (cf_query_timeout > 0 || cf_query_wait_timeout > 0) {
+	if (cf_query_timeout > 0 || cf_query_wait_timeout > 0 || cf_query_db_wait_timeout > 0) {
 		statlist_for_each_safe(item, &pool->waiting_client_list, tmp) {
 			client = container_of(item, PgSocket, head);
 			Assert(client->state == CL_WAITING || client->state == CL_WAITING_LOGIN);

--- a/src/main.c
+++ b/src/main.c
@@ -139,6 +139,7 @@ usec_t cf_server_idle_timeout;
 usec_t cf_server_connect_timeout;
 usec_t cf_server_login_retry;
 usec_t cf_query_timeout;
+usec_t cf_query_db_wait_timeout;
 usec_t cf_query_wait_timeout;
 usec_t cf_client_idle_timeout;
 usec_t cf_client_login_timeout;
@@ -262,6 +263,7 @@ CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
 CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
 CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
 CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
+CF_ABS("query_db_wait_timeout", CF_TIME_USEC, cf_query_db_wait_timeout, 0, "0"),
 CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
 CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),


### PR DESCRIPTION
Hello PgBouncer team. I'd like feedback on a new configuration field. This adds a parameter (`query_db_wait_timeout`) to address the problem described in in #585.

Setting `query_db_wait_timeout` to a nonzero value will disconnect a client if the following two things are true:
1. It's been waiting to be assigned a server connection for longer than query_db_wait_timeout
2. The underlying pool is detected to be in a fast-failure state, as determined by existing logic for fast failing new connections.

Note that this does not require the pool to have been in a fast failure state for `query_db_wait_timeout` seconds, just that the client has been waiting and the pool is currently in a broken state when the bookkeeping occurs.

Thanks in advance.