### PR TITLE
Add PgBouncer peering support

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -212,6 +212,12 @@ If you need to specify multiple values, use a comma-separated list (e.g.
 
 Default: empty
 
+## peer_id
+The peer id used to identify this pgbouncer process in a group of pgbouncer
+processes that are peered together. When set to 0 pgbouncer peering is disabled
+
+Default: 0
+
 ### disable_pqexec
 
 Disable the Simple Query protocol (PQexec).  Unlike the Extended Query protocol, Simple Query
@@ -402,7 +408,6 @@ Increase verbosity.  Mirrors the "-v" switch on the command line.
 For example, using "-v -v" on the command line is the same as `verbose=2`.
 
 Default: 0
-
 
 ## Console access control
 
@@ -852,6 +857,10 @@ at least `unix_socket_dir` and `pidfile`, as well as `logfile` if that
 is used.  Also note that if you make use of this option, you can no
 longer connect to a specific PgBouncer instance via TCP/IP, which
 might have implications for monitoring and metrics collection.
+
+To make sure query cancellations keep working, you should set up PgBouncer
+peering between the different PgBouncer processes. For details look at docs
+for the `peer_id` configuration option and the `peers` configuration section.
 
 Default: 0
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -425,6 +425,26 @@ maxwait_us
 pool_mode
 :   The pooling mode in use.
 
+#### SHOW PEER_POOLS
+
+A new peer_pool entry is made for each configured peer.
+
+database
+:   ID of the configured peer entry.
+
+cl_active_cancel_req
+:   Client connections that have forwarded query cancellations to the server and
+    are waiting for the server response.
+
+cl_waiting_cancel_req
+:   Client connections that have not forwarded query cancellations to the server yet.
+
+sv_active_cancel
+:   Server connections that are currently forwarding a cancel request.
+
+sv_login
+:   Server connections currently in the process of logging in.
+
 #### SHOW LISTS
 
 Show following internal information, in columns (not rows):
@@ -516,6 +536,20 @@ paused
 
 disabled
 :   1 if this database is currently disabled, else 0.
+
+#### SHOW PEERS
+
+peer_id
+:   ID of the configured peer entry.
+
+host
+:   Host pgbouncer connects to.
+
+port
+:   Port pgbouncer connects to.
+
+pool_size
+:   Maximum number of server connections that can be made to this peer
 
 #### SHOW FDS
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -62,6 +62,10 @@ listen_port = 6432
 ;unix_socket_mode = 0777
 ;unix_socket_group =
 
+;; The peer id used to identify this pgbouncer process in a group of pgbouncer
+;; processes that are peered together. When set to 0 pgbouncer peering is disabled
+;peer_id = 0
+
 ;;;
 ;;; TLS settings for accepting clients
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -197,6 +197,15 @@ extern int cf_sbuf_len;
 /* buffer size for startup noise */
 #define STARTUP_BUF	1024
 
+/*
+ * When peering is enabled we always put a 1 in the last two bits of the cancel
+ * key when sending it to the client. These bits indicate the TTL and thus
+ * allow forwarding the the cancel key 3 times before it is dropped. Triple
+ * forwarding seems enough for any reasonable multi layered load balancing
+ * setup.
+ */
+#define CANCELLATION_TTL_MASK 0x03
+
 
 /*
  * Remote/local address

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -261,7 +261,7 @@ struct PgPool {
 	struct List map_head;			/* entry in user->pool_list */
 
 	PgDatabase *db;			/* corresponding database */
-	PgUser *user;			/* user logged in as */
+	PgUser *user;			/* user logged in as, this field is NULL for peer pools */
 
 	/*
 	 * Clients that are both logged in and where pgbouncer is actively
@@ -441,6 +441,12 @@ struct PgDatabase {
 	char name[MAX_DBNAME];	/* db name for clients */
 
 	/*
+	 * Pgbouncer peer database related settings
+	 */
+	int peer_id;	/* the peer_id of this peer */
+	struct PgPool *pool;		/* the pool of this peer database */
+
+	/*
 	 * configuration
 	 */
 	char *host;		/* host or unix socket name */
@@ -578,6 +584,7 @@ extern char *cf_unix_socket_group;
 extern char *cf_listen_addr;
 extern int cf_listen_port;
 extern int cf_listen_backlog;
+extern int cf_peer_id;
 
 extern int cf_pool_mode;
 extern int cf_max_client_conn;

--- a/include/janitor.h
+++ b/include/janitor.h
@@ -22,4 +22,6 @@ void resume_all(void);
 void per_loop_maint(void);
 bool suspend_socket(PgSocket *sk, bool force)  _MUSTCHECK;
 void kill_pool(PgPool *pool);
+void kill_peer_pool(PgPool *pool);
 void kill_database(PgDatabase *db);
+void kill_peer(PgDatabase *db);

--- a/include/loader.h
+++ b/include/loader.h
@@ -18,6 +18,7 @@
 
 /* connstring parsing */
 bool parse_database(void *base, const char *name, const char *connstr) _MUSTCHECK;
+bool parse_peer(void *base, const char *name, const char *connstr) _MUSTCHECK;
 
 bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
 

--- a/include/objects.h
+++ b/include/objects.h
@@ -19,19 +19,25 @@
 extern struct StatList user_list;
 extern struct AATree user_tree;
 extern struct StatList pool_list;
+extern struct StatList peer_pool_list;
 extern struct StatList database_list;
+extern struct StatList peer_list;
 extern struct StatList autodatabase_idle_list;
 extern struct StatList login_client_list;
 extern struct Slab *client_cache;
 extern struct Slab *server_cache;
 extern struct Slab *db_cache;
+extern struct Slab *peer_cache;
+extern struct Slab *peer_pool_cache;
 extern struct Slab *pool_cache;
 extern struct Slab *user_cache;
 extern struct Slab *iobuf_cache;
 
+PgDatabase *find_peer(int peer_id);
 PgDatabase *find_database(const char *name);
 PgUser *find_user(const char *name);
 PgPool *get_pool(PgDatabase *, PgUser *);
+PgPool *get_peer_pool(PgDatabase *);
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs);
 bool evict_connection(PgDatabase *db)		_MUSTCHECK;
 bool evict_user_connection(PgUser *user)	_MUSTCHECK;
