### PR TITLE
Fixes segmentation fault caused by SIGINT when running pgbouncer in interactive mode

### DIFF
--- a/src/pooler.c
+++ b/src/pooler.c
@@ -71,7 +71,7 @@ static void cleanup_sockets(void)
 			safe_close(ls->fd);
 			ls->fd = 0;
 		}
-		if (pga_is_unix(&ls->addr) && cf_unix_socket_dir[0] != '@') {
+		if (pga_is_unix(&ls->addr) && cf_unix_socket_dir && cf_unix_socket_dir[0] != '@') {
 			char buf[sizeof(struct sockaddr_un) + 20];
 			snprintf(buf, sizeof(buf), "%s/.s.PGSQL.%d", cf_unix_socket_dir, cf_listen_port);
 			unlink(buf);


### PR DESCRIPTION
Fixes segmentation fault caused by SIGINT when running pgbouncer in interactive mode.

pgbouncer was configured on CentOS7 with the following options:
--enable-cassert --enable-debug --without-doc CFLAGS=-O0 -g3

There are no specific configurations for pgbouncer.ini. The test case is rather simple. To reproduce, you may use the following (or any other configuration for pgbouncer.ini).

```
[databases]
* = host=localhost
[pgbouncer]
listen_port = 6432
listen_addr = *
```

**Run the following commands:**
./pgbouncer pgbouncer.ini
Ctrl + C

Verified on CentOS 7.