### PR TITLE
Use life_over function instead of reimplementing logic

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -39,6 +39,7 @@ bool find_server(PgSocket *client)		_MUSTCHECK;
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;
 bool finish_client_login(PgSocket *client)	_MUSTCHECK;
 bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
+bool life_over(PgSocket *server);
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -423,15 +423,6 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
 	struct List *item, *tmp;
 	usec_t idle, age;
 	PgSocket *server;
-	usec_t lifetime_kill_gap = 0;
-
-	/*
-	 * Calculate the time that disconnects because of server_lifetime
-	 * must be separated.  This avoids the need to re-launch lot
-	 * of connections together.
-	 */
-	if (pool->db->pool_size > 0)
-		lifetime_kill_gap = cf_server_lifetime / pool->db->pool_size;
 
 	/* disconnect idle servers if needed */
 	statlist_for_each_safe(item, slist, tmp) {
@@ -450,7 +441,7 @@ static void check_unused_servers(PgPool *pool, struct StatList *slist, bool idle
 			   && (cf_min_pool_size == 0 || pool_connected_server_count(pool) > cf_min_pool_size)) {
 			disconnect_server(server, true, "server idle timeout");
 		} else if (age >= cf_server_lifetime) {
-			if (pool->last_lifetime_disconnect + lifetime_kill_gap <= now) {
+			if (life_over(server)) {
 				disconnect_server(server, true, "server lifetime over");
 				pool->last_lifetime_disconnect = now;
 			}

--- a/src/objects.c
+++ b/src/objects.c
@@ -719,7 +719,7 @@ static bool reset_on_release(PgSocket *server)
 	return res;
 }
 
-static bool life_over(PgSocket *server)
+bool life_over(PgSocket *server)
 {
 	PgPool *pool = server->pool;
 	usec_t lifetime_kill_gap = 0;


### PR DESCRIPTION
I don't have a bug report to make with this, but it seems like a minor, but worthwhile, cleanup.