### PR TITLE
Fixed multiple sequential queries logging

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -353,26 +353,46 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 		} else {
 			sbuf_prepare_send(sbuf, &client->sbuf, pkt->len);
 
-			/* every statement (independent or in a transaction) counts as a query */
-			if ((ready || idle_tx) && client->query_start) {
-				usec_t total;
-				total = get_cached_time() - client->query_start;
-				client->query_start = 0;
-				server->pool->stats.query_time += total;
-				slog_debug(client, "query time: %d us", (int)total);
-			} else if ((ready || idle_tx) && !async_response) {
-				slog_warning(client, "FIXME: query end, but query_start == 0");
-			}
+			/*
+			 * Compute query and transaction times
+			 *
+			 * For pipelined overlapping commands, we wait until
+			 * the last command is done (expect_rfq_count==0).
+			 * That means, we count the time that PgBouncer is
+			 * occupied in a query or transaction, not the total
+			 * time that all queries/transactions take
+			 * individually.  For that, we would have to track the
+			 * start time of each query separately in a queue or
+			 * similar, not only per client.
+			 */
+			if (client->expect_rfq_count == 0) {
+				/* every statement (independent or in a transaction) counts as a query */
+				if (ready || idle_tx) {
+					if (client->query_start) {
+						usec_t total;
+						total = get_cached_time() - client->query_start;
+						client->query_start = 0;
+						server->pool->stats.query_time += total;
+						slog_debug(client, "query time: %d us", (int)total);
+					} else if (!async_response) {
+						slog_warning(client, "FIXME: query end, but query_start == 0");
+					}
+				}
 
-			/* statement ending in "idle" ends a transaction */
-			if (ready && client->xact_start) {
-				usec_t total;
-				total = get_cached_time() - client->xact_start;
-				client->xact_start = 0;
-				server->pool->stats.xact_time += total;
-				slog_debug(client, "transaction time: %d us", (int)total);
-			} else if (ready && !async_response) {
-				slog_warning(client, "FIXME: transaction end, but xact_start == 0");
+				/* statement ending in "idle" ends a transaction */
+				if (ready) {
+					if (client->xact_start) {
+						usec_t total;
+						total = get_cached_time() - client->xact_start;
+						client->xact_start = 0;
+						server->pool->stats.xact_time += total;
+						slog_debug(client, "transaction time: %d us", (int)total);
+					} else if (!async_response) {
+						/* XXX This happens during takeover if the new process
+						 * continues a transaction. */
+						slog_warning(client, "FIXME: transaction end, but xact_start == 0");
+					}
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Running multiple queries in a pipelined way would trigger the dreaded
"FIXME: query end, but query_start == 0" log messages because when the
first query finishes, we reset the query_start, and then the return of
the second query gets upset.  To fix that, only compute the time when
all queries in flight have finished.

solution by @vonzshik

closes #39, closes #144, closes #215, closes #277, closes #376, closes #565