### PR TITLE
Tighten error handling of database and user parameters

### DIFF
--- a/include/loader.h
+++ b/include/loader.h
@@ -17,9 +17,9 @@
  */
 
 /* connstring parsing */
-bool parse_database(void *base, const char *name, const char *connstr);
+bool parse_database(void *base, const char *name, const char *connstr) _MUSTCHECK;
 
-bool parse_user(void *base, const char *name, const char *params);
+bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
 
 /* user file parsing */
 bool load_auth_file(const char *fn)  /* _MUSTCHECK */;

--- a/src/objects.c
+++ b/src/objects.c
@@ -350,7 +350,8 @@ PgDatabase *register_auto_database(const char *name)
 	if (!cf_autodb_connstr)
 		return NULL;
 
-	parse_database(NULL, name, cf_autodb_connstr);
+	if (!parse_database(NULL, name, cf_autodb_connstr))
+		return NULL;
 
 	db = find_database(name);
 	if (db) {


### PR DESCRIPTION
The previous code did error checking on the database connection string and user settings in the `[database]` and `[user]` sections, but `parse_database()` and `parse_user()` still returned true in case of error, so these errors were just logged and nothing else happened.  By returning false, we get the normal behavior for parsing the configuration file: on startup, you get a fatal error, on reload, you just get messages.  This also requires polishing the error messages a bit, since some of them were talking about "skipping" invalid settings, which isn't what happens anymore.