### PR TITLE
Configure and enforce max connections per pool at runtime

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -289,6 +289,7 @@ struct PgPool {
 
 	bool welcome_msg_ready:1;
 
+	int pool_size;		/* max server connections in one pool */
 	int16_t rrcounter;		/* round-robin counter */
 };
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -89,6 +89,7 @@ typedef struct PgUser PgUser;
 typedef struct PgUserEvent PgUserEvent;
 typedef struct PgDatabase PgDatabase;
 typedef struct PgPool PgPool;
+typedef struct PgPoolEvent PgPoolEvent;
 typedef struct PgStats PgStats;
 typedef union PgAddr PgAddr;
 typedef enum SocketState SocketState;
@@ -291,6 +292,14 @@ struct PgPool {
 
 	int pool_size;		/* max server connections in one pool */
 	int16_t rrcounter;		/* round-robin counter */
+};
+
+/*
+ * An association of an event occurring for a pool, such as the pool's config being reloaded.
+ */
+struct PgPoolEvent {
+	struct PgPool *pool;
+	struct event *ev;
 };
 
 #define pool_connected_server_count(pool) ( \

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -86,6 +86,7 @@ enum SSLMode {
 
 typedef struct PgSocket PgSocket;
 typedef struct PgUser PgUser;
+typedef struct PgUserEvent PgUserEvent;
 typedef struct PgDatabase PgDatabase;
 typedef struct PgPool PgPool;
 typedef struct PgStats PgStats;
@@ -330,6 +331,14 @@ struct PgUser {
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
+};
+
+/*
+ * An association of an event occurring for a user, such as the user's config being reloaded.
+ */
+struct PgUserEvent {
+	struct PgUser *user;
+	struct event *ev;
 };
 
 /*

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -594,6 +594,6 @@ last_socket(struct StatList *slist)
 void load_config(void);
 
 
-bool set_config_param(const char *key, const char *val);
+bool set_config_param(const char *sect, const char *key, const char *val);
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),
 		     void *arg);

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -326,6 +326,7 @@ struct PgUser {
 	uint8_t scram_ServerKey[32];
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
+	bool is_preconfigured;		/* true if user is created from pre-configuration parsing */
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */

--- a/include/loader.h
+++ b/include/loader.h
@@ -21,6 +21,8 @@ bool parse_database(void *base, const char *name, const char *connstr) _MUSTCHEC
 
 bool parse_user(void *base, const char *name, const char *params) _MUSTCHECK;
 
+bool parse_pool(void *base, const char *name, const char *params) _MUSTCHECK;
+
 /* user file parsing */
 bool load_auth_file(const char *fn)  /* _MUSTCHECK */;
 bool loader_users_check(void)  /* _MUSTCHECK */;

--- a/include/objects.h
+++ b/include/objects.h
@@ -80,6 +80,9 @@ void change_server_state(PgSocket *server, SocketState newstate);
 int get_active_client_count(void);
 int get_active_server_count(void);
 
+void handle_user_cf_update(evutil_socket_t sock, short flags, void *arg);
+void notify_user_event(PgUser *user, event_callback_fn cb);
+
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
 void tag_autodb_dirty(void);

--- a/include/objects.h
+++ b/include/objects.h
@@ -34,7 +34,7 @@ PgUser *find_user(const char *name);
 PgPool *get_pool(PgDatabase *, PgUser *);
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs);
 bool evict_connection(PgDatabase *db)		_MUSTCHECK;
-bool evict_user_connection(PgUser *user)	_MUSTCHECK;
+bool evict_idle_user_connection(PgUser *user)	_MUSTCHECK;
 bool find_server(PgSocket *client)		_MUSTCHECK;
 bool life_over(PgSocket *server);
 bool release_server(PgSocket *server)		/* _MUSTCHECK */;

--- a/include/objects.h
+++ b/include/objects.h
@@ -47,6 +47,7 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _
 
 PgDatabase * add_database(const char *name) _MUSTCHECK;
 PgDatabase *register_auto_database(const char *name);
+PgUser * find_original_user(PgUser *login_user) _MUSTCHECK;
 PgUser * add_user(const char *name, const char *passwd) _MUSTCHECK;
 PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;

