### PR TITLE
Mock authentication for missing databases

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -364,6 +364,7 @@ struct PgDatabase {
 	bool db_auto;		/* is the database auto-created by autodb_connstr */
 	bool db_disabled;	/* is the database accepting new connections? */
 	bool admin;		/* internal console db */
+	bool fake;		/* not a real database, only for mock auth */
 	usec_t inactive_time;	/* when auto-database became inactive (to kill it after timeout) */
 	unsigned active_stamp;	/* set if autodb has connections */
 	int connection_count;	/* total connections for this database in all pools */

--- a/src/client.c
+++ b/src/client.c
@@ -195,7 +195,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	bool ok = false;
 	int auth;
 
-	if (!client->login_user->mock_auth) {
+	if (!client->login_user->mock_auth && !client->db->fake) {
 		PgUser *pool_user;
 
 		if (client->db->forced_user)
@@ -285,20 +285,13 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	client->db = find_database(dbname);
 	if (!client->db) {
 		client->db = register_auto_database(dbname);
-		if (!client->db) {
-			disconnect_client(client, true, "no such database: %s", dbname);
-			if (cf_log_connections)
-				slog_info(client, "login failed: db=%s user=%s", dbname, username);
-			return false;
-		} else {
+		if (client->db)
 			slog_info(client, "registered new auto-database: db=%s", dbname);
-		}
 	}
-
-	/* are new connections allowed? */
-	if (client->db->db_disabled) {
-		disconnect_client(client, true, "database \"%s\" is disabled", dbname);
-		return false;
+	if (!client->db) {
+		client->db = calloc(1, sizeof(*client->db));
+		client->db->fake = true;
+		strlcpy(client->db->name, dbname, sizeof(client->db->name));
 	}
 
 	if (client->db->admin) {
@@ -359,12 +352,16 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 					client->db->auth_user = add_user(cf_auth_user, "");
 			}
 			if (client->db->auth_user) {
-				if (takeover) {
-					client->login_user = add_db_user(client->db, username, password);
-					return finish_set_pool(client, takeover);
+				if (client->db->fake)
+					slog_debug(client, "not running auth_query because database is fake");
+				else {
+					if (takeover) {
+						client->login_user = add_db_user(client->db, username, password);
+						return finish_set_pool(client, takeover);
+					}
+					start_auth_query(client, username);
+					return false;
 				}
-				start_auth_query(client, username);
-				return false;
 			}
 
 			slog_info(client, "no such user: %s", username);

--- a/test/test.sh
+++ b/test/test.sh
@@ -1241,8 +1241,7 @@ test_no_database_authfail() {
 	admin "set auth_type='md5'"
 
 	PGPASSWORD=wrong psql -X -d nosuchdb1 -c "select 1" && return 1
-	# TODO: reports missing database without authentication
-	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+	grep -F "closing because: password authentication failed" $BOUNCER_LOG || return 1
 
 	return 0
 }
@@ -1254,8 +1253,7 @@ test_no_database_auth_user() {
 	admin "set auth_user='pswcheck'"
 
 	PGPASSWORD=wrong psql -X -d nosuchdb1 -U someuser -c "select 1" && return 1
-	# TODO: reports missing database without authentication
-	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+	grep "closing because: password authentication failed" $BOUNCER_LOG || return 1
 
 	return 0
 }


### PR DESCRIPTION
On client login, when a database does not exist, don't immediately respond with "no such database", because we don't want hostile clients to be able to probe what databases exist.  Instead, do the authentication first and then respond about the database.

This is similar to 7f7ff12a4288d9ab52154c7229afc0186f8196bb, but for databases.