@@ -45,6 +51,7 @@ PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _PRINTF(3, 4);
 
+PgDatabase * add_peer(const char *name, int peer_id) _MUSTCHECK;
 PgDatabase * add_database(const char *name) _MUSTCHECK;
 PgDatabase *register_auto_database(const char *name);
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;

--- a/src/loader.c
+++ b/src/loader.c
@@ -235,6 +235,11 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 		}
 	}
 
+	if (!host) {
+		log_error("host was not provided for peer %d", peer_id);
+		goto fail;
+	}
+
 	peer = add_peer(name, peer_id);
 	if (!peer) {
 		log_error("cannot create peer, no memory?");

--- a/src/objects.c
+++ b/src/objects.c
@@ -1442,6 +1442,18 @@ void launch_new_connection(PgPool *pool, bool evict_if_needed)
 	max = pool_server_count(pool);
 
 	/*
+	 * Peer pools only have a single pool_size.
+	 */
+	if (pool->db->peer_id) {
+		if (max < pool_pool_size(pool))
+			goto force_new;
+
+		log_debug("launch_new_connection: peer pool full (%d >= %d)",
+				max, pool_pool_size(pool));
+		return;
+	}
+
+	/*
 	 * When a cancel request is queued allow connections up to twice the pool
 	 * size.
 	 *

--- a/src/objects.c
+++ b/src/objects.c
@@ -31,6 +31,8 @@
 STATLIST(user_list);
 STATLIST(database_list);
 STATLIST(pool_list);
+STATLIST(peer_list);
+STATLIST(peer_pool_list);
 
 /* All locally defined users (in auth_file) are kept here. */
 struct AATree user_tree;
@@ -53,6 +55,8 @@ STATLIST(login_client_list);
 struct Slab *server_cache;
 struct Slab *client_cache;
 struct Slab *db_cache;
+struct Slab *peer_cache;
+struct Slab *peer_pool_cache;
 struct Slab *pool_cache;
 struct Slab *user_cache;
 struct Slab *iobuf_cache;
@@ -122,9 +126,11 @@ void init_objects(void)
 	aatree_init(&pam_user_tree, user_node_cmp, NULL);
 	user_cache = slab_create("user_cache", sizeof(PgUser), 0, NULL, USUAL_ALLOC);
 	db_cache = slab_create("db_cache", sizeof(PgDatabase), 0, NULL, USUAL_ALLOC);
+	peer_cache = slab_create("db_cache", sizeof(PgDatabase), 0, NULL, USUAL_ALLOC);
+	peer_pool_cache = slab_create("peer_pool_cache", sizeof(PgPool), 0, NULL, USUAL_ALLOC);
 	pool_cache = slab_create("pool_cache", sizeof(PgPool), 0, NULL, USUAL_ALLOC);
 
-	if (!user_cache || !db_cache || !pool_cache)
+	if (!user_cache || !db_cache || !peer_cache || !peer_pool_cache || !pool_cache)
 		fatal("cannot create initial caches");
 }
 
