### PR TITLE
Allow comma-separated host list

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -167,6 +167,8 @@ task:
   name: FreeBSD
   freebsd_instance:
     image_family: freebsd-13-0
+  env:
+    HAVE_IPV6_LOCALHOST: yes
   setup_script:
     - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool pkgconf postgresql12-server python
     - pw useradd user
@@ -193,6 +195,8 @@ task:
   osx_instance:
     matrix:
       - image: monterey-base
+  env:
+    HAVE_IPV6_LOCALHOST: yes
   setup_script:
     - brew install autoconf automake bash libevent libtool openssl pandoc pkg-config postgresql
   env:
@@ -218,6 +222,7 @@ task:
   env:
     PATH: C:/tools/msys64/usr/bin;%PATH%
     HOME: .
+    HAVE_IPV6_LOCALHOST: yes
   matrix:
     - env:
         MSYSTEM: MINGW64

--- a/doc/config.md
+++ b/doc/config.md
@@ -193,8 +193,9 @@ Default: 0 (unlimited)
 
 By default, PgBouncer reuses server connections in LIFO (last-in, first-out) manner,
 so that few connections get the most load.  This gives best performance if you have
-a single server serving a database.  But if there is TCP round-robin behind a database
-IP address, then it is better if PgBouncer also uses connections in that manner, thus
+a single server serving a database.  But if there is a round-robin
+system behind a database address (TCP, DNS, or host list), then it is
+better if PgBouncer also uses connections in that manner, thus
 achieving uniform load.
 
 Default: 0
@@ -953,6 +954,27 @@ manner.
 If the value begins with `/`, then a Unix socket in the file-system
 namespace is used.  If the value begins with `@`, then a Unix socket
 in the abstract namespace is used.
+
+A comma-separated list of host names or addresses can be specified.
+In that case, connections are made in a round-robin manner.  (If a
+host list contains host names that in turn resolve via DNS to multiple
+addresses, the round-robin systems operate independently.  This is an
+implementation dependency that is subject to change.)  Note that in a
+list, all hosts must be available at all times: There are no
+mechanisms to skip unreachable hosts or to select only available hosts
+from a list or similar.  (This is different from what a host list in
+libpq means.)  Also note that this only affects how the destinations
+of new connections are chosen.  See also the setting
+`server_round_robin` for how clients are assigned to already
+established server connections.
+
+Examples:
+
+	host=localhost
+	host=127.0.0.1
+	host=2001:0db8:85a3:0000:0000:8a2e:0370:7334
+	host=/var/run/postgresql
+	host=192.168.0.1,192.168.0.2,192.168.0.3
 
 Default: not set, meaning to use a Unix socket
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -287,6 +287,8 @@ struct PgPool {
 	bool last_login_failed:1;
 
 	bool welcome_msg_ready:1;
+
+	int16_t rrcounter;		/* round-robin counter */
 };
 
 #define pool_connected_server_count(pool) ( \

--- a/test/test.ini
+++ b/test/test.ini
@@ -25,6 +25,9 @@ p8 = port=6666 host=127.0.0.1 dbname=p0 connect_query='set enable_seqscan=off; s
 
 authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
 
+hostlist1 = port=6666 host=127.0.0.1,::1 dbname=p0 user=bouncer
+hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
+
 ; commented out except for auto-database tests
 ;* = port=6666 host=127.0.0.1
 


### PR DESCRIPTION
A common feature request is to have PgBouncer do some kind of load-balancing or round-robin between a set of backend servers. This is currently possible by using DNS to resolve a host name to multiple addresses. But many people don't want to use DNS.

This patch implements a host list on the configuration level. So you can specify, for example

    host=server1,server2,server3

where the "serverN" can be IP addresses or host names as usual. On connection, PgBouncer will simply rotate between them.

Thoughts?