### PR TITLE
c-ares on Windows

### DIFF
--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -33,7 +33,11 @@
 #ifdef USE_CARES
 #include <ares.h>
 #include <ares_dns.h>
+#ifndef WIN32
 #include <arpa/nameser.h>
+#else
+#include <nameser.h>
+#endif
 #define ZONE_RECHECK 1
 #else
 /* only c-ares requires this */

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -765,7 +765,7 @@ const char *adns_get_backend(void)
 
 
 /* called by libevent on timer timeout */
-static void xares_timer_cb(int sock, short flags, void *arg)
+static void xares_timer_cb(evutil_socket_t sock, short flags, void *arg)
 {
 	struct DNSContext *ctx = arg;
 	struct XaresMeta *meta = ctx->edns;
@@ -777,7 +777,7 @@ static void xares_timer_cb(int sock, short flags, void *arg)
 }
 
 /* called by libevent on fd event */
-static void xares_fd_cb(int sock, short flags, void *arg)
+static void xares_fd_cb(evutil_socket_t sock, short flags, void *arg)
 {
 	struct XaresFD *xfd = arg;
 	struct XaresMeta *meta = xfd->meta;


### PR DESCRIPTION
This PR fixes the Windows build with `--with-cares`.