### PR TITLE
Fix shadow auth for users defined under [users] section

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -326,6 +326,7 @@ struct PgUser {
 	uint8_t scram_ServerKey[32];
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
+	bool is_preconfigured;		/* true if user is created from pre-configuration parsing */
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */

--- a/include/objects.h
+++ b/include/objects.h
@@ -47,6 +47,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _
 
 PgDatabase * add_database(const char *name) _MUSTCHECK;
 PgDatabase *register_auto_database(const char *name);
+PgUser * find_original_user(PgUser *login_user) _MUSTCHECK;
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;
 PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;

--- a/include/server.h
+++ b/include/server.h
@@ -24,3 +24,4 @@ int pool_min_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_res_pool_size(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgUser *user) _MUSTCHECK;
+bool user_is_authenticated(PgUser *user) _MUSTCHECK;

--- a/src/client.c
+++ b/src/client.c
@@ -206,7 +206,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		if (client->db->forced_user)
 			pool_user = client->db->forced_user;
 		else
-			pool_user = client->login_user;
+			pool_user = find_original_user(client->login_user);
 
 		client->pool = get_pool(client->db, pool_user);
 		if (!client->pool) {

--- a/src/client.c
+++ b/src/client.c
@@ -343,13 +343,12 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		}
 	} else {
 		client->login_user = find_user(username);
-		if (!client->login_user) {
+		if (!client->login_user || !user_is_authenticated(client->login_user)) {
 			/*
-			 * If the login user specified by the client
-			 * does not exist, check if an auth_user is
-			 * set and if so send off an auth_query.  If
-			 * no auth_user is set for the db, see if the
-			 * global auth_user is set and use that.
+			 * If the login user specified by the client does not exist or only exists as
+			 * a pre-configuration, check if an auth_user is set and if so send off an
+			 * auth_query. If no auth_user is set for the db, see if the global auth_user
+			 * is set and use that.
 			 */
 			if (!client->db->auth_user && cf_auth_user) {
 				client->db->auth_user = find_user(cf_auth_user);

--- a/src/loader.c
+++ b/src/loader.c
@@ -407,11 +407,13 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user = find_user(name);
 	if (!user) {
+		/* represents a user pre-configuration, not a connected logged-in user */
 		user = add_user(name, "");
 		if (!user) {
 			log_error("cannot create user, no memory?");
 			goto fail;
 		}
+		user->is_preconfigured = true;
 	}
 
 	user->pool_mode = pool_mode;

--- a/src/server.c
+++ b/src/server.c
@@ -243,6 +243,14 @@ int user_max_connections(PgUser *user)
 	}
 }
 
+bool user_is_authenticated(PgUser *user)
+{
+	/* authenticated users cannot be in a non-logged in or preconfigured state */
+	return cf_auth_type == AUTH_TRUST ||
+		   (cf_auth_user != NULL && strcmp(cf_auth_user, user->name) == 0) ||
+		   !user->is_preconfigured;
+}
+
 /* process packets on logged in connection */
 static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 {

--- a/test/test.ini
+++ b/test/test.ini
@@ -33,6 +33,7 @@ hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 
 [users]
 maxedout = max_user_connections=3
+shadowuser2 = max_user_connections=3
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.sh
+++ b/test/test.sh
@@ -185,6 +185,8 @@ psql -X -p $PG_PORT -d p0 -c "select * from pg_user" | grep pswcheck > /dev/null
 	psql -X -o /dev/null -p $PG_PORT -c "create user pswcheck with superuser createdb password 'pgbouncer-check';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user someuser with password 'anypasswd';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user maxedout;" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser1 with password 'bar';" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser2 with password 'foo';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user longpass with password '$long_password';" p0 || exit 1
 	if $pg_supports_scram; then
 		psql -X -o /dev/null -p $PG_PORT -c "set password_encryption = 'md5'; create user muser1 password 'foo';" p0 || exit 1
@@ -931,6 +933,48 @@ test_password_server() {
 	return 0
 }
 
+# test password authentication from PgBouncer to PostgreSQL server using
+# auth_query to retrieve user's shadow password from pg_shadow
+test_shadow_password_server_login() {
+	$have_getpeereid || return 77
+
+	admin "set auth_type='md5'"
+	admin "set auth_user='pswcheck'"
+
+	# plain-text password of auth_user in userlist.txt
+	curuser=`psql -X -d "dbname=authdb user=pswcheck password=pgbouncer-check" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "pswcheck" || return 1
+
+	# user with correct password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=bar" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser1" || return 1
+	# user with wrong password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=badpasswd" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "" || return 1
+
+	# user defined in ini [users] section with correct password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser2" || return 1
+	# user defined in ini [users] section with wrong password from PostgreSQL server
+	curuser2=`psql -X -d "dbname=authdb user=shadowuser2 password=badpasswd" -tAq -c "select current_user;"`
+	echo "curuser2=$curuser2"
+	test "$curuser2" = "" || return 1
+
+	# auth_user defined in ini [users] section with correct password from PostgreSQL server
+	admin "set auth_user='shadowuser2'"
+	curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser2" || return 1
+
+	admin "set auth_type='trust'"
+
+	return 0
+}
+
 # test plain-text password authentication from client to PgBouncer
 test_password_client() {
 	$have_getpeereid || return 77
@@ -1445,6 +1489,7 @@ test_server_lifetime
 test_server_idle_timeout
 test_query_timeout
 test_idle_transaction_timeout
+test_shadow_password_server_login
 test_server_connect_timeout_establish
 test_server_connect_timeout_reject
 test_server_check_delay


### PR DESCRIPTION
**Description**

When a user is not defined within `userlist.txt` and exists as a user in the Postgres server, PgBouncer should send an auth query to retrieve the user's md5 password hash in order to log the user in.

However, as outlined in issue: https://github.com/pgbouncer/pgbouncer/issues/484, if a user's password is not defined in `userlist.txt` and the user has overridden configurations under the `[users]` section in PgBouncer's ini file, the user is unable to login to the Postgres server through PgBouncer.

**Root Cause**

This happens because any users defined under `[users]` are parsed and added as new users in `loader.c`'s `parse_user`. As result, when the real and live user connects, PgBouncer thinks they already exist (not NULL) and skips the shadow authorization process where the user's md5 password hash is queried from `pg_shadow`.

**Fix**

This PR introduces a new flag to track whether a user was created from ini file parsing or from a real live login. Then, we determine whether a new user logging in requires shadow authorization.

This fix should now allow PgBouncer operators to use the `max_user_connections` per user feature.

cc @viggy28