### PR TITLE
Use true and false for bool constants consistently

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -274,10 +274,10 @@ struct PgPool {
 
 	/* if last connect to server failed, there should be delay before next */
 	usec_t last_connect_time;
-	unsigned last_connect_failed:1;
-	unsigned last_login_failed:1;
+	bool last_connect_failed:1;
+	bool last_login_failed:1;
 
-	unsigned welcome_msg_ready:1;
+	bool welcome_msg_ready:1;
 };
 
 #define pool_connected_server_count(pool) ( \

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -31,9 +31,9 @@ struct PktBuf {
 	struct event *ev;
 	PgSocket *queued_dst;
 
-	unsigned failed:1;
-	unsigned sending:1;
-	unsigned fixed_buf:1;
+	bool failed:1;
+	bool sending:1;
+	bool fixed_buf:1;
 };
 
 /*

--- a/src/client.c
+++ b/src/client.c
@@ -113,7 +113,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 		disconnect_client(client, true, "pause failed");
 		return;
 	}
-	client->link->ready = 0;
+	client->link->ready = false;
 
 	res = 0;
 	buf = pktbuf_dynamic(512);

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -754,7 +754,7 @@ struct XaresMeta {
 
 	/* If dns events happened during event loop,
 	   timer may need recalibration. */
-	int got_events;
+	bool got_events;
 
 };
 
@@ -772,8 +772,8 @@ static void xares_timer_cb(int sock, short flags, void *arg)
 
 	ares_process_fd(meta->chan, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
 
-	meta->timer_active = 0;
-	meta->got_events = 1;
+	meta->timer_active = false;
+	meta->got_events = true;
 }
 
 /* called by libevent on fd event */
@@ -787,7 +787,7 @@ static void xares_fd_cb(int sock, short flags, void *arg)
 	w = (flags & EV_WRITE) ? xfd->sock : ARES_SOCKET_BAD;
 	ares_process_fd(meta->chan, r, w);
 
-	meta->got_events = 1;
+	meta->got_events = true;
 }
 
 /* called by c-ares on new socket creation */
@@ -815,7 +815,7 @@ static int xares_new_socket_cb(ares_socket_t sock, int sock_type, void *arg)
 	xfd->meta = meta;
 	xfd->sock = sock;
 	xfd->wait = 0;
-	xfd->in_use = 1;
+	xfd->in_use = true;
 	return ARES_SUCCESS;
 }
 
@@ -861,7 +861,7 @@ re_set:
 		if (event_add(&xfd->ev, NULL) < 0)
 			log_warning("adns: event_add failed: %s", strerror(errno));
 	} else {
-		xfd->in_use = 0;
+		xfd->in_use = false;
 	}
 	return;
 }
@@ -905,7 +905,7 @@ static void impl_launch_query(struct DNSRequest *req)
 	log_noise("dns: ares_gethostbyname(%s)", req->name);
 	ares_gethostbyname(meta->chan, req->name, af, xares_host_cb, req);
 
-	meta->got_events = 1;
+	meta->got_events = true;
 }
 
 /* re-set timer if any dns event happened */
@@ -929,7 +929,7 @@ static void impl_per_loop(struct DNSContext *ctx)
 		meta->timer_active = true;
 	}
 
-	meta->got_events = 0;
+	meta->got_events = false;
 }
 
 /* c-ares setup */
@@ -1155,7 +1155,7 @@ static void xares_soa_cb(void *arg, int status, int timeouts,
 	struct XaresMeta *meta = ctx->edns;
 	struct ares_soa_reply *soa = NULL;
 
-	meta->got_events = 1;
+	meta->got_events = true;
 
 	log_noise("ares SOA result: %s", ares_strerror(status));
 	if (status != ARES_SUCCESS) {
@@ -1183,7 +1183,7 @@ static int impl_query_soa_serial(struct DNSContext *ctx, const char *zonename)
 	ares_search(meta->chan, zonename, ns_c_in, ns_t_soa,
 		    xares_soa_cb, ctx);
 
-	meta->got_events = 1;
+	meta->got_events = true;
 	return 0;
 }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -285,9 +285,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	}
 
 	/* tag the db as alive */
-	db->db_dead = 0;
+	db->db_dead = false;
 	/* assuming not an autodb */
-	db->db_auto = 0;
+	db->db_auto = false;
 	db->inactive_time = 0;
 
 	/* if updating old db, check if anything changed */

