### PR TITLE
Close connection when check query errors

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -771,6 +771,13 @@ bool release_server(PgSocket *server)
 	case SV_LOGIN:
 		pool->last_login_failed = false;
 		pool->last_connect_failed = false;
+
+        /*
+         * Run check on fresh connection if check_delay is zero
+         */
+        if (cf_server_check_delay == 0 && *cf_server_check_query) {
+            newstate = SV_USED;
+        }
 		break;
 	default:
 		fatal("bad server state: %d", server->state);

--- a/src/server.c
+++ b/src/server.c
@@ -303,6 +303,14 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 	 * it later.
 	 */
 	case 'E':		/* ErrorResponse */
+        if (server->state == SV_TESTED) {
+            /*
+             * Check query returned with an error, so we need to throw this connection away
+             */
+            disconnect_server(server, false, "test query failed");
+            sbuf_prepare_skip(sbuf, pkt->len);
+            return false;
+        }
 		if (server->setting_vars) {
 			/*
 			 * the SET and user query will be different TX
@@ -424,6 +432,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			slog_warning(server,
 				     "got packet '%c' from server when not linked",
 				     pkt_desc(pkt));
+
 		sbuf_prepare_skip(sbuf, pkt->len);
 	}
 


### PR DESCRIPTION
Currently, pgbouncer will ignore errors returned by the check query. This is mostly ok for traditional Postgres, but creates issues when using pgbouncer in front of high availability pg compatible databases (ex: CockroachDB). Essentially, the pooler will hand out broken connections if the database is draining. This change simply closes SV_TESTED connections that receive errors, allowing for seamless failover. Additionally, newly logged in connections are now checked when check delay is set to zero.