@@ -300,8 +306,25 @@ static int cmp_pool(struct List *i1, struct List *i2)
 	PgPool *p2 = container_of(i2, PgPool, head);
 	if (p1->db != p2->db)
 		return strcmp(p1->db->name, p2->db->name);
-	if (p1->user != p2->user)
+	if (p1->user != p2->user) {
+		if (p1->user == NULL) {
+			return 1;
+		}
+		if (p2->user == NULL) {
+			return -1;
+		}
 		return strcmp(p1->user->name, p2->user->name);
+	}
+	return 0;
+}
+
+/* compare pool names, for use with put_in_order */
+static int cmp_peer_pool(struct List *i1, struct List *i2)
+{
+	PgPool *p1 = container_of(i1, PgPool, head);
+	PgPool *p2 = container_of(i2, PgPool, head);
+	if (p1->db != p2->db)
+		return p1->db->peer_id - p2->db->peer_id;
 	return 0;
 }
 
@@ -312,6 +335,15 @@ static int cmp_user(struct List *i1, struct List *i2)
 	PgUser *u2 = container_of(i2, PgUser, head);
 	return strcmp(u1->name, u2->name);
 }
+
+/* compare db names, for use with put_in_order */
+static int cmp_peer(struct List *i1, struct List *i2)
+{
+	PgDatabase *db1 = container_of(i1, PgDatabase, head);
+	PgDatabase *db2 = container_of(i2, PgDatabase, head);
+	return db1->peer_id - db2->peer_id;
+}
+
 
 /* compare db names, for use with put_in_order */
 static int cmp_database(struct List *i1, struct List *i2)
@@ -338,6 +370,25 @@ static void put_in_order(struct List *newitem, struct StatList *list,
 		}
 	}
 	statlist_append(list, newitem);
+}
+
+/* create new object if new, then return it */
+PgDatabase *add_peer(const char *name, int peer_id)
+{
+	PgDatabase *peer = find_peer(peer_id);
+
+	/* create new object if needed */
+	if (peer == NULL) {
+		peer = slab_alloc(peer_cache);
+		if (!peer)
+			return NULL;
+
+		list_init(&peer->head);
+		peer->peer_id = peer_id;
+		put_in_order(&peer->head, &peer_list, cmp_peer);
+	}
+
+	return peer;
 }
 
 /* create new object if new, then return it */
