### PR TITLE
Required dependency libraries on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ ifeq ($(cares_support),yes)
 dep_win_libs_abs += $(wildcard $(dep_win_dir)/libcares*.dll)
 endif
 dist_bin_DATA = $(dep_win_libs_abs)
+dep_win_libs_rel = $(subst $(dep_win_dir)/,,$(dep_win_libs_abs))
 endif
 
 #
@@ -156,9 +157,9 @@ zip: $(w32zip)
 $(w32zip): pgbouncer.exe pgbevent.dll etc/pgbouncer.ini etc/userlist.txt README.md COPYRIGHT
 	rm -rf $(basename $@)
 	mkdir $(basename $@)
-	cp $^ $(basename $@)
-	$(STRIP) $(addprefix $(basename $@)/,$(filter %.exe %.dll,$(^F)))
-	zip -MM $@ $(addprefix $(basename $@)/,$(filter %.exe %.dll,$(^F)))
+	cp $^ $(dep_win_libs_abs) $(basename $@)
+	$(STRIP) $(addprefix $(basename $@)/,$(filter %.exe,$(^F))) $(addprefix $(basename $@)/,$(filter %.dll,$(dep_win_libs_rel)))
+	zip -MM $@ $(addprefix $(basename $@)/,$(filter %.exe,$(^F))) $(addprefix $(basename $@)/,$(filter %.dll,$(dep_win_libs_rel)))
 # NB: zip -l for text files for end-of-line conversion
 	zip -MM -l $@ $(addprefix $(basename $@)/,$(filter-out %.exe %.dll,$(^F)))
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,21 @@ AM_LANG_RC_SRCEXTS = .rc
 AM_LANG_RC_COMPILE = $(WINDRES) $< -o $@ --include-dir=$(srcdir)/win32
 AM_LANG_RC_LINK = false
 
+# Windows: install required libraries into bin/
+ifeq ($(PORTNAME),win32)
+dep_win_dir = $(shell dirname $(shell which $(CC)))
+dep_win_libs_abs = \
+	$(wildcard \
+	$(dep_win_dir)/libcrypto*.dll \
+	$(dep_win_dir)/libevent*.dll \
+	$(dep_win_dir)/libssl*.dll \
+	$(dep_win_dir)/libwinpthread*.dll )
+ifeq ($(cares_support),yes)
+dep_win_libs_abs += $(wildcard $(dep_win_dir)/libcares*.dll)
+endif
+dist_bin_DATA = $(dep_win_libs_abs)
+endif
+
 #
 # now load antimake
 #

--- a/config.mak.in
+++ b/config.mak.in
@@ -70,5 +70,6 @@ WINDRES = @WINDRES@
 
 enable_debug = @enable_debug@
 tls_support = @tls_support@
+cares_support = @use_cares@
 
 host_cpu = @host_cpu@

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,7 @@ AC_MSG_RESULT([$use_cares])
 if test "$use_cares" = "auto"; then
   PKG_CHECK_MODULES(CARES, [libcares >= 1.6.0], [use_cares=yes], [use_cares=no])
 fi
+AC_SUBST(use_cares)
 
 if test "$use_cares" = "yes"; then
   AC_DEFINE(USE_CARES, 1, [Use c-ares for name resolution.])


### PR DESCRIPTION
This PR contains 2 commits. The first one installs all required libraries for PgBouncer on Windows. It means that when you `make install`, you don't need to copy some dependency libraries from a MinGW directory. The other commit allows `make zip` to include all required libraries into a final zip.