### PR TITLE
Handle race condition between cancel requests and server reuse

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -379,11 +379,23 @@ cl_active
 cl_waiting
 :   Client connections that have sent queries but have not yet got a server connection.
 
-cl_cancel_req
+cl_waiting_cancel_req
 :   Client connections that have not forwarded query cancellations to the server yet.
+
+cl_active_cancel_req
+:   Client connections that have forwarded query cancellations to the server and
+    are waiting for the server response.
 
 sv_active
 :   Server connections that are linked to a client.
+
+sv_active_cancel
+:   Server connections that are currently forwarding a cancel request
+
+sv_wait_cancels
+:   Servers that normally could become idle, but are waiting to do so until
+    all in-flight cancel requests have completed that were sent to cancel
+    a query on this server.
 
 sv_idle
 :   Server connections that are unused and immediately usable for client queries.

--- a/include/objects.h
+++ b/include/objects.h
@@ -54,7 +54,7 @@ PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _M
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
 
 void accept_cancel_request(PgSocket *req);
-void forward_cancel_request(PgSocket *server);
+bool forward_cancel_request(PgSocket *server);
 
 void launch_new_connection(PgPool *pool, bool evict_if_needed);
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -823,11 +823,15 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		admin_error(admin, "no mem");
 		return true;
 	}
-	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiis",
+	pktbuf_write_RowDescription(buf, "ssiiiiiiiiiiiiis",
 				    "database", "user",
 				    "cl_active", "cl_waiting",
-				    "cl_cancel_req",
-				    "sv_active", "sv_idle",
+				    "cl_waiting_cancel_req",
+				    "cl_active_cancel_req",
+				    "sv_active",
+				    "sv_active_cancel",
+				    "sv_wait_cancels",
+					"sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
 				    "maxwait_us", "pool_mode");
@@ -836,12 +840,15 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 		waiter = first_socket(&pool->waiting_client_list);
 		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
 		pool_mode = pool_pool_mode(pool);
-		pktbuf_write_DataRow(buf, "ssiiiiiiiiiis",
+		pktbuf_write_DataRow(buf, "ssiiiiiiiiiiiiis",
 				     pool->db->name, pool->user->name,
 				     statlist_count(&pool->active_client_list),
 				     statlist_count(&pool->waiting_client_list),
-				     statlist_count(&pool->cancel_req_list),
+				     statlist_count(&pool->active_cancel_req_list),
+				     statlist_count(&pool->waiting_cancel_req_list),
 				     statlist_count(&pool->active_server_list),
+				     statlist_count(&pool->active_cancel_server_list),
+				     statlist_count(&pool->wait_cancels_server_list),
 				     statlist_count(&pool->idle_server_list),
 				     statlist_count(&pool->used_server_list),
 				     statlist_count(&pool->tested_server_list),

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -177,7 +177,7 @@ static void per_loop_activate(PgPool *pool)
 	int sv_tested, sv_used;
 
 	/* if there is a cancel request waiting, open a new connection */
-	if (!statlist_empty(&pool->cancel_req_list)) {
+	if (!statlist_empty(&pool->waiting_cancel_req_list)) {
 		launch_new_connection(pool, /* evict_if_needed= */ true);
 		return;
 	}
@@ -674,9 +674,13 @@ void kill_pool(PgPool *pool)
 
 	close_client_list(&pool->active_client_list, reason);
 	close_client_list(&pool->waiting_client_list, reason);
-	close_client_list(&pool->cancel_req_list, reason);
+
+	close_client_list(&pool->active_cancel_req_list, reason);
+	close_client_list(&pool->waiting_cancel_req_list, reason);
 
 	close_server_list(&pool->active_server_list, reason);
+	close_server_list(&pool->active_cancel_server_list, reason);
+	close_server_list(&pool->wait_cancels_server_list, reason);
 	close_server_list(&pool->idle_server_list, reason);
 	close_server_list(&pool->used_server_list, reason);
 	close_server_list(&pool->tested_server_list, reason);


### PR DESCRIPTION
Cancel requests happen out of band with regular queries. Because
PgBouncer reuses server connections across clients its possible to get
race conditions here if you're not careful.

Without this patch there were two possibilities for a race condition
where a cancel request for client A could cancel a query that was sent
by client B. These race conditions happened when:
1. A cancel request on client A was forwarded to the server only after
   the server was reused by another client.
2. A cancel request for client A was already forwarded to the server,
   but not yet handled by the server and then the server was reused for
   client B.

The first race conditions was especially likely if connection
establishment takes a while, for example because of TLS roundtrips.
Because a new connection needs to be established for every forwarded
cancellation request. While establishing this connection the query
running on the server might finish by itself already, and then the
server could be reused by another already waiting client.

To resolve these race conditions the following two fixes are implemented:
1. We now only forward the cancel request if the server connection over
   which the query was sent hasn't become idle or disconnected in the
   meantime. This is done by doubly-linking cancel requests and the
   original server connection that was used for the query.
2. Once a cancel request is forwarded to the server, we do not allow reuse of
   the server until the cancel request completes. This required tracking
   the response of the server for cancel requests too, instead of
   closing the connection right after forwarding the cancel.

Fixes #544

In passing this also adds more comprehensive comments to the different
`StatList`s in the `PgPool` struct. Because understanding how the state
machine worked was the part of this PR that took me the longest.