@@ -475,6 +526,19 @@ PgUser *force_user(PgDatabase *db, const char *name, const char *passwd)
 }
 
 /* find an existing database */
+PgDatabase *find_peer(int peer_id)
+{
+	struct List *item;
+	PgDatabase *peer;
+	statlist_for_each(item, &peer_list) {
+		peer = container_of(item, PgDatabase, head);
+		if (peer->peer_id == peer_id)
+			return peer;
+	}
+	return NULL;
+}
+
+/* find an existing database */
 PgDatabase *find_database(const char *name)
 {
 	struct List *item, *tmp;
@@ -543,6 +607,37 @@ static PgPool *new_pool(PgDatabase *db, PgUser *user)
 	return pool;
 }
 
+
+/*
+ * create new peer pool object
+ *
+ * This pool should only be used to forward cancellations to other pgbouncers
+ * behind the same load balancer. The user field of this pool is NULL, because
+ * cancellations don't need a user.
+ */
+static PgPool *new_peer_pool(PgDatabase *db)
+{
+	PgPool *pool;
+
+	pool = slab_alloc(peer_pool_cache);
+	if (!pool)
+		return NULL;
+
+	list_init(&pool->head);
+	list_init(&pool->map_head);
+
+	pool->db = db;
+
+	statlist_init(&pool->new_server_list, "new_server_list");
+	statlist_init(&pool->waiting_cancel_req_list, "waiting_cancel_req_list");
+	statlist_init(&pool->active_cancel_req_list, "active_cancel_req_list");
+	statlist_init(&pool->active_cancel_server_list, "active_cancel_server_list");
+
+	/* keep pools in db/user order to make stats faster */
+	put_in_order(&pool->head, &peer_pool_list, cmp_peer_pool);
+
+	return pool;
+}
 /* find pool object, create if needed */
 PgPool *get_pool(PgDatabase *db, PgUser *user)
 {
@@ -559,6 +654,17 @@ PgPool *get_pool(PgDatabase *db, PgUser *user)
 	}
 
 	return new_pool(db, user);
+}
+
+/* find pool object for the peer */
+PgPool *get_peer_pool(PgDatabase *db)
+{
+	if (!db)
+		return NULL;
+	if (!db->pool) {
+		db->pool = new_peer_pool(db);
+	}
+	return db->pool;
 }
 
 /* deactivate socket and put into wait queue */
@@ -956,7 +1062,9 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	free_scram_state(&server->scram_state);
 
 	server->pool->db->connection_count--;
-	server->pool->user->connection_count--;
+	if (server->pool->user) {
+		server->pool->user->connection_count--;
+	}
 
 	change_server_state(server, SV_JUSTFREE);
 	if (!sbuf_close(&server->sbuf))
@@ -1381,18 +1489,20 @@ allow_new:
 		}
 	}
 