--- a/include/objects.h
+++ b/include/objects.h
@@ -83,6 +83,9 @@ int get_active_server_count(void);
 void handle_user_cf_update(evutil_socket_t sock, short flags, void *arg);
 void notify_user_event(PgUser *user, event_callback_fn cb);
 
+void handle_pool_cf_update(evutil_socket_t sock, short flags, void *arg);
+void notify_pool_event(PgPool *pool, event_callback_fn cb);
+
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
 void tag_autodb_dirty(void);

--- a/include/server.h
+++ b/include/server.h
@@ -24,3 +24,4 @@ int pool_min_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_res_pool_size(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgUser *user) _MUSTCHECK;
+bool user_is_authenticated(PgUser *user) _MUSTCHECK;

--- a/src/admin.c
+++ b/src/admin.c
@@ -584,7 +584,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	}
 	cv.extra = pool_mode_map;
 
-	pktbuf_write_RowDescription(buf, "ss", "name", "pool_mode");
+	pktbuf_write_RowDescription(buf, "sss", "name", "pool_mode", "max_user_connections");
 	statlist_for_each(item, &user_list) {
 		user = container_of(item, PgUser, head);
 		pool_mode_str = NULL;
@@ -592,7 +592,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		if (user->pool_mode != POOL_INHERIT)
 			pool_mode_str = cf_get_lookup(&cv);
 
-		pktbuf_write_DataRow(buf, "ss", user->name, pool_mode_str);
+		pktbuf_write_DataRow(buf, "ssi", user->name, pool_mode_str, user_max_connections(user));
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;

--- a/src/admin.c
+++ b/src/admin.c
@@ -836,20 +836,20 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		admin_error(admin, "no mem");
 		return true;
 	}
-	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiis",
+	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiisi",
 				    "database", "user",
 				    "cl_active", "cl_waiting",
 				    "cl_cancel_req",
 				    "sv_active", "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
