### PR TITLE
feat: introduce support for the `auth_dbname` option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -148,6 +148,18 @@ is used, it needs to be installed into each database.
 
 Default: `SELECT usename, passwd FROM pg_shadow WHERE usename=$1`
 
+### auth_dbname
+
+Name of the database in the `[databases]` section to be used for
+authentication purposes. This option can be either global or overridden
+in the connection parameters string of a given database (including the
+automated fallback database `*`).
+
+When defined, the authentication query will be run on this database
+via the specified `auth_user` option.
+
+Default: not set
+
 ### auth_user
 
 If `auth_user` is set, then any user not specified in `auth_file` will be

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -5,7 +5,8 @@
 ;; database name = connect string
 ;;
 ;; connect string params:
-;;   dbname= host= port= user= password= auth_user=
+;;   dbname= host= port= user= password=
+;;   auth_user= auth_dbname=
 ;;   client_encoding= datestyle= timezone=
 ;;   pool_size= reserve_pool= max_db_connections=
 ;;   pool_mode= connect_query= application_name=

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -367,6 +367,7 @@ struct PgDatabase {
 	int max_db_connections;	/* max server connections between all pools */
 
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
+	const char *auth_dbname; /* name of the authentication database (if any) */
 
 	/* startup commands to send to server after connect. malloc-ed */
 	char *connect_query;
@@ -516,6 +517,7 @@ extern char *cf_resolv_conf;
 extern int cf_auth_type;
 extern char *cf_auth_file;
 extern char *cf_auth_query;
+extern char *cf_auth_dbname;
 extern char *cf_auth_user;
 extern char *cf_auth_hba_file;
 

--- a/src/main.c
+++ b/src/main.c
@@ -106,6 +106,7 @@ char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_user;
 char *cf_auth_query;
+char *cf_auth_dbname;
 
 int cf_max_client_conn;
 int cf_default_pool_size;
@@ -223,6 +224,7 @@ CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"
 CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
+CF_ABS("auth_dbname", CF_STR, cf_auth_dbname, 0, ""),
 CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),
@@ -825,6 +827,7 @@ static void cleanup(void)
 	xfree(&cf_auth_file);
 	xfree(&cf_auth_hba_file);
 	xfree(&cf_auth_query);
+	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_user);
 	xfree(&cf_server_reset_query);
 	xfree(&cf_server_check_query);

--- a/test/test.ini
+++ b/test/test.ini
@@ -21,6 +21,7 @@ p62= port=6666 host=127.0.0.1 dbname=p6
 p7a= port=6666 host=127.0.0.1 dbname=p7
 p7b= port=6666 host=127.0.0.1 dbname=p7
 p7c= port=6666 host=127.0.0.1 dbname=p7
+pauthz = port=6666 host=127.0.0.1 dbname=p7 auth_user=pswcheck auth_dbname=authdb
 
 authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -854,6 +854,17 @@ test_wait_close() {
 	test $psql_running -ne 0
 }
 
+# test auth_db
+test_auth_db() {
+	$have_getpeereid || return 77
+	admin "set auth_type='md5'"
+	curuser=`psql -X -d "dbname=pauthz user=someuser password=anypasswd" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "someuser" || return 1
+
+	return 0
+}
+
 # test auth_user
 test_auth_user() {
 	$have_getpeereid || return 77
@@ -1291,6 +1302,7 @@ test_show_version
 test_show
 test_server_login_retry
 test_auth_user
+test_auth_db
 test_client_idle_timeout
 test_server_lifetime
 test_server_idle_timeout


### PR DESCRIPTION
Introduce a global or database-specific option (specified in the
connection parameters string) called `auth_dbname` which points
to the name of a database defined in the `[databases]` section
to be reserved for authentication purposes.

If required, the `auth_query` will be run against this database.

By default it is not set. It requires that `auth_user` is set.

Signed-off-by: Gabriele Bartolini <gabriele.bartolini@enterprisedb.com>
Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>