### PR TITLE
Skip special database pgbouncer

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -885,6 +885,9 @@ Such automatically created database entries are cleaned up
 if they stay idle longer than the time specified by the `autodb_idle_timeout`
 parameter.
 
+The special database **pgbouncer** is reserved. An error will be reported if
+you include it here.
+
 ### dbname
 
 Destination database name.

--- a/src/loader.c
+++ b/src/loader.c
@@ -201,6 +201,12 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	cv.value_p = &pool_mode;
 	cv.extra = (const void *)pool_mode_map;
 
+	/* pgbouncer pool is set by admin_setup() */
+	if (strcmp(name, "pgbouncer") == 0) {
+		log_error("database %s is reserved", name);
+		return true;
+	}
+
 	if (strcmp(name, "*") == 0) {
 		set_autodb(connstr);
 		return true;


### PR DESCRIPTION
If the user set "pgbouncer" as a database in the "databases" section,
skip it. This database entry is created by admin_setup() with certain
options. I also added a note saying so.

This is related to issue #134