-				    "maxwait_us", "pool_mode");
+				    "maxwait_us", "pool_mode", "pool_size");
 	statlist_for_each(item, &pool_list) {
 		pool = container_of(item, PgPool, head);
 		waiter = first_socket(&pool->waiting_client_list);
 		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
 		pool_mode = pool_pool_mode(pool);
-		pktbuf_write_DataRow(buf, "ssiiiiiiiiiis",
+		pktbuf_write_DataRow(buf, "ssiiiiiiiiiisi",
 				     pool->db->name, pool->user->name,
 				     statlist_count(&pool->active_client_list),
 				     statlist_count(&pool->waiting_client_list),
@@ -862,7 +862,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				     /* how long is the oldest client waited */
 				     (int)(max_wait / USEC),
 				     (int)(max_wait % USEC),
-				     cf_get_lookup(&cv));
+				     cf_get_lookup(&cv), pool_pool_size(pool));
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;

--- a/src/admin.c
+++ b/src/admin.c
@@ -32,7 +32,7 @@
 /* regex elements */
 #define WS0	"[ \t\n\r]*"
 #define WS1	"[ \t\n\r]+"
-#define WORD	"(\"([^\"]+|\"\")*\"|[0-9a-z_]+)"
+#define WORD	"(\"([^\"]+|\"\")*\"|[0-9a-z._-]+)"
 #define STRING	"('([^']|'')*')"
 
 /* possible max + 1 */

--- a/src/client.c
+++ b/src/client.c
@@ -202,7 +202,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		if (client->db->forced_user)
 			pool_user = client->db->forced_user;
 		else
-			pool_user = client->login_user;
+			pool_user = find_original_user(client->login_user);
 
 		client->pool = get_pool(client->db, pool_user);
 		if (!client->pool) {

--- a/src/client.c
+++ b/src/client.c
@@ -339,13 +339,12 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		}
 	} else {
 		client->login_user = find_user(username);
-		if (!client->login_user) {
+		if (!client->login_user || !user_is_authenticated(client->login_user)) {
 			/*
-			 * If the login user specified by the client
-			 * does not exist, check if an auth_user is
-			 * set and if so send off an auth_query.  If
-			 * no auth_user is set for the db, see if the
-			 * global auth_user is set and use that.
+			 * If the login user specified by the client does not exist or only exists as
+			 * a pre-configuration, check if an auth_user is set and if so send off an
+			 * auth_query. If no auth_user is set for the db, see if the global auth_user
+			 * is set and use that.
 			 */
 			if (!client->db->auth_user && cf_auth_user) {
 				client->db->auth_user = find_user(cf_auth_user);

--- a/src/loader.c
+++ b/src/loader.c
@@ -418,6 +418,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user->pool_mode = pool_mode;
 	user->max_user_connections = max_user_connections;
+	notify_user_event(user, handle_user_cf_update);
 
 	free(tmp_connstr);
 	return true;

--- a/src/loader.c
+++ b/src/loader.c
@@ -407,11 +407,13 @@ bool parse_user(void *base, const char *name, const char *connstr)
 
 	user = find_user(name);
 	if (!user) {
+		/* represents a user pre-configuration, not a connected logged-in user */
 		user = add_user(name, "");
 		if (!user) {
 			log_error("cannot create user, no memory?");
 			goto fail;
 		}
+		user->is_preconfigured = true;
 	}
 
 	user->pool_mode = pool_mode;

--- a/src/loader.c
+++ b/src/loader.c
@@ -547,6 +547,7 @@ bool parse_pool(void *base, const char *name, const char *params)
 		goto fail;
 	}
 	pool->pool_size = pool_size;
+	notify_pool_event(pool, handle_pool_cf_update);
 
 	free(tmp_pool_name);
 	free(tmp_pool_params);

--- a/src/loader.c
+++ b/src/loader.c
@@ -364,6 +364,30 @@ fail:
 	return false;
 }
 
+static PgUser *get_preconfigured_user(const char *name)
+{
+	PgUser *user;
+
+	if (name == NULL) {
+		log_error("empty user name");
+		return NULL;
+	}
+
+	user = find_user(name);
+	if (user != NULL)
+		return user;
+
+	/* represents a user pre-configuration, not a connected logged-in user */
+	user = add_user(name, "");
+	if (user == NULL) {
+		log_error("cannot create user, no memory?");
+		return NULL;
+	}
+
+	user->is_preconfigured = true;
+	return user;
+}
+
 bool parse_user(void *base, const char *name, const char *connstr)
 {
 	char *p, *key, *val, *tmp_connstr;
@@ -412,16 +436,8 @@ bool parse_user(void *base, const char *name, const char *connstr)
 		}
 	}
 
-	user = find_user(name);
-	if (!user) {
-		/* represents a user pre-configuration, not a connected logged-in user */
-		user = add_user(name, "");
-		if (!user) {
-			log_error("cannot create user, no memory?");
-			goto fail;
-		}
-		user->is_preconfigured = true;
-	}
+	if ((user = get_preconfigured_user(name)) == NULL)
+		goto fail;
 
 	user->pool_mode = pool_mode;
 	user->max_user_connections = max_user_connections;
@@ -511,16 +527,8 @@ bool parse_pool(void *base, const char *name, const char *params)
 	if (!parse_pool_name(tmp_pool_name, &username, &dbname))
 		goto fail;
 
-	user = find_user(username);
-	if (!user) {
-		/* represents a user pre-configuration, not a connected logged-in user */
-		user = add_user(username, "");
-		if (!user) {
-			log_error("cannot create user, no memory?");
-			goto fail;
-		}
-		user->is_preconfigured = true;
-	}
+	if ((user = get_preconfigured_user(username)) == NULL)
+		goto fail;
 
 	if ((db = find_database(dbname)) == NULL) {
 		if ((db = add_database(dbname)) == NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -332,6 +332,9 @@ static const struct CfSect config_sects [] = {
 		.sect_name = "users",
 		.set_key = parse_user,
 	}, {
+		.sect_name = "pools",
+		.set_key = parse_pool,
+	}, {
 		.sect_name = NULL,
 	}
 };

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ static void usage(const char *exe)
 }
 
 /* global libevent handle */
-struct event_base *pgb_event_base;
+struct event_base *pgb_event_base = NULL;
 
 /* async dns handler */
 struct DNSContext *adns;
@@ -338,9 +338,9 @@ static const struct CfSect config_sects [] = {
 
 static struct CfContext main_config = { config_sects, };
 
-bool set_config_param(const char *key, const char *val)
+bool set_config_param(const char *sect, const char *key, const char *val)
 {
-	return cf_set(&main_config, "pgbouncer", key, val);
+	return cf_set(&main_config, sect, key, val);
 }
 
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1212,7 +1212,7 @@ bool evict_connection(PgDatabase *db)
 }
 
 /* evict the single most idle connection from among all pools to make room in the user */
-bool evict_user_connection(PgUser *user)
+bool evict_idle_user_connection(PgUser *user)
 {
 	struct List *item;
 	PgPool *pool;
@@ -1305,7 +1305,7 @@ allow_new:
 	if (max > 0) {
 		/* try to evict unused connection first */
 		while (pool->user->connection_count >= max) {
-			if (!evict_user_connection(pool->user)) {
+			if (!evict_idle_user_connection(pool->user)) {
 				break;
 			}
 		}

--- a/src/objects.c
+++ b/src/objects.c
@@ -1420,6 +1420,21 @@ allow_new:
 		}
 	}
 
+	max = pool_pool_size(pool) + pool_res_pool_size(pool);
+	if (max > 0) {
+		/* try to evict unused connections first */
+		while (pool_connected_server_count(pool) >= max) {
+			if (!evict_idle_pool_connection(pool)) {
+				break;
+			}
+		}
+		if (pool_connected_server_count(pool) >= max) {
+			log_debug("launch_new_connection: pool '%s.%s' full (%d >= %d)",
+					  pool->user->name, pool->db->name, pool_connected_server_count(pool), max);
+			return;
+		}
+	}
+
 	max = user_max_connections(pool->user);
 	if (max > 0) {
 		/* try to evict unused connection first */

--- a/src/objects.c
+++ b/src/objects.c
@@ -534,6 +534,8 @@ static PgPool *new_pool(PgDatabase *db, PgUser *user)
 
 	pool->user = user;
 	pool->db = db;
+	/* pool will use default_pool_size until overridden */
+	pool->pool_size = -1;
 
 	statlist_init(&pool->active_client_list, "active_client_list");
 	statlist_init(&pool->waiting_client_list, "waiting_client_list");
@@ -1211,6 +1213,22 @@ bool evict_connection(PgDatabase *db)
 	return false;
 }
 
+/* evict the single most idle connection from pool */
+static bool evict_idle_pool_connection(PgPool *pool)
+{
+	PgSocket *oldest_connection = NULL;
+
+	oldest_connection = last_socket(&pool->used_server_list);
+	if (!oldest_connection)
+		oldest_connection = last_socket(&pool->idle_server_list);
+
+	if (oldest_connection) {
+		disconnect_server(oldest_connection, true, "evicted");
+		return true;
+	}
+	return false;
+}
+
 /* evict the single most idle connection from among all pools to make room in the user */
 bool evict_idle_user_connection(PgUser *user)
 {
@@ -1297,6 +1315,45 @@ void notify_user_event(PgUser *user, event_callback_fn cb) {
 	user_event->user = user;
 	user_event->ev = event_new(pgb_event_base, -1, 0, cb, user_event);
 	event_active(user_event->ev, EV_TIMEOUT, 0);
+}
+
+static void enforce_pool_connection_limit(PgPool *pool)
+{
+	PgSocket *oldest_connection = NULL;
+	int max = pool_pool_size(pool);
+
+	while (pool_connected_server_count(pool) > max) {
+		if (evict_idle_pool_connection(pool))
+			continue;
+		if ((oldest_connection = last_socket(&pool->active_server_list)) == NULL)
+			return;
+
+		disconnect_server(oldest_connection, true, "evicted");
+	}
+}
+
+void handle_pool_cf_update(evutil_socket_t sock, short flags, void *arg)
+{
+	PgPoolEvent *pool_event = (PgPoolEvent*)arg;
+	enforce_pool_connection_limit(pool_event->pool);
+	event_free(pool_event->ev);
+	free(pool_event);
+}
+
+void notify_pool_event(PgPool *pool, event_callback_fn cb) {
+	struct PgPoolEvent *pool_event;
+	if (pgb_event_base == NULL)
+		return;
+
+	pool_event = malloc(sizeof(PgUserEvent));
+	if (pool_event == NULL) {
+		log_error("could not allocate user event: %s", strerror(errno));
+		return;
+	}
+
+	pool_event->pool = pool;
+	pool_event->ev = event_new(pgb_event_base, -1, 0, cb, pool_event);
+	event_active(pool_event->ev, EV_TIMEOUT, 0);
 }
 
 /* the pool needs new connection, if possible */

--- a/src/server.c
+++ b/src/server.c
@@ -203,10 +203,17 @@ int pool_pool_mode(PgPool *pool)
 
 int pool_pool_size(PgPool *pool)
 {
-	if (pool->db->pool_size < 0)
-		return cf_default_pool_size;
-	else
+	/* both database and user max pool limits are not configured */
+	if (pool->db->pool_size < 0 && pool->pool_size < 0)
+		return cf_default_pool_size < 0 ? 0 : cf_default_pool_size;
+	/* max pool limit is only configured for database */
+	else if (pool->pool_size < 0)
 		return pool->db->pool_size;
+	/* max pool limit is only configured for pool */
+	else if (pool->db->pool_size < 0)
+		return pool->pool_size;
+	/* max pool limit is the most restrictive limit of both */
+	return pool->db->pool_size < pool->pool_size ? pool->db->pool_size : pool->pool_size;
 }
 
 int pool_min_pool_size(PgPool *pool)

--- a/src/server.c
+++ b/src/server.c
@@ -243,6 +243,14 @@ int user_max_connections(PgUser *user)
 	}
 }
 
+bool user_is_authenticated(PgUser *user)
+{
+	/* authenticated users cannot be in a non-logged in or preconfigured state */
+	return cf_auth_type == AUTH_TRUST ||
+		   (cf_auth_user != NULL && strcmp(cf_auth_user, user->name) == 0) ||
+		   !user->is_preconfigured;
+}
+
 /* process packets on logged in connection */
 static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 {

--- a/test/test.ini
+++ b/test/test.ini
@@ -22,6 +22,7 @@ p7a= port=6666 host=127.0.0.1 dbname=p7
 p7b= port=6666 host=127.0.0.1 dbname=p7
 p7c= port=6666 host=127.0.0.1 dbname=p7
 p8 = port=6666 host=127.0.0.1 dbname=p0 connect_query='set enable_seqscan=off; set enable_nestloop=off'
+p8a= port=6666 host=127.0.0.1 dbname=p0 pool_size=4
 
 authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
 
@@ -34,6 +35,9 @@ hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 [users]
 maxedout = max_user_connections=3
 shadowuser2 = max_user_connections=3
+
+[pools]
+maxedout.p7a = pool_size=3
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.ini
+++ b/test/test.ini
@@ -33,6 +33,7 @@ hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 
 [users]
 maxedout = max_user_connections=3
+shadowuser2 = max_user_connections=3
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.sh
+++ b/test/test.sh
@@ -565,7 +565,7 @@ test_pool_size() {
 
 	docount() {
 		for i in {1..10}; do
-			psql -X -c "select pg_sleep(0.5)" $1 >/dev/null &
+			psql -X -c "select pg_sleep(1)" $1 >/dev/null &
 		done
 		wait
 		cnt=`psql -X -p $PG_PORT -tAq -c "select count(1) from pg_stat_activity where usename='bouncer' and datname='$1'" postgres`

--- a/test/test.sh
+++ b/test/test.sh
@@ -185,6 +185,8 @@ psql -X -p $PG_PORT -d p0 -c "select * from pg_user" | grep pswcheck > /dev/null
 	psql -X -o /dev/null -p $PG_PORT -c "create user pswcheck with superuser createdb password 'pgbouncer-check';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user someuser with password 'anypasswd';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user maxedout;" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser1 with password 'bar';" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user shadowuser2 with password 'foo';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user longpass with password '$long_password';" p0 || exit 1
 	if $pg_supports_scram; then
 		psql -X -o /dev/null -p $PG_PORT -c "set password_encryption = 'md5'; create user muser1 password 'foo';" p0 || exit 1
@@ -931,6 +933,48 @@ test_password_server() {
 	return 0
 }
 
+# test password authentication from PgBouncer to PostgreSQL server using
+# auth_query to retrieve user's shadow password from pg_shadow
+test_shadow_password_server_login() {
+  $have_getpeereid || return 77
+
+  admin "set auth_type='md5'"
+  admin "set auth_user='pswcheck'"
+
+  # plain-text password of auth_user in userlist.txt
+  curuser=`psql -X -d "dbname=authdb user=pswcheck password=pgbouncer-check" -tAq -c "select current_user;"`
+  echo "curuser=$curuser"
+  test "$curuser" = "pswcheck" || return 1
+
+  # user with good password from PostgreSQL server
+  curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=bar" -tAq -c "select current_user;"`
+  echo "curuser=$curuser"
+  test "$curuser" = "shadowuser1" || return 1
+  # user with bad password from PostgreSQL server
+  curuser=`psql -X -d "dbname=authdb user=shadowuser1 password=badpasswd" -tAq -c "select current_user;"`
+  echo "curuser=$curuser"
+  test "$curuser" = "" || return 1
+
+  # user defined in ini [users] section with good password from PostgreSQL server
+  curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+  echo "curuser=$curuser"
+  test "$curuser" = "shadowuser2" || return 1
+  # user defined in ini [users] section with bad password from PostgreSQL server
+  curuser2=`psql -X -d "dbname=authdb user=shadowuser2 password=badpasswd" -tAq -c "select current_user;"`
+  echo "curuser2=$curuser2"
+  test "$curuser2" = "" || return 1
+
+  # auth_user defined in ini [users] section with good password from PostgreSQL server
+  admin "set auth_user='shadowuser2'"
+  curuser=`psql -X -d "dbname=authdb user=shadowuser2 password=foo" -tAq -c "select current_user;"`
+  echo "curuser=$curuser"
+  test "$curuser" = "shadowuser2" || return 1
+
+  admin "set auth_type='trust'"
+
+  return 0
+}
+
 # test plain-text password authentication from client to PgBouncer
 test_password_client() {
 	$have_getpeereid || return 77
@@ -1401,6 +1445,7 @@ test_server_lifetime
 test_server_idle_timeout
 test_query_timeout
 test_idle_transaction_timeout
+test_shadow_password_server_login
 test_server_connect_timeout_establish
 test_server_connect_timeout_reject
 test_server_check_delay

--- a/test/test.sh
+++ b/test/test.sh
@@ -657,8 +657,8 @@ test_max_db_connections() {
 }
 
 test_max_user_connections() {
+  rm -f $LOGDIR/test.tmp
 	local databases
-
 	databases=(p7a p7b p7c)
 
 	spawn_connections() {
@@ -713,8 +713,19 @@ test_max_user_connections() {
   admin "set user longpass = 'max_user_connections=4'"
   wait
   test `count_connections longpass` -eq 4 || return 1
+  # set user command with malformed max_user_connections value should be rejected
+  spawn_connections longpass
+  psql -X -h $BOUNCER_ADMIN_HOST -U pgbouncer -d pgbouncer -c "set user longpass = 'max_user_connections=0d';" >>$LOGDIR/test.tmp 2>&1
+  grep -q "ERROR:  SET failed" $LOGDIR/test.tmp || return 1
+  test `count_connections longpass` -eq 4 || return 1
+  # set user command with empty max_user_connections value should be rejected
+  psql -X -h $BOUNCER_ADMIN_HOST -U pgbouncer -d pgbouncer -c "set user longpass = 'max_user_connections=';" >>$LOGDIR/test.tmp 2>&1
+  grep -q "ERROR:  SET failed" $LOGDIR/test.tmp || return 1
+  # set user command with empty parameters should be rejected
+  psql -X -h $BOUNCER_ADMIN_HOST -U pgbouncer -d pgbouncer -c "set user longpass = '';" >>$LOGDIR/test.tmp 2>&1
+  grep -q "ERROR:  SET failed" $LOGDIR/test.tmp || return 1
 
-  # reset users with default max user connections
+  # reset users to default max user connections
   admin "set user longpass = 'max_user_connections=0'"
   admin "set user maxedout = 'max_user_connections=3'"
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -661,16 +661,62 @@ test_max_user_connections() {
 
 	databases=(p7a p7b p7c)
 
-	docount() {
+	spawn_connections() {
+	  local user=${1}
 		for i in {1..10}; do
-			psql -X -U maxedout -c "select pg_sleep(0.5)" ${databases[$(($i % 3))]} >/dev/null &
+		  psql -X -U "$user" -c "select pg_sleep(2)" "${databases[$(($i % 3))]}" >/dev/null &
 		done
 		wait
-		cnt=`psql -X -p $PG_PORT -tAq -c "select count(1) from pg_stat_activity where datname = 'p7'" postgres`
-		echo $cnt
 	}
 
-	test `docount` -eq 3 || return 1
+	count_connections() {
+	  local user=${1}
+	  cnt=`psql -X -p $PG_PORT -tAq -c "select count(1) from pg_stat_activity where usename =  '$user' and datname = 'p7'" postgres`
+    echo $cnt
+	}
+
+  spawn_connections maxedout
+	test `count_connections maxedout` -eq 3 || return 1
+  # new larger limit should be respected when creating new connections
+  admin "set user maxedout = 'max_user_connections=8'"
+  spawn_connections maxedout
+	test `count_connections maxedout` -eq 8 || return 1
+	# new smaller limit should be respected when creating new connections
+  admin "set user maxedout = 'max_user_connections=2'"
+  spawn_connections maxedout
+  test `count_connections maxedout` -eq 2 || return 1
+  # any existing connections above new limit should be evicted
+  admin "set user maxedout = 'max_user_connections=10'"
+  spawn_connections maxedout
+	admin "set user maxedout = 'max_user_connections=1'"
+	wait
+  test `count_connections maxedout` -eq 1 || return 1
+  # user connection limit should be reset to original value in ini file
+  admin "reload"
+  spawn_connections maxedout
+  test `count_connections maxedout` -eq 3 || return 1
+  # no connections should be evicted because current limit is set to unlimited
+  admin "set user maxedout = 'max_user_connections=0'"
+  spawn_connections maxedout
+  test `count_connections maxedout` -eq 10 || return 1
+  # no connections should be evicted because current limit is set to unlimited
+  admin "set user maxedout = 'max_user_connections=-1'"
+  spawn_connections maxedout
+  test `count_connections maxedout` -eq 10 || return 1
+  # no connections should be evicted because current limit is not exceeded
+  spawn_connections maxedout
+  admin "set user maxedout = 'max_user_connections=10'"
+  wait
+  test `count_connections maxedout` -eq 10 || return 1
+  # any existing connections above new limit should be evicted for user not defined in [users]
+  spawn_connections longpass
+  admin "set user longpass = 'max_user_connections=4'"
+  wait
+  test `count_connections longpass` -eq 4 || return 1
+
+  # reset users with default max user connections
+  admin "set user longpass = 'max_user_connections=0'"
+  admin "set user maxedout = 'max_user_connections=3'"
 
 	return 0
 }


### PR DESCRIPTION
**Description**

This PR introduces the ability to tune the maximum number of connections for a specific connection pool associated to a user and a database. Applying these now pool level configurations will take effect immediately; existing connections that surpass the new max `pool_size` limit will be evicted. PgBouncer will prioritize killing any idle and unused server connections before killing the oldest active connections within the targeted pool.

**Motivation**

We have seen the need for PgBouncer to throttle/reduce connections. When our upstream services (PG users) acquire too many connections while executing expensive and/or repetitive queries, this often puts strain on our Postgres primary server and starves CPU/Disk IO resources at the server. This also creates back-pressure by blocking other queued user clients from acquiring server side connections and executing queries, increasing overall query latencies.

Many of our tenants have different workloads that span across different databases (and by extension different pools). Under high load scenarios, although throttling max user connections owned by a tenant across all their pools will reduce load, being able to **throttle a tenant's specific pool** effectively reduces load in a targeted manner. It also minimizing service disruptions to other well behaved pools owned by the tenant.

**Ini Configuration**

A new `[pools]` section has been added in the `.ini` configuration file, where an example of a pool's configuration is as follows:

```
[pools]
maxedout.p7a = pool_size=3
```

Each pool name is uniquely denoted by `<user>.<database>`. Similar to the `[users]` section, upon PgBouncer `RELOAD;`, the values under this section will be loaded into memory and applied to the relevant `PgPool *` references at runtime.

**Admin Command**

We also introduce a new command to enforce per pool max connections at runtime. Operators can now execute `SET POOL <user>.<database> = 'pool_size=<new limit>'` to update the maximum number of server side connections that a specific pool can use. This syntax matches the proposed `SET USER ...` convention in the previous PR: https://github.com/pgbouncer/pgbouncer/pull/707

In addition, this PR also updates the `SHOW POOLS;` command to display the maximum configured connections per pool to increase visibility when throttling users via the new `pool_size` column.

**Note**

This PR follows from https://github.com/pgbouncer/pgbouncer/pull/707 and has some overlapping commits. The previous PR should merge before this one.

cc @viggy28