### PR TITLE
Include number of query cancellations into SHOW POOLS

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -365,6 +365,9 @@ cl_active
 cl_waiting
 :   Client connections that have sent queries but have not yet got a server connection.
 
+cl_cancel_req
+:   Client connections that have not forwarded query cancellations to the server yet.
+
 sv_active
 :   Server connections that are linked to a client.
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -810,9 +810,10 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		admin_error(admin, "no mem");
 		return true;
 	}
-	pktbuf_write_RowDescription(buf, "ssiiiiiiiiis",
+	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiis",
 				    "database", "user",
 				    "cl_active", "cl_waiting",
+					"cl_cancel_req",
 				    "sv_active", "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
@@ -822,10 +823,11 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		waiter = first_socket(&pool->waiting_client_list);
 		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
 		pool_mode = pool_pool_mode(pool);
-		pktbuf_write_DataRow(buf, "ssiiiiiiiiis",
+		pktbuf_write_DataRow(buf, "ssiiiiiiiiiis",
 				     pool->db->name, pool->user->name,
 				     statlist_count(&pool->active_client_list),
 				     statlist_count(&pool->waiting_client_list),
+				     statlist_count(&pool->cancel_req_list),
 				     statlist_count(&pool->active_server_list),
 				     statlist_count(&pool->idle_server_list),
 				     statlist_count(&pool->used_server_list),

--- a/src/admin.c
+++ b/src/admin.c
@@ -813,7 +813,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiis",
 				    "database", "user",
 				    "cl_active", "cl_waiting",
-					"cl_cancel_req",
+				    "cl_cancel_req",
 				    "sv_active", "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",


### PR DESCRIPTION
This commit includes a new metricto SHOW POOLS command: cl_cancel_req.
It informs the number of clients that request query cancellations.