### PR TITLE
Bump MAX_PASSWORD to support AWS RDS IAM auth

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -133,7 +133,8 @@ extern int cf_sbuf_len;
 #define MAX_DBNAME	64
 #define MAX_USERNAME	64
 /* typical SCRAM-SHA-256 verifier takes at least 133 bytes */
-#define MAX_PASSWORD	160
+/* AWS RDS IAM auth requires up to 476 bytes */
+#define MAX_PASSWORD	512
 
 /*
  * AUTH_* symbols are used for both protocol handling and


### PR DESCRIPTION
# Motivation

We want to use pgbouncer to connect to AWS RDS instances using IAM auth: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html but we need to bump MAX_PASSWORD to make it work

# Explanation

To generate a PGPASSWORD using IAM auth, one can use the AWS CLI:

```
aws rds generate-db-auth-token --hostname XXXXX.czldyizapuwt.us-northeast-1.rds.amazonaws.com --username XXXX
```

This returns a token that contains the hostname, username, and a signature that is used to authenticate the user on the RDS instance. Sadly this is larger than the current supported MAX_PASSWORD of 160 bytes. 

To figure out how large that token can get:

- the longest allowed RDS instance name is 63 bytes (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html)
- the longest postgres user name is also 63 bytes (https://til.hashrocket.com/posts/8f87c65a0a-postgresqls-max-identifier-length-is-63-bytes)
- the current largest aws region name is us-northeast-1
- the largest port number is 65535

This gives us a mean of finding the largest possible password for IAM authentication:

```
aws rds generate-db-auth-token --hostname XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.czldyizapuwt.us-northeast-1.rds.amazonaws.com --username XXXXXXXX
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX --port 65535 | wc
``` 
and that's 476 bytes.

This change bumps the MAX_PASSWORD to 512 based on this and with some extra margin just in case (also a nice round number) 
