### PR TITLE
Clarify 'server_lifetime' description

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -489,7 +489,8 @@ Default: 0
 
 ### server_lifetime
 
-The pooler will close an unused server connection that has been connected longer
+The pooler will close an unused (not currently linked to any client connection)
+server connection that has been connected longer
 than this. Setting it to 0 means the connection is to be used only once,
 then closed. [seconds]
 


### PR DESCRIPTION
IMO the "unused" term was a bit confusing.