### PR TITLE
Configure and enforce max connections per user at runtime

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1069,6 +1069,10 @@ database or default `pool_mode` is used.
 Configure a maximum for the user (i.e. all pools with the user will
 not have more than this many server connections).
 
+If a user is configured with `max_user_connections` in the `[users]`
+section, any of their connections that exceed the new limit will
+automatically be closed in priority of idle, used, tested, then active
+connections.
 
 ## Include directive
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -97,6 +97,9 @@ statement
 :   Server is released back to pool after query finishes. Transactions
     spanning multiple statements are disallowed in this mode.
 
+This can also be set per database in the `[databases]` section and per user
+in the `[users]` section or by using the command `SET USER [user] = 'pool_mode=[mode]'`.
+
 ### max_client_conn
 
 Maximum number of client connections allowed.

--- a/doc/config.md
+++ b/doc/config.md
@@ -178,7 +178,8 @@ associated with a pool, which is either the user specified for the
 server connection or in absence of that the user the client has
 connected as.
 
-This can also be set per user in the `[users]` section.
+This can also be set per user in the `[users]` section, or by using
+the command `SET USER [user] = 'max_user_connections=[new limit]`.
 
 Note that when you hit the limit, closing a client connection to one
 pool will not immediately allow a server connection to be established

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -86,6 +86,7 @@ enum SSLMode {
 
 typedef struct PgSocket PgSocket;
 typedef struct PgUser PgUser;
+typedef struct PgUserEvent PgUserEvent;
 typedef struct PgDatabase PgDatabase;
 typedef struct PgPool PgPool;
 typedef struct PgStats PgStats;
@@ -330,6 +331,14 @@ struct PgUser {
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
+};
+
+/*
+ * An association of an event occurring for a user, such as the user's config being reloaded.
+ */
+struct PgUserEvent {
+	struct PgUser *user;
+	struct event *ev;
 };
 
 /*

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -594,6 +594,6 @@ last_socket(struct StatList *slist)
 void load_config(void);
 
 
-bool set_config_param(const char *key, const char *val);
+bool set_config_param(const char *sect, const char *key, const char *val);
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),
 		     void *arg);

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -326,6 +326,7 @@ struct PgUser {
 	uint8_t scram_ServerKey[32];
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
+	bool is_preconfigured;		/* true if user is created from pre-configuration parsing */
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */

--- a/include/objects.h
+++ b/include/objects.h
@@ -80,6 +80,9 @@ void change_server_state(PgSocket *server, SocketState newstate);
 int get_active_client_count(void);
 int get_active_server_count(void);
 
+void handle_user_cf_update(evutil_socket_t sock, short flags, void *arg);
+void notify_user_event(PgUser *user, event_callback_fn cb);
+
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
 void tag_autodb_dirty(void);

--- a/include/objects.h
+++ b/include/objects.h
@@ -34,7 +34,7 @@ PgUser *find_user(const char *name);
 PgPool *get_pool(PgDatabase *, PgUser *);
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs);
 bool evict_connection(PgDatabase *db)		_MUSTCHECK;
-bool evict_user_connection(PgUser *user)	_MUSTCHECK;
+bool evict_idle_user_connection(PgUser *user)	_MUSTCHECK;
 bool find_server(PgSocket *client)		_MUSTCHECK;
 bool life_over(PgSocket *server);
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;

--- a/include/objects.h
+++ b/include/objects.h
@@ -47,6 +47,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _
 
 PgDatabase * add_database(const char *name) _MUSTCHECK;
 PgDatabase *register_auto_database(const char *name);
+PgUser * find_original_user(PgUser *login_user) _MUSTCHECK;
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;
 PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;

--- a/include/server.h
+++ b/include/server.h
@@ -24,3 +24,4 @@ int pool_min_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_res_pool_size(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgUser *user) _MUSTCHECK;
+bool user_is_authenticated(PgUser *user) _MUSTCHECK;

--- a/src/admin.c
+++ b/src/admin.c
@@ -584,7 +584,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	}
 	cv.extra = pool_mode_map;
 
