### PR TITLE
Don't apply fast-fail at connect time

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -222,9 +222,6 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		}
 	}
 
-	if (!check_fast_fail(client))
-		return false;
-
 	if (takeover)
 		return true;
 


### PR DESCRIPTION
As a general principle, we shouldn't expose that kind of information
to clients before they are authenticated.

Also, if SCRAM pass-through is used and the password in auth_file is
updated, server connections will start to fail becaues the ClientKey
and ServerKey are outdated.  In that case, we need to allow new
clients to log in to pgbouncer, since that updates those values.

We could move the check to finish_client_login(), so it happens during
login but after authentication.  But in practice, the check in
find_server() will soon be executed anyway, unless the client just
logs in and does nothing.

This effectively reverts 760760d62b71b773aca6efef8024039501819210.