### PR TITLE
Fail sbuf_send_pending operation if dst socket is closed

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -520,6 +520,7 @@ try_more:
 
 	if (sbuf->dst->sock == 0) {
 		log_error("sbuf_send_pending: no dst sock?");
+		sbuf_call_proto(sbuf, SBUF_EV_SEND_FAILED);
 		return false;
 	}
 


### PR DESCRIPTION
If the dst socket is closed, `sbuf_send_pending` will fail but not mark the operation as failed.

It will then retry repeatedly, consuming a lot of CPU until pgbouncer is restarted.