-	pktbuf_write_RowDescription(buf, "ss", "name", "pool_mode");
+	pktbuf_write_RowDescription(buf, "ssi", "name", "pool_mode", "max_user_connections");
 	statlist_for_each(item, &user_list) {
 		user = container_of(item, PgUser, head);
 		pool_mode_str = NULL;
@@ -592,7 +592,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		if (user->pool_mode != POOL_INHERIT)
 			pool_mode_str = cf_get_lookup(&cv);
 
-		pktbuf_write_DataRow(buf, "ss", user->name, pool_mode_str);
+		pktbuf_write_DataRow(buf, "ssi", user->name, pool_mode_str, user_max_connections(user));
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;

--- a/src/client.c
+++ b/src/client.c
@@ -202,7 +202,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		if (client->db->forced_user)
 			pool_user = client->db->forced_user;
 		else
-			pool_user = client->login_user;
+			pool_user = find_original_user(client->login_user);
 
 		client->pool = get_pool(client->db, pool_user);
 		if (!client->pool) {

--- a/src/client.c
+++ b/src/client.c
@@ -339,13 +339,12 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		}
 	} else {
 		client->login_user = find_user(username);
-		if (!client->login_user) {
+		if (!client->login_user || !user_is_authenticated(client->login_user)) {
 			/*
-			 * If the login user specified by the client
-			 * does not exist, check if an auth_user is
-			 * set and if so send off an auth_query.  If
-			 * no auth_user is set for the db, see if the
-			 * global auth_user is set and use that.
+			 * If the login user specified by the client does not exist or only exists as
+			 * a pre-configuration, check if an auth_user is set and if so send off an
+			 * auth_query. If no auth_user is set for the db, see if the global auth_user
+			 * is set and use that.
 			 */
 			if (!client->db->auth_user && cf_auth_user) {
 				client->db->auth_user = find_user(cf_auth_user);

--- a/src/loader.c
+++ b/src/loader.c
@@ -418,6 +418,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user->pool_mode = pool_mode;
 	user->max_user_connections = max_user_connections;
+	notify_user_event(user, handle_user_cf_update);
 
 	free(tmp_connstr);
 	return true;

--- a/src/loader.c
+++ b/src/loader.c
@@ -407,11 +407,13 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user = find_user(name);
 	if (!user) {
+		/* represents a user pre-configuration, not a connected logged-in user */
 		user = add_user(name, "");
 		if (!user) {
 			log_error("cannot create user, no memory?");
 			goto fail;
 		}
+		user->is_preconfigured = true;
 	}
 
 	user->pool_mode = pool_mode;

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ static void usage(const char *exe)
 }
 
 /* global libevent handle */
-struct event_base *pgb_event_base;
+struct event_base *pgb_event_base = NULL;
 
 /* async dns handler */
 struct DNSContext *adns;
@@ -338,9 +338,9 @@ static const struct CfSect config_sects [] = {
 
 static struct CfContext main_config = { config_sects, };
 
-bool set_config_param(const char *key, const char *val)
+bool set_config_param(const char *sect, const char *key, const char *val)
 {
-	return cf_set(&main_config, "pgbouncer", key, val);
+	return cf_set(&main_config, sect, key, val);
 }
 
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1212,7 +1212,7 @@ bool evict_connection(PgDatabase *db)
 }
 
 /* evict the single most idle connection from among all pools to make room in the user */
-bool evict_user_connection(PgUser *user)
+bool evict_idle_user_connection(PgUser *user)
 {
 	struct List *item;
 	PgPool *pool;
@@ -1305,7 +1305,7 @@ allow_new:
 	if (max > 0) {
 		/* try to evict unused connection first */
 		while (pool->user->connection_count >= max) {
-			if (!evict_user_connection(pool->user)) {
+			if (!evict_idle_user_connection(pool->user)) {
 				break;
 			}
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -243,6 +243,14 @@ int user_max_connections(PgUser *user)
 	}
 }
 
+bool user_is_authenticated(PgUser *user)
+{
+	/* authenticated users cannot be in a non-logged in or preconfigured state */
+	return cf_auth_type == AUTH_TRUST ||
+		   (cf_auth_user != NULL && strcmp(cf_auth_user, user->name) == 0) ||
+		   !user->is_preconfigured;
+}
+
 /* process packets on logged in connection */
 static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 {

--- a/test/test.ini
+++ b/test/test.ini
@@ -33,6 +33,7 @@ hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 
 [users]
 maxedout = max_user_connections=3
+shadowuser2 = max_user_connections=3
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.sh
+++ b/test/test.sh
@@ -565,7 +565,7 @@ test_pool_size() {
 
 	docount() {
 		for i in {1..10}; do
-			psql -X -c "select pg_sleep(0.5)" $1 >/dev/null &
+			psql -X -c "select pg_sleep(1)" $1 >/dev/null &
 		done
 		wait
 		cnt=`psql -X -p $PG_PORT -tAq -c "select count(1) from pg_stat_activity where usename='bouncer' and datname='$1'" postgres`

--- a/test/test.sh
+++ b/test/test.sh
@@ -185,6 +185,8 @@ psql -X -p $PG_PORT -d p0 -c "select * from pg_user" | grep pswcheck > /dev/null
 	psql -X -o /dev/null -p $PG_PORT -c "create user pswcheck with superuser createdb password 'pgbouncer-check';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user someuser with password 'anypasswd';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user maxedout;" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser1 with password 'bar';" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser2 with password 'foo';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user longpass with password '$long_password';" p0 || exit 1
 	if $pg_supports_scram; then
 		psql -X -o /dev/null -p $PG_PORT -c "set password_encryption = 'md5'; create user muser1 password 'foo';" p0 || exit 1
@@ -931,6 +933,48 @@ test_password_server() {
 	return 0
 }
 
+# test password authentication from PgBouncer to PostgreSQL server using
+# auth_query to retrieve user's shadow password from pg_shadow
+test_shadow_password_server_login() {
+	$have_getpeereid || return 77
+
+	admin "set auth_type='md5'"
+	admin "set auth_user='pswcheck'"
+
+	# plain-text password of auth_user in userlist.txt
+	curuser=`psql -X -d "dbname=authdb user=pswcheck password=pgbouncer-check" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "pswcheck" || return 1
+
+	# user with correct password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=bar" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser1" || return 1
+	# user with wrong password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=badpasswd" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "" || return 1
+
+	# user defined in ini [users] section with correct password from PostgreSQL server
+	curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser2" || return 1
+	# user defined in ini [users] section with wrong password from PostgreSQL server
+	curuser2=`psql -X -d "dbname=authdb user=shadowuser2 password=badpasswd" -tAq -c "select current_user;"`
+	echo "curuser2=$curuser2"
+	test "$curuser2" = "" || return 1
+
+	# auth_user defined in ini [users] section with correct password from PostgreSQL server
+	admin "set auth_user='shadowuser2'"
+	curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+	echo "curuser=$curuser"
+	test "$curuser" = "shadowuser2" || return 1
+
+	admin "set auth_type='trust'"
+
+	return 0
+}
+
 # test plain-text password authentication from client to PgBouncer
 test_password_client() {
 	$have_getpeereid || return 77
@@ -1401,6 +1445,7 @@ test_server_lifetime
 test_server_idle_timeout
 test_query_timeout
 test_idle_transaction_timeout
+test_shadow_password_server_login
 test_server_connect_timeout_establish
 test_server_connect_timeout_reject
 test_server_check_delay


### PR DESCRIPTION
**Description**

This PR introduces a new command to enforce max user connections at runtime. In addition to existing `max_user_connections` per user on `pgbouncer.ini` file reload, PgBouncer operators can now execute `SET USER <user> = 'max_user_connections=<new limit> pool_mode=<session|transaction|statement>'` to update a user's max connections across all pools that the user is in.

When the `pgbouncer.ini` file is reloaded, or the above command is submitted, PgBouncer will now drop the user's connections as a reaction to these new values. PgBouncer will prioritize killing any idle and unused connections, and then kill the oldest active connections across all pools owned by the user to achieve the configured connection limit.

In addition, this PR also updates the `SHOW USERS;` command to display the maximum configured connections per user to increase visibility when throttling users.

In a production multi-tenant cluster, we have seen the need for PgBouncer to enforce maximum connections per user across all pools. When our upstream services (PG users) acquires too many connections while executing expensive and/or repetitive queries, this often puts strain on our Postgres primary server and starves CPU/Disk IO resources at the server. To remediate this, currently we manually constrain the user to maximum number of Postgres connections at server side via `ALTER USER "some_bad-user" WITH CONNECTION LIMIT 123;`. We've seen a clear correlation between the connection pool size (concurrency) per tenant denoted in green and database resource load denoted in yellow:

<img width="593" alt="production connections to load correlation (1)" src="https://user-images.githubusercontent.com/37853180/163653820-e2679664-dae8-4715-a308-71830e789c3f.png">

Having this option in PgBouncer would be very convenient because:

1. Postgres does not actively kill existing connections that surpass the new limit (which means load does not immediately reduce)
2. This opens the option for operators to build custom scripts that can automate per user connection throttling in PgBouncer via the `SET USER ...` command

**Note**

This PR follows from https://github.com/pgbouncer/pgbouncer/pull/706 and has some overlapping commits. The previous PR should merge before this one.

cc @viggy28