### PR TITLE
Unsupported Windows command line options

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -563,6 +563,10 @@ static void go_daemon(void)
 {
 	int pid, fd;
 
+#ifdef WIN32
+	die("option --daemon (-d) is not supported on this platform");
+#endif
+
 	if (!cf_pidfile || !cf_pidfile[0])
 		die("daemon needs pidfile configured");
 

--- a/src/system.c
+++ b/src/system.c
@@ -45,6 +45,10 @@ void change_user(const char *user)
 	const struct passwd *pw;
 	gid_t gset[1];
 
+#ifdef WIN32
+	die("option --user (-u) is not supported on this platform");
+#endif
+
 	/* check for a valid username */
 	pw = getpwnam(user);
 	if (pw == NULL)


### PR DESCRIPTION
Provide suitable FATAL messages for unsupported options on Windows.