### PR TITLE
Fix a crash when connection to pgbouncer database

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -498,6 +498,7 @@ static void handle_sighup(int sock, short flags, void *arg)
 	log_info("got SIGHUP, re-reading config");
 	sd_notify(0, "RELOADING=1");
 	load_config();
+	admin_setup();
 	sd_notify(0, "READY=1");
 }
 #endif


### PR DESCRIPTION
PgBouncer crashes if you have 'pgbouncer' as a pool (which is not
recommended) and reload the configuration. The initialization code path
calls admin_setup() to setup the 'pgbouncer' pool. However, when you
reload it tries to setup all databases in the databases section (in this
case, it changes the 'pgbouncer' pool too) but the problem is that
'pgbouncer' pool needs special bits (welcome_msg_ready) to work
accordingly. The fix is simple: admin_setup() must be called after
reloading the configuration.

Closes #134