### PR TITLE
Prevent Segfault when connecting to non-existent DB with Scram Authentication

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -110,7 +110,7 @@ static bool send_client_authreq(PgSocket *client)
 	    slog_noise(client, "No authentication response received");
 		disconnect_client(client, false, "failed to send auth req");
 	} else {
-		slog_noise(client, "Auth request sent successfully")
+		slog_noise(client, "Auth request sent successfully");
 	}
 	return res;
 }
@@ -808,7 +808,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 					return false;
 				if (scram_client_final(client, length, data)) {
 					/* save SCRAM keys for user */
-					if (!client->scram_state.adhoc) {
+					if (!client->scram_state.adhoc && !client->db->fake) {
 						memcpy(client->pool->user->scram_ClientKey,
 						       client->scram_state.ClientKey,
 						       sizeof(client->scram_state.ClientKey));

--- a/src/client.c
+++ b/src/client.c
@@ -106,8 +106,10 @@ static bool send_client_authreq(PgSocket *client)
 		return false;
 	}
 
-	if (!res)
+	if (!res) {
+	    slog_debug(client, "No authentication response received");
 		disconnect_client(client, false, "failed to send auth req");
+	}
 	return res;
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -107,8 +107,10 @@ static bool send_client_authreq(PgSocket *client)
 	}
 
 	if (!res) {
-	    slog_debug(client, "No authentication response received");
+	    slog_noise(client, "No authentication response received");
 		disconnect_client(client, false, "failed to send auth req");
+	} else {
+		slog_noise(client, "Auth request sent successfully")
 	}
 	return res;
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -823,6 +823,10 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	char buf[128];
 	va_list ap;
 
+	if (server == NULL) {
+		return;
+	}
+
 	va_start(ap, reason);
 	vsnprintf(buf, sizeof(buf), reason, ap);
 	va_end(ap);

--- a/src/objects.c
+++ b/src/objects.c
@@ -823,10 +823,6 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	char buf[128];
 	va_list ap;
 
-	if (server == NULL) {
-		return;
-	}
-
 	va_start(ap, reason);
 	vsnprintf(buf, sizeof(buf), reason, ap);
 	va_end(ap);

--- a/test/test.sh
+++ b/test/test.sh
@@ -1272,16 +1272,29 @@ test_no_database_auth_user() {
 	return 0
 }
 
-test_no_database_md5_auth_success() {
-	# Testing what happens on successful md5 auth connection to non-existent DB
+test_no_database_scram_auth_success() {
+	# Testing what happens on successful SCRAM auth connection to non-existent DB
 	# Segfaults have been seen after mock authentication was put in place
 
 	admin "set auth_type='md5'"
 	PGPASSWORD=foo psql -X -U scramuser1 -d nosuchdb1 -c "select 1" && return 1
 	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
 
-	return 0
+    return 0
 }
+
+test_no_database_md5_auth_success() {
+	# Testing what happens on successful SCRAM auth connection to non-existent DB
+	# Segfaults have been seen after mock authentication was put in place
+
+	admin "set auth_type='md5'"
+	PGPASSWORD=foo psql -X -U muser1 -d nosuchdb1 -c "select 1" && return 1
+	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+
+    return 0
+}
+
+
 
 test_cancel() {
 	case `uname` in MINGW*) return 77;; esac
@@ -1453,6 +1466,7 @@ test_auto_database
 test_no_database
 test_no_database_authfail
 test_no_database_auth_user
+test_no_database_scram_auth_success
 test_no_database_md5_auth_success
 test_cancel
 test_cancel_wait

--- a/test/test.sh
+++ b/test/test.sh
@@ -1272,6 +1272,17 @@ test_no_database_auth_user() {
 	return 0
 }
 
+test_no_database_md5_auth_success() {
+	# Testing what happens on successful md5 auth connection to non-existent DB
+	# Segfaults have been seen after mock authentication was put in place
+
+	admin "set auth_type='md5'"
+	PGPASSWORD=foo psql -X -U scramuser1 -d nosuchdb1 -c "select 1" && return 1
+	grep -F "no such database: nosuchdb1" $BOUNCER_LOG || return 1
+
+	return 0
+}
+
 test_cancel() {
 	case `uname` in MINGW*) return 77;; esac
 
@@ -1442,6 +1453,7 @@ test_auto_database
 test_no_database
 test_no_database_authfail
 test_no_database_auth_user
+test_no_database_md5_auth_success
 test_cancel
 test_cancel_wait
 test_cancel_pool_size


### PR DESCRIPTION
We were seeing segfaults occur when using scram authentication to connect to non-existent databases. Looks like the issue arises when attempting to save the Scram authentication keys. This PR adds a check that the DB isn't fake before attempting to save the credentials