### PR TITLE
Don't evict connections to achieve min_pool_size

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -39,6 +39,7 @@ bool find_server(PgSocket *client)		_MUSTCHECK;
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;
 bool finish_client_login(PgSocket *client)	_MUSTCHECK;
 bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
+bool check_max_connection_limits(PgPool *pool) _MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);

--- a/include/objects.h
+++ b/include/objects.h
@@ -39,7 +39,6 @@ bool find_server(PgSocket *client)		_MUSTCHECK;
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;
 bool finish_client_login(PgSocket *client)	_MUSTCHECK;
 bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
-bool check_max_connection_limits(PgPool *pool) _MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
@@ -56,7 +55,7 @@ PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
 void accept_cancel_request(PgSocket *req);
 void forward_cancel_request(PgSocket *server);
 
-void launch_new_connection(PgPool *pool);
+void launch_new_connection(PgPool *pool, bool evict_if_needed);
 
 bool use_client_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -491,7 +491,8 @@ static void check_pool_size(PgPool *pool)
 	    cur < pool_pool_size(pool) &&
 	    cf_pause_mode == P_NONE &&
 	    cf_reboot == 0 &&
-	    pool_client_count(pool) > 0)
+	    pool_client_count(pool) > 0 &&
+			!check_max_connection_limits(pool))
 	{
 		log_debug("launching new connection to satisfy min_pool_size");
 		launch_new_connection(pool);

--- a/src/objects.c
+++ b/src/objects.c
@@ -612,6 +612,25 @@ bool check_fast_fail(PgSocket *client)
 	return false;
 }
 
+/* Check if the pool's db or user has hit their max connection limits. */
+bool check_max_connection_limits(PgPool *pool) {
+	int max;
+	
+	/* Has the db hit its max connection limit? */
+	max = database_max_connections(pool->db);
+	if (max > 0 && pool->db->connection_count >= max) {
+		return true;
+	}
+
+	/* Has the user hit its max connection limit? */
+	max = user_max_connections(pool->user);
+	if (max > 0 && pool->user->connection_count >= max) {
+		return true;
+	}
+
+	return false;
+}
+
 /* link if found, otherwise put into wait queue */
 bool find_server(PgSocket *client)
 {

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -365,7 +365,7 @@ void takeover_init(void)
 		fatal("no admin pool?");
 
 	log_info("takeover_init: launching connection");
-	launch_new_connection(pool);
+	launch_new_connection(pool, /* evict_if_needed= */ true);
 }
 
 void takeover_login_failed(void)

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,7 +1,7 @@
 [databases]
 p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
 p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
-p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=3
+p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=2
 p1 = port=6666 host=127.0.0.1 dbname=p1 user=bouncer
 p2 = port=6666 host=127.0.0.1 dbname=p0 max_db_connections=4
 p3 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_mode=session
@@ -31,6 +31,7 @@ authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
 
 [users]
 maxedout = max_user_connections=3
+maxedout2 = max_user_connections=2
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,5 +1,7 @@
 [databases]
 p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
+p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
+p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=3
 p1 = port=6666 host=127.0.0.1 dbname=p1 user=bouncer
 p2 = port=6666 host=127.0.0.1 dbname=p0 max_db_connections=4
 p3 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_mode=session

--- a/test/userlist.txt
+++ b/test/userlist.txt
@@ -4,6 +4,7 @@
 "pgbouncer" "fake"
 "pswcheck" "pgbouncer-check"
 "maxedout" ""
+"maxedout2" ""
 
 ;the following pairs of passwords are "foo" and "bar"
 


### PR DESCRIPTION
This should prevent us from evicting older idle connections unnecessarily if the max connection limit for the user or db has been reached.

This should address issue: https://github.com/pgbouncer/pgbouncer/issues/647

I have ran `test/test.sh` and all tests are passing (including two newly added ones).
I have also tested locally reverting the checks I added to janitor and verified that the newly added tests fail.