### PR TITLE
CI: Install bash on Alpine

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,7 +145,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 wget
+    - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - adduser --disabled-password user


### PR DESCRIPTION
It seems the default Alpine image doesn't have bash installed anymore,
but the test.sh script requires it. This installs it on CI.

An example of a failed CI run can be found here: https://cirrus-ci.com/task/6439380507164672