--- a/src/pam.c
+++ b/src/pam.c
@@ -148,7 +148,7 @@ void pam_auth_begin(PgSocket *client, const char *passwd)
 		"pam_auth_begin(): pam_first_taken_slot=%d, pam_first_free_slot=%d",
 		pam_first_taken_slot, pam_first_free_slot);
 
-	client->wait_for_auth = 1;
+	client->wait_for_auth = true;
 
 	/* Check that we have free slots in the queue, and if no
 	 * then block until one is available.

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -69,11 +69,11 @@ PktBuf *pktbuf_dynamic(int start_len)
 
 void pktbuf_reset(struct PktBuf *pkt)
 {
-	pkt->failed = 0;
+	pkt->failed = false;
 	pkt->write_pos = 0;
 	pkt->pktlen_pos = 0;
 	pkt->send_pos = 0;
-	pkt->sending = 0;
+	pkt->sending = false;
 }
 
 void pktbuf_static(PktBuf *buf, uint8_t *data, int len)
@@ -81,7 +81,7 @@ void pktbuf_static(PktBuf *buf, uint8_t *data, int len)
 	memset(buf, 0, sizeof(*buf));
 	buf->buf = data;
 	buf->buf_len = len;
-	buf->fixed_buf = 1;
+	buf->fixed_buf = true;
 }
 
 static PktBuf *temp_pktbuf;
@@ -162,7 +162,7 @@ bool pktbuf_send_queued(PktBuf *buf, PgSocket *sk)
 		pktbuf_free(buf);
 		return send_pooler_error(sk, true, "result prepare failed");
 	} else {
-		buf->sending = 1;
+		buf->sending = true;
 		buf->queued_dst = sk;
 		pktbuf_send_func(sk->sbuf.sock, EV_WRITE, buf);
 		return true;
@@ -182,7 +182,7 @@ static void make_room(PktBuf *buf, int len)
 		return;
 
 	if (buf->fixed_buf) {
-		buf->failed = 1;
+		buf->failed = true;
 		return;
 	}
 
@@ -193,7 +193,7 @@ static void make_room(PktBuf *buf, int len)
 		  buf, len, newlen);
 	ptr = realloc(buf->buf, newlen);
 	if (!ptr) {
-		buf->failed = 1;
+		buf->failed = true;
 	} else {
 		buf->buf = ptr;
 		buf->buf_len = newlen;

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -509,12 +509,12 @@ void pooler_setup(void)
 		}
 	} else {
 		bool ok;
-		static int init_done = 0;
+		static bool init_done = false;
 
 		if (!init_done) {
 			/* remove socket on shutdown */
 			atexit(cleanup_sockets);
-			init_done = 1;
+			init_done = true;
 		}
 
 		ok = parse_word_list(cf_listen_addr, parse_addr, NULL);

--- a/src/proto.c
+++ b/src/proto.c
@@ -205,7 +205,7 @@ void finish_welcome_msg(PgSocket *server)
 	PgPool *pool = server->pool;
 	if (pool->welcome_msg_ready)
 		return;
-	pool->welcome_msg_ready = 1;
+	pool->welcome_msg_ready = true;
 }
 
 bool welcome_client(PgSocket *client)

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -122,7 +122,7 @@ static void disconnect(DbConn *db, bool is_err, const char *reason, ...)
 		log_debug("disconnect because: %s", buf);
 		PQfinish(db->con);
 		db->con = NULL;
-		db->logged_in = 0;
+		db->logged_in = false;
 		set_idle(db);
 	}
 }
@@ -304,7 +304,7 @@ static void connect_cb(int sock, short flags, void *arg)
 	case PGRES_POLLING_OK:
 		log_debug("login ok: fd=%d", PQsocket(db->con));
 		LoginOkCount++;
-		db->logged_in = 1;
+		db->logged_in = true;
 		send_query(db);
 		break;
 	default:
@@ -315,7 +315,7 @@ static void connect_cb(int sock, short flags, void *arg)
 static void launch_connect(DbConn *db)
 {
 	/* launch new connection */
-	db->logged_in = 0;
+	db->logged_in = false;
 	db->query_count = 0;
 	db->con = PQconnectStart(db->connstr);
 	if (db->con == NULL) {


### PR DESCRIPTION
Some code was using 0 and 1, although most newer code seems to prefer
true and false.

Also, turn the declaration of some variables from integer to bool if
they are actually used as Booleans.