-	max = user_max_connections(pool->user);
-	if (max > 0) {
-		/* try to evict unused connection first */
-		while (evict_if_needed && pool->user->connection_count >= max) {
-			if (!evict_user_connection(pool->user)) {
-				break;
+	if (pool->user) {
+		max = user_max_connections(pool->user);
+		if (max > 0) {
+			/* try to evict unused connection first */
+			while (evict_if_needed && pool->user->connection_count >= max) {
+				if (!evict_user_connection(pool->user)) {
+					break;
+				}
 			}
-		}
-		if (pool->user->connection_count >= max) {
-			log_debug("launch_new_connection: user '%s' full (%d >= %d)",
-				  pool->user->name, pool->user->connection_count, max);
-			return;
+			if (pool->user->connection_count >= max) {
+				log_debug("launch_new_connection: user '%s' full (%d >= %d)",
+					  pool->user->name, pool->user->connection_count, max);
+				return;
+			}
 		}
 	}
 
@@ -1412,7 +1522,9 @@ force_new:
 	pool->last_connect_time = get_cached_time();
 	change_server_state(server, SV_LOGIN);
 	pool->db->connection_count++;
-	pool->user->connection_count++;
+	if (pool->user) {
+		pool->user->connection_count++;
+	}
 
 	dns_connect(server);
 }
@@ -1497,6 +1609,57 @@ bool finish_client_login(PgSocket *client)
 	return true;
 }
 
+static void accept_cancel_request_for_peer(int peer_id, PgSocket *req) {
+	PgDatabase *peer = NULL;
+	PgPool *pool = NULL;
+	int ttl = req->cancel_key[7] & 0x03;
+
+	if (ttl == 0) {
+		disconnect_client(req, false, "failed to forward cancel request because its TTL was exhausted");
+		return;
+	}
+
+	/*
+	 * Before forwarding the cancel key, we need to decrement the TTL. Now is
+	 * as a good a time to do so. We simply subtract 1 from the last byte,
+	 * since the TTL is stored in the least significant bits.
+	 */
+	req->cancel_key[7]--;
+
+	peer = find_peer(peer_id);
+	if (!peer) {
+		disconnect_client(req, false, "could not find peer to forward request to");
+		return;
+	}
+	log_debug("forwarding cancellation request to peer %d", peer_id);
+
+	/*
+	 * When using peering (multiple pgbouncers behind the same load
+	 * balancer), we may receive cancellation messages that were intended
+	 * for another peer via the load balancer. We propagate the
+	 * cancellation via the peer's pool, instead of the server pool.
+	 */
+	pool = get_peer_pool(peer);
+	if (!pool) {
+		disconnect_client(req, false, "out of memory");
+		return;
+	}
+
+	/*
+	 * Attach to the target pool and change state to waiting_cancel. This way
+	 * once a new connection is opened, it's used to forward the cancel
+	 * request.
+	 */
+	req->pool = pool;
+	change_client_state(req, CL_WAITING_CANCEL);
+
+	/*
+	 * Open a new connection over which the cancel request is forwarded to the
+	 * server.
+	 */
+	launch_new_connection(pool, /* evict_if_needed= */ true);
+}
+
 /*
  * Accepts a cancellation request, which will eventual cancel the query running
  * on the client that matches req->client_key
@@ -1506,8 +1669,33 @@ void accept_cancel_request(PgSocket *req)
 	struct List *pitem, *citem;
 	PgPool *pool = NULL;
 	PgSocket *server = NULL, *client, *main_client = NULL;
+	bool peering_enabled = false;
 
 	Assert(req->state == CL_LOGIN);
+
+	/*
+	 * PgBouncer peering
+	 */
+	peering_enabled = cf_peer_id > 0;
+	if (peering_enabled) {
+		/*
+		 * Extract the peer id from the cancel key
+		 */
+		int peer_id = req->cancel_key[0] + (req->cancel_key[1] << 8);
+		bool needs_forwarding_to_peer = cf_peer_id != peer_id;
+		if (needs_forwarding_to_peer) {
+			accept_cancel_request_for_peer(peer_id, req);
+			return;
+		}
+
+		/*
+		 * Set the last two bits of the cancel key to 1. This is necessary to
+		 * compare the key from the request to our stored cancel keys, because
+		 * those have these TTL bits set to 1.
+		 */
+		req->cancel_key[7] |= 0x03;
+	}
+
 
 	/* find the client that has the same cancel_key as this request */
 	statlist_for_each(pitem, &pool_list) {
@@ -1584,27 +1772,34 @@ bool forward_cancel_request(PgSocket *server)
 {
 	bool res;
 	PgSocket *req = first_socket(&server->pool->waiting_cancel_req_list);
+	bool forwarding_to_peer = server->pool->db->peer_id != 0;
 
 	Assert(req != NULL && req->state == CL_WAITING_CANCEL);
 	Assert(server->state == SV_LOGIN);
 
-	/*
-	 * In between accepting the cancel request and receiving an open connection
-	 * the query that was supposed to be cancelled has now completed. This
-	 * becomes a problem when the server is then reused for some other client.
-	 * Because this will mean that the cancel that is forwarded will cancel a
-	 * query from a completely different client than the client it was intended
-	 * for.
-	 */
-	if (!req->canceled_server) {
-		disconnect_client(req, false, "not sending cancel request for client that is now idle");
-		return false;
+	if (!forwarding_to_peer) {
+		/*
+		 * In between accepting the cancel request and receiving an open connection
+		 * the query that was supposed to be cancelled has now completed. This
+		 * becomes a problem when the server is then reused for some other client.
+		 * Because this will mean that the cancel that is forwarded will cancel a
+		 * query from a completely different client than the client it was intended
+		 * for.
+		 */
+		if (!req->canceled_server) {
+			disconnect_client(req, false, "not sending cancel request for client that is now idle");
+			return false;
+		}
 	}
 
 	server->link = req;
 	req->link = server;
 
-	SEND_CancelRequest(res, server, req->canceled_server->cancel_key);
+	if (forwarding_to_peer) {
+		SEND_CancelRequest(res, server, req->cancel_key);
+	} else {
+		SEND_CancelRequest(res, server, req->canceled_server->cancel_key);
+	}
 	if (!res) {
 		log_warning("sending cancel request failed: %s", strerror(errno));
 		disconnect_client(req, false, "failed to send cancel request");
@@ -1980,6 +2175,10 @@ void objects_cleanup(void)
 		db = container_of(item, PgDatabase, head);
 		kill_database(db);
 	}
+	statlist_for_each_safe(item, &peer_list, tmp) {
+		PgDatabase *peer = container_of(item, PgDatabase, head);
+		kill_peer(peer);
+	}
 
 	memset(&login_client_list, 0, sizeof login_client_list);
 	memset(&user_list, 0, sizeof user_list);
@@ -1994,6 +2193,10 @@ void objects_cleanup(void)
 	client_cache = NULL;
 	slab_destroy(db_cache);
 	db_cache = NULL;
+	slab_destroy(peer_cache);
+	peer_cache = NULL;
+	slab_destroy(peer_pool_cache);
+	peer_pool_cache = NULL;
 	slab_destroy(pool_cache);
 	pool_cache = NULL;
 	slab_destroy(user_cache);

--- a/src/proto.c
+++ b/src/proto.c
@@ -275,16 +275,13 @@ bool welcome_client(PgSocket *client)
 		 * peer id when they receive this cancellation.
 		 */
 		client->cancel_key[0] = cf_peer_id & 0xFF;
-		client->cancel_key[1] = cf_peer_id >> 8;
+		client->cancel_key[1] = (cf_peer_id >> 8) & 0xFF;
 
 		/*
-		 * When sending the key to the client we always store a 1 in the last
-		 * two bits of the cancel key. These bits indicate the TTL and thus
-		 * allow forwarding the the cancel key 3 times before it is dropped.
-		 * Triple forwarding seems enough for any reasonable multi layered load
-		 * balancing setup.
+		 * Initially we set the two TTL mask bits to a 1, so that the cancel
+		 * message can be forwarded to peers up to 3 times.
 		 */
-		client->cancel_key[7] |= 0x03;
+		client->cancel_key[7] |= CANCELLATION_TTL_MASK;
 	}
 
 	pktbuf_write_BackendKeyData(msg, client->cancel_key);

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -14,6 +14,8 @@ def test_show(bouncer):
         # "fds",
         "help",
         "lists",
+        "peers",
+        "peer_pools",
         "pools",
         "servers",
         "sockets",

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -1,0 +1,67 @@
+import pytest
+import asyncio
+import time
+import psycopg
+from typing import Dict
+from concurrent.futures import ThreadPoolExecutor
+from .utils import Bouncer, LINUX
+
+if not LINUX:
+    pytest.skip(allow_module_level=True, reason='peering tests require so_reuseport')
+
+@pytest.mark.asyncio
+@pytest.fixture
+async def peers(pg, tmp_path):
+    peers: Dict[int, Bouncer] = {}
+    peers[1] = Bouncer(pg, tmp_path / "bouncer1")
+
+    peers[2] = Bouncer(pg, tmp_path / "bouncer2", port=peers[1].port)
+
+    peers[3] = Bouncer(pg, tmp_path / "bouncer3", port=peers[1].port)
+
+    for own_index, bouncer in peers.items():
+        with bouncer.ini_path.open("a") as f:
+            f.write('so_reuseport=1\n')
+            f.write(f'peer_id={own_index}\n')
+            f.write("[peers]\n")
+            for other_index, peer in peers.items():
+                if own_index == other_index:
+                    continue
+                f.write(f"{other_index} = host={peer.admin_host} port={peer.port}\n")
+
+    await asyncio.gather(*[p.start() for p in peers.values()])
+
+    yield peers
+
+    await asyncio.gather(*[p.cleanup() for p in peers.values()])
+
+def test_peering_without_own_index(peers):
+    with peers[1].cur() as cur:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            for _ in range(10):
+                query = pool.submit(cur.execute, "select pg_sleep(5)")
+                time.sleep(.5)
+                cancel = pool.submit(cur.connection.cancel)
+                cancel.result()
+                with pytest.raises(
+                    psycopg.errors.QueryCanceled, match="due to user request"
+                ):
+                    query.result()
+
+def test_peering_with_own_index(peers):
+    for own_index, bouncer in peers.items():
+        with bouncer.ini_path.open("a") as f:
+            f.write(f"{own_index} = host={bouncer.admin_host} port={bouncer.port}\n")
+        bouncer.admin('reload')
+
+    with peers[1].cur() as cur:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            for _ in range(10):
+                query = pool.submit(cur.execute, "select pg_sleep(5)")
+                time.sleep(.5)
+                cancel = pool.submit(cur.connection.cancel)
+                cancel.result()
+                with pytest.raises(
+                    psycopg.errors.QueryCanceled, match="due to user request"
+                ):
+                    query.result()

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -1,13 +1,16 @@
-import pytest
 import asyncio
 import time
-import psycopg
-from typing import Dict
 from concurrent.futures import ThreadPoolExecutor
-from .utils import Bouncer, LINUX
+from typing import Dict
+
+import psycopg
+import pytest
+
+from .utils import LINUX, Bouncer
 
 if not LINUX:
-    pytest.skip(allow_module_level=True, reason='peering tests require so_reuseport')
+    pytest.skip(allow_module_level=True, reason="peering tests require so_reuseport")
+
 
 @pytest.mark.asyncio
 @pytest.fixture
@@ -21,8 +24,8 @@ async def peers(pg, tmp_path):
 
     for own_index, bouncer in peers.items():
         with bouncer.ini_path.open("a") as f:
-            f.write('so_reuseport=1\n')
-            f.write(f'peer_id={own_index}\n')
+            f.write("so_reuseport=1\n")
+            f.write(f"peer_id={own_index}\n")
             f.write("[peers]\n")
             for other_index, peer in peers.items():
                 if own_index == other_index:
@@ -35,12 +38,13 @@ async def peers(pg, tmp_path):
 
     await asyncio.gather(*[p.cleanup() for p in peers.values()])
 
+
 def test_peering_without_own_index(peers):
     with peers[1].cur() as cur:
         with ThreadPoolExecutor(max_workers=2) as pool:
             for _ in range(10):
                 query = pool.submit(cur.execute, "select pg_sleep(5)")
-                time.sleep(.5)
+                time.sleep(0.5)
                 cancel = pool.submit(cur.connection.cancel)
                 cancel.result()
                 with pytest.raises(
@@ -48,17 +52,18 @@ def test_peering_without_own_index(peers):
                 ):
                     query.result()
 
+
 def test_peering_with_own_index(peers):
     for own_index, bouncer in peers.items():
         with bouncer.ini_path.open("a") as f:
             f.write(f"{own_index} = host={bouncer.admin_host} port={bouncer.port}\n")
-        bouncer.admin('reload')
+        bouncer.admin("reload")
 
     with peers[1].cur() as cur:
         with ThreadPoolExecutor(max_workers=2) as pool:
             for _ in range(10):
                 query = pool.submit(cur.execute, "select pg_sleep(5)")
-                time.sleep(.5)
+                time.sleep(0.5)
                 cancel = pool.submit(cur.connection.cancel)
                 cancel.result()
                 with pytest.raises(

--- a/test/utils.py
+++ b/test/utils.py
@@ -634,7 +634,7 @@ class Bouncer(QueryRunner):
                 # Linux.
                 self.admin_host = str(self.config_dir)
             else:
-                self.admin_host = '/tmp'
+                self.admin_host = "/tmp"
         else:
             self.admin_host = "127.0.0.1"
 


### PR DESCRIPTION
For both performance and availability reasons it can be useful to load
balance across multiple PgBouncer processes, possibly on different
machines. It's very easy to do, by simply putting a generic TCP load
balancer in front of these pgbouncer processes. The `so_reuseport`
option is an example of such a load balancer, which uses the OS kernel
to do the load balancing.

However, there is a problem with this simple approach. Query
cancellations will not work most of the time. The reason is that a
cancellation will open another TCP connection, which might be handled by
another pgbouncer process than the one that is processing the query that
should be cancelled. I talked about this problem in more detail at
the Uptime conference: https://www.youtube.com/watch?v=M585FfbboNA

This change adds support for pgbouncer peering. To enable peering two
things need to be added to the configuration of each pgbouncer:
1. A peer_id that's unique for each pgbouncer that is peered with
2. A new "peers" section that should get an entry for each of the other
   peers

When pgbouncer is configured like this, then whenever it receives a
cancellation request for an unknown session, it will forward it to the
peer that owns this session.

To configure three pgbouncers in peering mode using `so_reuseport`, you
can use these example configs.

pgbouncer1.ini
```ini
[databases]
postgres = host=localhost dbname=postgres

[pgbouncer]
peer_id=1
pool_mode=transaction
listen_addr=127.0.0.1
auth_type=trust
admin_users=jelte
auth_file=auth_file.conf
so_reuseport=1
unix_socket_dir=/tmp/pgbouncer1

[peers]
2 = host=/tmp/pgbouncer2
3 = host=/tmp/pgbouncer3
```

pgbouncer2.ini
```ini
[databases]
postgres = host=localhost dbname=postgres

[pgbouncer]
peer_id=2
pool_mode=transaction
listen_addr=127.0.0.1
auth_type=trust
admin_users=jelte
auth_file=auth_file.conf
so_reuseport=1
unix_socket_dir=/tmp/pgbouncer2

[peers]
1 = host=/tmp/pgbouncer1
3 = host=/tmp/pgbouncer3
```

pgbouncer3.ini
```ini
[databases]
postgres = host=localhost dbname=postgres

[pgbouncer]
peer_id=3
pool_mode=transaction
listen_addr=127.0.0.1
auth_type=trust
admin_users=jelte
auth_file=auth_file.conf
so_reuseport=1
unix_socket_dir=/tmp/pgbouncer3

[peers]
1 = host=/tmp/pgbouncer1
2 = host=/tmp/pgbouncer2
```

To then try out the cancellation forwarding. Simply run the following in
`psql`:
```sql
select pg_sleep(20);
```

And then press ctrl+c

Related to #345