### PR TITLE
Fix DNS error treated as success

### DIFF
--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -878,7 +878,7 @@ static void xares_host_cb(void *arg, int status, int timeouts, struct hostent *h
 		got_result_gai(0, res, req);
 	} else {
 		log_debug("DNS lookup failed: %s - %s", req->name, ares_strerror(status));
-		got_result_gai(0, res, req);
+		got_result_gai(1, res, req);
 	}
 }
 


### PR DESCRIPTION
We have a failed DNS lookup, and even log as such at the debug level,
but then instruct the DNS result function that our result status was a
success, meaning we won't log_warning that failure as well as incorrect
update the cached results and ttl.