### PR TITLE
SHOW STATE command

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -616,6 +616,9 @@ count
 
 Show the PgBouncer version string.
 
+#### SHOW STATE
+
+Show the PgBouncer state settings. Current states are active, paused and suspended.
 
 ### Process controlling commands
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -362,7 +362,7 @@ test_help() {
 # commands don't completely die.  The output can be manually eyeballed
 # in the test log file.
 test_show() {
-	for what in clients config databases fds help lists pools servers sockets active_sockets stats stats_totals stats_averages users totals mem dns_hosts dns_zones; do
+	for what in clients config databases fds help lists pools servers sockets active_sockets stats stats_totals stats_averages users totals mem dns_hosts dns_zones state; do
 		    echo "=> show $what;"
 		    psql -X -h $BOUNCER_ADMIN_HOST -U pgbouncer -d pgbouncer -c "show $what;" || return 1
 	done


### PR DESCRIPTION
This new command exposes the current PgBouncer state which can be:
active, pause or suspend (see PauseMode). Although it is possible to
obtain this state looking at SHOW DATABASES, you have to process
multiple entries to discover the global state; it seems a fragile
solution. PgBouncer has an internal variable that knows the current
state so let's expose it.

Closes #528