### PR TITLE
Add LDAP authentication to pgbouncer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
     - container:
         image: ubuntu:22.04
       env:
-        configure_args: '--with-cares --with-pam'
+        configure_args: '--with-cares --with-pam --with-ldap'
     - container:
         image: ubuntu:22.04
       env:
@@ -68,6 +68,7 @@ task:
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
     - apt-get -y install $pkgs
+    - apt-get -y install libldap-dev slapd ldap-utils
     - python3 -m venv /venv
     - /venv/bin/pip install -r requirements.txt
     - useradd user

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ pgbouncer_SOURCES = \
 	src/main.c \
 	src/objects.c \
 	src/pam.c \
+	src/ldapauth.c \
 	src/pktbuf.c \
 	src/pooler.c \
 	src/proto.c \
@@ -44,6 +45,7 @@ pgbouncer_SOURCES = \
 	include/messages.h \
 	include/objects.h \
 	include/pam.h \
+	include/ldapauth.h \
 	include/pktbuf.h \
 	include/pooler.h \
 	include/proto.h \
@@ -69,7 +71,7 @@ pgbouncer_SOURCES = \
 	include/common/uthash_lowercase.h
 
 UTHASH = uthash
-pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS)
+pgbouncer_CPPFLAGS = -Iinclude $(CARES_CFLAGS) $(LIBEVENT_CFLAGS) $(TLS_CPPFLAGS) $(LDAP_CFLAGS)
 pgbouncer_CPPFLAGS += -I$(UTHASH)/src
 
 # include libusual sources directly

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ To enable PAM authentication, `./configure` has a flag `--with-pam`
 (default value is no).  When compiled with PAM support, a new global
 authentication type `pam` is available to validate users through PAM.
 
+LDAP authentication
+------------------
+
+To enable LDAP authentication, `./configure` has a flag `--with-ldap`
+(default value is no).  When compiled with LDAP support, a new global
+authentication type `ldap` is available to validate users through LDAP.
+
 systemd integration
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ PgBouncer depends on few things to get compiled:
 * [OpenSSL] 1.0.1+ for TLS support
 * (optional) [c-ares] as alternative to Libevent's evdns
 * (optional) PAM libraries
+* (optional) LDAP libraries
 
 [GNU Make]: https://www.gnu.org/software/make/
 [Libevent]: http://libevent.org/

--- a/config.mak.in
+++ b/config.mak.in
@@ -61,6 +61,7 @@ LIBEVENT_LIBS = @LIBEVENT_LIBS@
 TLS_CPPFLAGS = @TLS_CPPFLAGS@
 TLS_LDFLAGS = @TLS_LDFLAGS@
 TLS_LIBS = @TLS_LIBS@
+LDAP_CFLAGS = @LDAP_CFLAGS@
 
 PANDOC = @PANDOC@
 PYTHON = @PYTHON@
@@ -70,5 +71,6 @@ WINDRES = @WINDRES@
 
 enable_debug = @enable_debug@
 tls_support = @tls_support@
+ldap_support = @ldap_support@
 
 host_cpu = @host_cpu@

--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,32 @@ AC_ARG_WITH(pam,
     fi
   ], [])
 
+dnl Check for LDAP authentication support
+ldap_support=no
+AC_ARG_WITH(ldap,
+  AS_HELP_STRING([--with-ldap], [build with LDAP support]),
+  [ LDAP=
+    if test "$withval" != no; then
+        have_pthreads=no
+        # Look for LDAP header and lib
+        AC_CHECK_HEADERS(ldap.h, [have_ldap_header=t])
+        AC_CHECK_HEADERS(pthread.h, [have_pthreads=yes])
+        AC_SEARCH_LIBS(ldap_initialize, ldap, [have_libldap=t])
+        AC_SEARCH_LIBS(pthread_create, pthread, [], [have_pthreads=no])
+        if test x"${have_pthreads}" != xyes; then
+           AC_MSG_ERROR([pthread library should be available for LDAP support])
+        fi
+        if test x"${have_ldap_header}" != x -a x"${have_libldap}" != x -a x"${have_pthreads}" = xyes; then
+          ldap_support=yes
+          AC_SUBST(ldap_support)
+          AC_SUBST(LDAP_CFLAGS, "-DLDAP_DEPRECATED")
+          AC_DEFINE(HAVE_LDAP, 1, [LDAP support])
+        else
+          AC_MSG_ERROR([ldap libarary or header is needed for LDAP compilation])
+        fi
+    fi
+  ], [])
+
 dnl Check for systemd support
 AC_MSG_CHECKING([whether to build with systemd support])
 AC_ARG_WITH(systemd,
@@ -192,6 +218,7 @@ else
   echo "  adns    = compat"
 fi
 echo "  pam     = $pam_support"
+echo "  ldap    = $ldap_support"
 echo "  systemd = $with_systemd"
 echo "  tls     = $tls_support"
 echo ""

--- a/doc/config.md
+++ b/doc/config.md
@@ -483,9 +483,11 @@ Otherwise, you can set `auth_type` directly to `ldap`. If `auth_type` is set to 
 ### auth_ldap_parameter
 This value is the global ldap parameter if `auth_type` is set to `ldap`. The value would be 
 similar to the ldap line in pg_hba.conf. If no `auth_ldap_parameter` is set, then ldap 
-authentication will fail. However, the value only contents the parameter after the 'ldap' 
-word of hba line. For example, if the hba line looks like this: `host all ldapuser1 
-0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`. 
+authentication will fail. However, the value only contains the parameter after the 'ldap' 
+keyword in the hba line. For example, if the hba line looks like this:
+```conf
+host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`. 
+```
 The corresponding value of `auth_ldap_parameter` would be 
 `ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -472,6 +472,23 @@ pam
     compatible with databases using the `auth_user` option. The service name reported to
     PAM is "pgbouncer". `pam` is not supported in the HBA configuration file.
 
+ldap
+:   LDAP is used to authenticate users with ldap server(OpenLDAP on Linux or AD on Windows).
+In order to use ldap, `auth_type` needs to be set to `hba`. The value of
+`auth_hba_file` has also to be set. And the content of the `auth_hba_file` could be
+the same format like `pg_hba.conf` in Postgres.
+Otherwise, you can set `auth_type` directly to `ldap`. If `auth_type` is set to `ldap`, the
+`auth_ldap_parameter` has also to be set.
+
+### auth_ldap_parameter
+This value is the global ldap parameter if `auth_type` is set to `ldap`. The value would be 
+similar to the ldap line in pg_hba.conf. If no `auth_ldap_parameter` is set, then ldap 
+authentication will fail. However, the value only contents the parameter after the 'ldap' 
+word of hba line. For example, if the hba line looks like this: `host all ldapuser1 
+0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`. 
+The corresponding value of `auth_ldap_parameter` would be 
+`ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
+
 ### auth_hba_file
 
 HBA configuration file to use when `auth_type` is `hba`. See

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -118,7 +118,7 @@ listen_port = 6432
 ;;; Authentication settings
 ;;;
 
-;; any, trust, plain, md5, cert, hba, pam
+;; any, trust, plain, md5, cert, hba, pam, ldap
 auth_type = md5
 auth_file = /etc/pgbouncer/userlist.txt
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -128,6 +128,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Path to Pg-ident-style map file
 ; auth_ident_file =
 
+;; Parameter ldap authentication would use when "auth_type = ldap"
+; auth_ldap_parameter = 
+
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.
 ;auth_query = SELECT rolname, CASE WHEN rolvaliduntil < pg_catalog.now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin

--- a/include/hba.h
+++ b/include/hba.h
@@ -50,6 +50,7 @@ struct HBARule {
 	struct HBAName user_name;
 	struct IdentMap *identmap;
 	int hba_linenr;
+	char *auth_options;
 };
 
 struct HBA {

--- a/include/ldapauth.h
+++ b/include/ldapauth.h
@@ -1,0 +1,32 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * LDAP support.
+ */
+
+/*
+ * Defines how many authentication requests can be placed to the waiting queue.
+ * When the queue is full calls to ldap_auth_begin() will block until there is
+ * free space in the queue.
+ */
+#define LDAP_REQUEST_QUEUE_SIZE 20
+
+void auth_ldap_init(void);
+void ldap_auth_begin(PgSocket *client, const char *passwd);
+int ldap_poll(void);

--- a/src/client.c
+++ b/src/client.c
@@ -401,7 +401,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		auth = rule->rule_method;
 #ifdef HAVE_LDAP
 		if (auth == AUTH_TYPE_LDAP) {
-				snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", rule->auth_options);
+			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", rule->auth_options);
 		}
 #endif
 		slog_noise(client, "HBA Line %d is matched", rule->hba_linenr);
@@ -515,7 +515,7 @@ static bool check_if_need_ldap_authentication(PgSocket *client, const char *dbna
 {
 	if (cf_auth_type == AUTH_TYPE_HBA) {
 		struct HBARule *rule = hba_eval(parsed_hba, &client->remote_addr, !!client->sbuf.tls,
-				REPLICATION_NONE, dbname, username);
+						REPLICATION_NONE, dbname, username);
 		if (rule != NULL && rule->rule_method == AUTH_TYPE_LDAP)
 			return true;
 	}

--- a/src/client.c
+++ b/src/client.c
@@ -596,7 +596,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 			return false;
 		}
 		/* Password will be set after successful authentication when not in takeover mode */
-		client->login_user_credentials = add_global_credentials(username, NULL);
+		client->login_user_credentials = find_or_add_new_global_credentials(username, NULL);
 		if (!client->login_user_credentials) {
 			slog_error(client, "set_pool(): failed to allocate new LDAP user");
 			disconnect_client(client, true, "bouncer resources exhaustion");

--- a/src/client.c
+++ b/src/client.c
@@ -147,7 +147,7 @@ static bool send_client_authreq(PgSocket *client)
 		uint8_t saltlen = 4;
 		get_random_bytes((void *)client->tmp_login_salt, saltlen);
 		SEND_generic(res, client, PqMsg_AuthenticationRequest, "ib", AUTH_REQ_MD5, client->tmp_login_salt, saltlen);
-	} else if (auth_type == AUTH_TYPE_PLAIN || auth_type == AUTH_TYPE_PAM) {
+	} else if (auth_type == AUTH_TYPE_PLAIN || auth_type == AUTH_TYPE_PAM || auth_type == AUTH_TYPE_LDAP) {
 		SEND_generic(res, client, PqMsg_AuthenticationRequest, "i", AUTH_REQ_PASSWORD);
 	} else if (auth_type == AUTH_TYPE_SCRAM_SHA_256) {
 		SEND_generic(res, client, PqMsg_AuthenticationRequest, "iss", AUTH_REQ_SASL, "SCRAM-SHA-256", "");
@@ -373,6 +373,17 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		return finish_client_login(client);
 
 	auth = cf_auth_type;
+#ifdef HAVE_LDAP
+	if (auth == AUTH_TYPE_LDAP) {
+		if (cf_auth_ldap_parameter == NULL) {
+			disconnect_client(client, true, "auth_ldap_parameter is null");
+			return false;
+		} else {
+			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", cf_auth_ldap_parameter);
+			slog_noise(client, "The value of cf_auth_ldap_parameter is %s", cf_auth_ldap_parameter);
+		}
+	} else
+#endif
 	if (auth == AUTH_TYPE_HBA) {
 		rule = hba_eval(
 			parsed_hba,
@@ -387,10 +398,21 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 			return false;
 		}
 
-		slog_noise(client, "HBA Line %d is matched", rule->hba_linenr);
-
 		auth = rule->rule_method;
+#ifdef HAVE_LDAP
+		if (auth == AUTH_TYPE_LDAP) {
+				snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", rule->auth_options);
+		}
+#endif
+		slog_noise(client, "HBA Line %d is matched", rule->hba_linenr);
 	}
+
+#ifndef HAVE_LDAP
+	if (auth == AUTH_TYPE_LDAP) {
+		disconnect_client(client, true, "ldap is not supported by this build");
+		return false;
+	}
+#endif
 
 	if (auth == AUTH_TYPE_MD5) {
 		if (get_password_type(client->login_user_credentials->passwd) == PASSWORD_TYPE_SCRAM_SHA_256)
@@ -413,6 +435,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	case AUTH_TYPE_PLAIN:
 	case AUTH_TYPE_MD5:
 	case AUTH_TYPE_PAM:
+	case AUTH_TYPE_LDAP:
 	case AUTH_TYPE_SCRAM_SHA_256:
 		ok = send_client_authreq(client);
 		break;
@@ -487,6 +510,18 @@ bool check_user_connection_count(PgSocket *client)
 
 	return false;
 }
+#ifdef HAVE_LDAP
+static bool check_if_need_ldap_authentication(PgSocket *client, const char *dbname, const char *username)
+{
+	if (cf_auth_type == AUTH_TYPE_HBA) {
+		struct HBARule *rule = hba_eval(parsed_hba, &client->remote_addr, !!client->sbuf.tls,
+				REPLICATION_NONE, dbname, username);
+		if (rule != NULL && rule->rule_method == AUTH_TYPE_LDAP)
+			return true;
+	}
+	return false;
+}
+#endif
 
 bool set_pool(PgSocket *client, const char *dbname, const char *username, const char *password, bool takeover)
 {
@@ -553,6 +588,24 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		if (!check_user_connection_count(client)) {
 			return false;
 		}
+#ifdef HAVE_LDAP
+	} else if (check_if_need_ldap_authentication(client, dbname, username) || cf_auth_type == AUTH_TYPE_LDAP) {
+		if (client->db->auth_user_credentials) {
+			slog_error(client, "LDAP can't be used together with database authentication");
+			disconnect_client(client, true, "bouncer config error");
+			return false;
+		}
+		/* Password will be set after successful authentication when not in takeover mode */
+		client->login_user_credentials = add_global_credentials(username, NULL);
+		if (!client->login_user_credentials) {
+			slog_error(client, "set_pool(): failed to allocate new LDAP user");
+			disconnect_client(client, true, "bouncer resources exhaustion");
+			return false;
+		}
+		if (!check_user_connection_count(client)) {
+			return false;
+		}
+#endif
 	} else {
 		client->login_user_credentials = find_global_credentials(username);
 
@@ -1326,6 +1379,15 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 						return false;
 					}
 					pam_auth_begin(client, passwd);
+					return false;
+				}
+
+				if (client->client_auth_type == AUTH_TYPE_LDAP) {
+					if (!sbuf_pause(&client->sbuf)) {
+						disconnect_client(client, true, "pause failed");
+						return false;
+					}
+					ldap_auth_begin(client, passwd);
 					return false;
 				}
 

--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -1,0 +1,855 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * LDAP authentication support. (Use the same thread model of pam)
+ */
+
+#include "bouncer.h"
+
+#ifdef HAVE_LDAP
+
+#include <pthread.h>
+#include <ldap.h>
+
+/* The request is waiting in the queue or being authenticated */
+#define LDAP_STATUS_IN_PROGRESS  1
+/* The request was successfully authenticated */
+#define LDAP_STATUS_SUCCESS      2
+/* The request failed authentication */
+#define LDAP_STATUS_FAILED       3
+
+/*
+ * How many microseconds to sleep between calls to ldap_poll in
+ * ldap_auth_begin when the queue is full.
+ * Default is 100 milliseconds.
+ */
+#define LDAP_QUEUE_WAIT_SLEEP_MCS    (100*1000)
+#define LDAP_LONG_LENGTH 256
+
+struct ldap_auth_request {
+	/* The socket we check authentication for */
+	PgSocket *client;
+
+	/* CHECKME: The socket can be closed and reused while the request is waiting
+	 * in the queue. Thus we need something to check the socket validity, and
+	 * combination of its state and connect_time seems to be the good one.
+	 */
+	usec_t connect_time;
+
+	/* Same as in client->remote_addr.
+	 * We want to minimize synchronization between the authentication thread and
+	 * the rest of pgbouncer, so the username and remote_addr are explicitly stored here.
+	 */
+	PgAddr remote_addr;
+
+	/* The request status, one of the LDAP_STATUS_* constants */
+	int status;
+	/* Protect status from main thread reading and worker thread writing at the same time */
+	pthread_mutex_t mutex;
+
+	/* The username (same as in client->login_user_credentials->name).
+	 * See the comment for remote_addr.
+	 */
+	char username[MAX_USERNAME];
+
+	/* password we should check for validity together with the socket's username */
+	char password[MAX_PASSWORD];
+
+	char ldap_parameters[MAX_LDAP_CONFIG];
+	int param_pos;
+	/* ldap specific parameters */
+	bool ldaptls;
+	char *ldapscheme;
+	char *ldapserver;
+	char *ldapbinddn;
+	char *ldapsearchattribute;
+	char *ldapsearchfilter;
+	char *ldapbasedn;
+	char *ldapbindpasswd;
+	char *ldapprefix;
+	char *ldapsuffix;
+	int ldapport;
+	int ldapscope;
+};
+
+
+/*
+ * All incoming requests are kept in a queue which is implemented using a ring buffer.
+ * Such structure allows to avoid memory reallocation thus minimizing amount of
+ * synchronization to be done between threads.
+ *
+ * ldap_first_taken_slot points to the first element in the queue;
+ * ldap_first_free_slot points to the next slot after the last element in the queue.
+ *
+ * if ldap_first_taken_slot == ldap_first_free_slot then the queue is considered empty;
+ *
+ */
+volatile int ldap_first_taken_slot;
+volatile int ldap_first_free_slot;
+struct ldap_auth_request ldap_auth_queue[LDAP_REQUEST_QUEUE_SIZE];
+
+pthread_t ldap_worker_thread;
+
+/*
+ * Mutex serializes access to the queue's tail when we add new requests or
+ * check that we reach the end of the queue in the worker thread.
+ *
+ * Head and tail are modified only in the main thread. In theory, being sure that they
+ * are properly aligned we can access them directly without any risk for data races.
+ * Practically, it is better to secure them anyway to increase overall stability and
+ * provide faster notification of new requests via the condition variable.
+ */
+pthread_mutex_t ldap_queue_tail_mutex;
+pthread_cond_t ldap_data_available;
+
+/* Forward declarations */
+static void *ldap_auth_worker(void *arg);
+static bool is_valid_socket(const struct ldap_auth_request *request);
+static void ldap_auth_finish(struct ldap_auth_request *request, int status);
+static void free_ldap_parameters(struct ldap_auth_request *request);
+static bool validate_ldap_parameters(struct ldap_auth_request *request);
+static bool parse_ldapurl(struct ldap_auth_request *request, char *val);
+static bool get_key_value(char **p, char **key, char **value);
+static bool initialize_ldap_parameters(struct ldap_auth_request *request, char *parameter);
+static bool InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **ldap);
+static void format_search_filter(char *filter, int length, const char *pattern, const char *user_name);
+static bool check_ldap_auth(struct ldap_auth_request *request);
+static int get_request_status(struct ldap_auth_request *request);
+static void set_request_status(struct ldap_auth_request *request, int status);
+
+/*
+ * Initialize LDAP subsystem.
+ */
+void auth_ldap_init(void)
+{
+	int rc;
+
+	ldap_first_taken_slot = 0;
+	ldap_first_free_slot = 0;
+
+	rc = pthread_mutex_init(&ldap_queue_tail_mutex, NULL);
+	if (rc != 0) {
+		die("failed to initialize a mutex: %s", strerror(errno));
+	}
+
+	rc = pthread_cond_init(&ldap_data_available, NULL);
+	if (rc != 0) {
+		die("failed to initialize a condition variable: %s", strerror(errno));
+	}
+
+	rc = pthread_create(&ldap_worker_thread, NULL, &ldap_auth_worker, NULL);
+	if (rc != 0) {
+		die("failed to create the authentication thread: %s", strerror(errno));
+	}
+	for (int i = 0; i < LDAP_REQUEST_QUEUE_SIZE; i++) {
+		struct ldap_auth_request *request = &ldap_auth_queue[i];
+		rc = pthread_mutex_init(&request->mutex, NULL);
+		if (rc != 0) {
+			die("failed to initialize a mutex for request[%d]: %s", i, strerror(errno));
+		}
+	}
+}
+
+static int get_request_status(struct ldap_auth_request *request)
+{
+	int rc = 0;
+
+	pthread_mutex_lock(&request->mutex);
+	rc = request->status;
+	pthread_mutex_unlock(&request->mutex);
+	return rc;
+}
+
+static void set_request_status(struct ldap_auth_request *request, int status)
+{
+	pthread_mutex_lock(&request->mutex);
+	request->status = status;
+	pthread_mutex_unlock(&request->mutex);
+}
+
+#define reset_ptr(ptr, name) ptr->name = NULL
+#define ldap_parameter_dup(ptr, name, src_str) \
+	do {                                           \
+		(ptr)->name = (ptr)->ldap_parameters + (ptr)->param_pos; \
+		safe_strcpy((ptr)->name, src_str, sizeof((ptr)->ldap_parameters) - (ptr)->param_pos); \
+		(ptr)->param_pos += strlen(src_str) + 1;      \
+		if ((ptr)->param_pos >= MAX_LDAP_CONFIG) {    \
+			log_warning("The parameters are longer than MAX_LDAP_CONFIG:%d", MAX_LDAP_CONFIG); \
+			return false; \
+		} \
+	} while (0)
+
+static void free_ldap_parameters(struct ldap_auth_request *request)
+{
+	memset(request->ldap_parameters, 0, MAX_LDAP_CONFIG);
+	request->param_pos = 0;
+	reset_ptr(request, ldapserver);
+	reset_ptr(request, ldapbinddn);
+	reset_ptr(request, ldapsearchattribute);
+	reset_ptr(request, ldapbasedn);
+	reset_ptr(request, ldapbindpasswd);
+	reset_ptr(request, ldapprefix);
+	reset_ptr(request, ldapsuffix);
+
+	request->ldaptls = false;
+	request->ldapport = 0;
+	request->ldapscope = 0;
+}
+
+static bool validate_ldap_parameters(struct ldap_auth_request *request)
+{
+	/*
+	 * LDAP can operate in two modes: either with a direct bind, using
+	 * ldapprefix and ldapsuffix, or using a search+bind, using
+	 * ldapbasedn, ldapbinddn, ldapbindpasswd and ldapsearchattribute.
+	 * Disallow mixing these parameters.
+	 */
+	if (request->ldapprefix || request->ldapsuffix) {
+		if (request->ldapbasedn ||
+		    request->ldapbinddn ||
+		    request->ldapbindpasswd ||
+		    request->ldapsearchattribute ||
+		    request->ldapsearchfilter) {
+			log_warning("cannot use ldapbasedn, ldapbinddn, ldapbindpasswd, "
+				    "ldapsearchattribute, ldapsearchfilter, or ldapurl together with ldapprefix");
+			return false;
+		}
+	} else if (!request->ldapbasedn) {
+		log_warning(
+			"authentication method \"ldap\" requires argument \"ldapbasedn\", \"ldapprefix\", or \"ldapsuffix\" to be set");
+		return false;
+	}
+	/*
+	 * When using search+bind, you can either use a simple attribute
+	 * (defaulting to "uid") or a fully custom search filter.  You can't
+	 * do both.
+	 */
+	if (request->ldapsearchattribute && request->ldapsearchfilter) {
+		log_warning("cannot use ldapsearchattribute together with ldapsearchfilter");
+		return false;
+	}
+
+	return true;
+}
+
+static bool parse_ldapurl(struct ldap_auth_request *request, char *val)
+{
+	LDAPURLDesc *urldata;
+	int rc = ldap_url_parse(val, &urldata);
+	if (rc != LDAP_SUCCESS) {
+		log_warning("could not parse LDAP URL \"%s\": %s", val, ldap_err2string(rc));
+		return false;
+	}
+
+	if (strcmp(urldata->lud_scheme, "ldap") != 0 &&
+	    strcmp(urldata->lud_scheme, "ldaps") != 0) {
+		log_warning("unsupported LDAP URL scheme: %s", urldata->lud_scheme);
+		ldap_free_urldesc(urldata);
+		return false;
+	}
+	if (urldata->lud_scheme)
+		ldap_parameter_dup(request, ldapscheme, urldata->lud_scheme);
+
+	if (urldata->lud_host)
+		ldap_parameter_dup(request, ldapserver, urldata->lud_host);
+	request->ldapport = urldata->lud_port;
+	if (urldata->lud_dn)
+		ldap_parameter_dup(request, ldapbasedn, urldata->lud_dn);
+	if (urldata->lud_attrs)
+		ldap_parameter_dup(request, ldapsearchattribute, urldata->lud_attrs[0]);/* only use first one */
+	request->ldapscope = urldata->lud_scope;
+	if (urldata->lud_filter)
+		ldap_parameter_dup(request, ldapsearchfilter, urldata->lud_filter);
+	ldap_free_urldesc(urldata);
+	return true;
+}
+
+static bool get_key_value(char **p, char **key, char **value)
+{
+	char *start, *name, *val;
+	char *name_copy = NULL;
+	char *val_copy = NULL;
+
+	start = *p;
+	while (*start && isspace(*start))
+		++start;/* skip space */
+	if (*start == ',')
+		++start;/* skip ',' */
+	while (*start && isspace(*start))
+		++start;/* skip space */
+
+	/* Parse key */
+	if (*start == '"') {
+		start++;
+		name = start;
+		name_copy = start;
+		while (*start) {
+			if (*start == '"' && *(start + 1) == '"') {
+				*name_copy++ = '"';
+				start += 2;
+			} else if (*start == '"') {
+				*name_copy = '\0';
+				start++;
+				break;
+			} else {
+				*name_copy++ = *start++;
+			}
+		}
+		if ((!*start) || (*start != '='))
+			return false;	/* Only key, stop scan */
+	} else {
+		name = start;
+		name_copy = start;
+		while ((*start) && (*start != '=')) {
+			*name_copy++ = *start++;
+		}
+		if ((!*start) || (*start != '='))
+			return false;	/* Only key, stop scan */
+		*name_copy = '\0';
+	}
+
+	start++;// skip '='
+	if (isspace(*start)) {
+		/* Not allow insert space after '=' */
+		return false;
+	}
+
+	/* Parse value */
+	if (*start == '"') {
+		start++;
+		val = start;
+		val_copy = start;
+		while (*start) {
+			if (*start == '"' && *(start + 1) == '"') {
+				*val_copy++ = '"';
+				start += 2;
+			} else if (*start == '"') {
+				*val_copy++ = '\0';
+				start++;
+				break;
+			} else {
+				*val_copy++ = *start++;
+			}
+		}
+	} else {
+		val = start;
+		val_copy = start;
+		while (*start && !(isspace(*start) || *start == ',')) {
+			*val_copy++ = *start++;
+		}
+		if (*val_copy != '\0') {
+			*val_copy = '\0';
+			start++;
+		}
+	}
+	if (*name == '\0' || *val == '\0') {
+		return false;	/* No key or no value */
+	}
+
+	*p = start;
+	*key = name;
+	*value = val;
+	return true;
+}
+static void ignore_space_from_end(char *parameter)
+{
+	int length = strlen(parameter);
+	while (length > 0 && isspace(parameter[length - 1])) {
+		parameter[length - 1] = '\0';
+		length--;
+	}
+	return;
+}
+
+static bool initialize_ldap_parameters(struct ldap_auth_request *request, char *parameter)
+{
+	char *key, *value;
+	char *p = parameter;
+
+	/* There maybe \n at the end of parameter */
+	ignore_space_from_end(parameter);
+	request->ldapscope = LDAP_SCOPE_SUBTREE;
+	while (get_key_value(&p, &key, &value)) {
+		if (strcmp(key, "ldaptls") == 0) {
+			if (strcmp(value, "1") == 0)
+				request->ldaptls = true;
+			else
+				request->ldaptls = false;
+		} else if (strcmp(key, "ldapscheme") == 0) {
+			if (strcmp(value, "ldap") != 0 && strcmp(value, "ldaps") != 0) {
+				log_warning("invalid ldapscheme value: \"%s\"", value);
+				return false;
+			}
+			ldap_parameter_dup(request, ldapscheme, value);
+		} else if (strcmp(key, "ldapport") == 0) {
+			request->ldapport = atoi(value);
+			if (request->ldapport == 0) {
+				log_warning("invalid LDAP port number: \"%s\"", value);
+				return false;
+			}
+		} else if (strcmp(key, "ldapserver") == 0) {
+			ldap_parameter_dup(request, ldapserver, value);
+		} else if (strcmp(key, "ldapbinddn") == 0) {
+			ldap_parameter_dup(request, ldapbinddn, value);
+		} else if (strcmp(key, "ldapsearchattribute") == 0) {
+			ldap_parameter_dup(request, ldapsearchattribute, value);
+		} else if (strcmp(key, "ldapsearchfilter") == 0) {
+			ldap_parameter_dup(request, ldapsearchfilter, value);
+		} else if (strcmp(key, "ldapbasedn") == 0) {
+			ldap_parameter_dup(request, ldapbasedn, value);
+		} else if (strcmp(key, "ldapbindpasswd") == 0) {
+			ldap_parameter_dup(request, ldapbindpasswd, value);
+		} else if (strcmp(key, "ldapprefix") == 0) {
+			ldap_parameter_dup(request, ldapprefix, value);
+		} else if (strcmp(key, "ldapsuffix") == 0) {
+			ldap_parameter_dup(request, ldapsuffix, value);
+		} else if (strcmp(key, "ldapurl") == 0) {
+			if (!parse_ldapurl(request, value))
+				return false;
+		} else {
+			log_warning("invalid LDAP key parameter: \"%s\"", key);
+			return false;
+		}
+	}
+
+	return validate_ldap_parameters(request);
+}
+
+/*
+ * Initiate the authentication request using LDAP. The request result will be
+ * available during next calls to ldap_poll(). The function might block if the
+ * request queue is full until there are free slots available.
+ * The function is called only from the main thread.
+ */
+void ldap_auth_begin(PgSocket *client, const char *passwd)
+{
+	int next_free_slot = (ldap_first_free_slot + 1) % LDAP_REQUEST_QUEUE_SIZE;
+	struct ldap_auth_request *request;
+
+	slog_debug(
+		client,
+		"ldap_auth_begin(): ldap_first_taken_slot=%d, ldap_first_free_slot=%d",
+		ldap_first_taken_slot, ldap_first_free_slot);
+
+	client->wait_for_auth = true;
+
+	/* Check that we have free slots in the queue, and if no
+	 * then block until one is available.
+	 */
+	if (next_free_slot == ldap_first_taken_slot)
+		slog_debug(client, "LDAP queue is full, waiting");
+
+	while (next_free_slot == ldap_first_taken_slot) {
+		if (ldap_poll() == 0) {
+			/* Sleep a bit between consequent queue checks to avoid consuming too much CPU */
+			usleep(LDAP_QUEUE_WAIT_SLEEP_MCS);
+		}
+	}
+
+	pthread_mutex_lock(&ldap_queue_tail_mutex);
+
+	request = &ldap_auth_queue[ldap_first_free_slot];
+
+	request->client = client;
+	request->connect_time = client->connect_time;
+	request->status = LDAP_STATUS_IN_PROGRESS;	/* This is protected by ldap_queue_tail_mutex */
+	memcpy(&request->remote_addr, &client->remote_addr, sizeof(client->remote_addr));
+	safe_strcpy(request->username, client->login_user_credentials->name, MAX_USERNAME);
+	safe_strcpy(request->password, passwd, MAX_PASSWORD);
+	/* Reset value of ldap parameters */
+	free_ldap_parameters(request);
+
+	ldap_first_free_slot = next_free_slot;
+
+	pthread_cond_signal(&ldap_data_available);
+	pthread_mutex_unlock(&ldap_queue_tail_mutex);
+}
+
+/*
+ * Checks for completed auth requests, returns amount of requests handled.
+ * The function is called only from the main thread.
+ */
+int ldap_poll(void)
+{
+	struct ldap_auth_request *request;
+	int count = 0;
+	int status = 0;
+
+	while (ldap_first_taken_slot != ldap_first_free_slot) {
+		request = &ldap_auth_queue[ldap_first_taken_slot];
+
+		status = get_request_status(request);
+		if (status == LDAP_STATUS_IN_PROGRESS) {
+			/* When still-in-progress slot is found there is no need to continue
+			 * the loop since all further requests will be in progress too.
+			 */
+			break;
+		}
+
+		if (is_valid_socket(request)) {
+			ldap_auth_finish(request, status);
+		}
+
+		count++;
+		ldap_first_taken_slot = (ldap_first_taken_slot + 1) % LDAP_REQUEST_QUEUE_SIZE;
+	}
+
+	return count;
+}
+
+
+/*
+ * The authentication thread function.
+ * Performs scanning the queue for new requests and calling LDAP for them.
+ */
+static void *ldap_auth_worker(void *arg)
+{
+	int current_slot = ldap_first_taken_slot;
+	struct ldap_auth_request *request;
+	int request_status = 0;
+
+	while (true) {
+		/* Wait for new data in the queue */
+		pthread_mutex_lock(&ldap_queue_tail_mutex);
+
+		while (current_slot == ldap_first_free_slot) {
+			pthread_cond_wait(&ldap_data_available, &ldap_queue_tail_mutex);
+		}
+
+		pthread_mutex_unlock(&ldap_queue_tail_mutex);
+
+		log_debug("ldap_auth_worker(): processing slot %d", current_slot);
+
+		/* We have at least one request in the queue */
+		request = &ldap_auth_queue[current_slot];
+		current_slot = (current_slot + 1) % LDAP_REQUEST_QUEUE_SIZE;
+
+		if (check_ldap_auth(request)) {
+			request_status = LDAP_STATUS_SUCCESS;
+		} else {
+			request_status = LDAP_STATUS_FAILED;
+		}
+		set_request_status(request, request_status);
+
+		log_debug("ldap_auth_worker(): authentication completed, status=%d", request_status);
+	}
+
+	return NULL;
+}
+
+/*
+ * Checks that the socket is still valid to be processed.
+ * By validity we mean that it is still waiting in the login phase
+ * and was not reused for other connections.
+ */
+static bool is_valid_socket(const struct ldap_auth_request *request)
+{
+	if (request->client->state != CL_LOGIN || request->client->connect_time != request->connect_time)
+		return false;
+	return true;
+}
+
+/*
+ * Finishes the handshake after successful or unsuccessful authentication.
+ * The function is only called from the main thread.
+ */
+static void ldap_auth_finish(struct ldap_auth_request *request, int status)
+{
+	PgSocket *client = request->client;
+	bool authenticated = (status == LDAP_STATUS_SUCCESS);
+
+	if (authenticated) {
+		safe_strcpy(client->login_user_credentials->passwd, request->password, sizeof(client->login_user_credentials->passwd));
+		sbuf_continue(&client->sbuf);
+	} else {
+		disconnect_client(client, true, "LDAP authentication failed");
+	}
+}
+
+/*
+ * Initialize a connection to the LDAP server, including setting up
+ * TLS if requested.
+ */
+static bool InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **ldap)
+{
+	int ldapversion = LDAP_VERSION3;
+	int r;
+	struct timeval ts;
+
+	if (strncmp(request->ldapserver, "ldaps://", 8) == 0 ||
+	    strncmp(request->ldapserver, "ldap://", 7) == 0) {
+		if ((r = ldap_initialize(ldap, request->ldapserver)) != LDAP_SUCCESS) {
+			log_warning("could not initialize LDAP: code: %d, msg: %s",
+				    r, ldap_err2string(r));
+			*ldap = NULL;
+			return false;
+		}
+	} else {
+		*ldap = ldap_init(request->ldapserver, request->ldapport);
+	}
+
+	if (!*ldap) {
+		log_warning("could not initialize LDAP: %m");
+		return false;
+	}
+
+	if ((r = ldap_set_option(*ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapversion)) != LDAP_SUCCESS) {
+		log_warning("could not set LDAP protocol version: %s", ldap_err2string(r));
+		ldap_unbind(*ldap);
+		return false;
+	}
+
+	ts.tv_sec = 3;
+	ts.tv_usec = 0;
+	if ((r = ldap_set_option(*ldap, LDAP_OPT_NETWORK_TIMEOUT, &ts)) != LDAP_SUCCESS) {
+		log_warning("could not set LDAP timeout: %s", ldap_err2string(r));
+		ldap_unbind(*ldap);
+		return false;
+	}
+
+	if (request->ldaptls) {
+		if ((r = ldap_start_tls_s(*ldap, NULL, NULL)) != LDAP_SUCCESS) {
+			log_warning("could not start LDAP TLS session: %s, server: %s, port: %d",
+				    ldap_err2string(r), request->ldapserver, request->ldapport);
+			ldap_unbind(*ldap);
+			return false;
+		}
+	}
+
+	return true;
+}
+/* Placeholders recognized by format_search_filter.  For now just one. */
+#define LPH_USERNAME "$username"
+#define LPH_USERNAME_LEN strlen(LPH_USERNAME)
+/*
+ * Return a newly allocated C string copied from "pattern" with all
+ * occurrences of the placeholder "$username" replaced with "user_name".
+ */
+static void format_search_filter(char *filter, int length, const char *pattern, const char *user_name)
+{
+	int cur_len = 0;
+	while ((*pattern != '\0') && (cur_len < length)) {
+		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0) {
+			cur_len += snprintf(filter + cur_len, length - cur_len, "%s", user_name);
+			pattern += LPH_USERNAME_LEN;
+		} else {
+			filter[cur_len++] = *pattern++;
+		}
+	}
+	if (cur_len >= length)
+		cur_len = length - 1;
+	filter[cur_len] = '\0';
+}
+/*
+ * Perform LDAP authentication
+ */
+static bool check_ldap_auth(struct ldap_auth_request *request)
+{
+	LDAP *ldap;
+	int r;
+	char fulluser[LDAP_LONG_LENGTH];
+
+	if (!initialize_ldap_parameters(request, request->client->ldap_parameters)) {
+		return false;
+	}
+	if ((!request->ldapserver || request->ldapserver[0] == '\0') &&
+	    (!request->ldapbasedn || request->ldapbasedn[0] == '\0')) {
+		log_warning("LDAP server not specified, and no ldapbasedn");
+		return false;
+	}
+
+	if (request->ldapport == 0) {
+		if (request->ldapscheme != NULL &&
+		    strcmp(request->ldapscheme, "ldaps") == 0)
+			request->ldapport = LDAPS_PORT;
+		else
+			request->ldapport = LDAP_PORT;
+	}
+
+	if (request->password[0] == '\0') {
+		return false;
+	}
+
+	if (InitializeLDAPConnection(request, &ldap) == false) {
+		return false;
+	}
+
+	if (request->ldapbasedn) {
+		/*
+		 * First perform an LDAP search to find the DN for the user we are
+		 * trying to log in as.
+		 */
+		char filter[LDAP_LONG_LENGTH];
+		LDAPMessage *search_message;
+		LDAPMessage *entry;
+		char *attributes[2] = {LDAP_NO_ATTRS, NULL};
+		char *dn;
+		char *c;
+		int count;
+
+		/*
+		 * Disallow any characters that we would otherwise need to escape,
+		 * since they aren't really reasonable in a username anyway. Allowing
+		 * them would make it possible to inject any kind of custom filters in
+		 * the LDAP filter.
+		 */
+		for (c = request->username; *c; c++) {
+			if (*c == '*' ||
+			    *c == '(' ||
+			    *c == ')' ||
+			    *c == '\\' ||
+			    *c == '/') {
+				log_warning("invalid character in user name for LDAP authentication");
+				return false;
+			}
+		}
+
+		/*
+		 * Bind with a pre-defined username/password (if available) for
+		 * searching. If none is specified, this turns into an anonymous bind.
+		 */
+		r = ldap_simple_bind_s(ldap,
+				       request->ldapbinddn ? request->ldapbinddn : "",
+				       request->ldapbindpasswd ? request->ldapbindpasswd : "");
+		if (r != LDAP_SUCCESS) {
+			log_warning("could not perform initial LDAP bind for ldapbinddn \"%s\" on server \"%s\": %s",
+				    request->ldapbinddn ? request->ldapbinddn : "",
+				    request->ldapserver, ldap_err2string(r));
+			ldap_unbind(ldap);
+			return false;
+		}
+
+		/* Fetch just one attribute, else *all* attributes are returned */
+		if (request->ldapsearchfilter) {
+			format_search_filter(filter, LDAP_LONG_LENGTH, request->ldapsearchfilter, request->username);
+		} else {
+			attributes[0] = request->ldapsearchattribute ? request->ldapsearchattribute : "uid";
+			attributes[1] = NULL;
+			snprintf(filter, LDAP_LONG_LENGTH, "(%s=%s)",
+				 attributes[0],
+				 request->username);
+		}
+
+		r = ldap_search_s(ldap,
+				  request->ldapbasedn,
+				  request->ldapscope,
+				  filter,
+				  attributes,
+				  0,
+				  &search_message);
+
+		if (r != LDAP_SUCCESS) {
+			log_warning("could not search LDAP for filter \"%s\" on server \"%s\": %s",
+				    filter, request->ldapserver, ldap_err2string(r));
+			ldap_unbind(ldap);
+			return false;
+		}
+
+		count = ldap_count_entries(ldap, search_message);
+		if (count != 1) {
+			if (count == 0) {
+				log_warning("LDAP user \"%s\" does not exist", request->username);
+				log_warning("LDAP search for filter \"%s\" on server \"%s\" returned no entries.",
+					    filter, request->ldapserver);
+			} else {
+				log_warning("LDAP user \"%s\" is not unique", request->username);
+				log_warning("LDAP search for filter \"%s\" on server \"%s\" returned %d entries.",
+					    filter, request->ldapserver, count);
+			}
+			ldap_unbind(ldap);
+			ldap_msgfree(search_message);
+			return false;
+		}
+
+		entry = ldap_first_entry(ldap, search_message);
+		dn = ldap_get_dn(ldap, entry);
+		if (dn == NULL) {
+			int error;
+
+			(void) ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &error);
+			log_warning("could not get dn for the first entry matching \"%s\" on server \"%s\": %s",
+				    filter, request->ldapserver, ldap_err2string(error));
+			ldap_unbind(ldap);
+			ldap_msgfree(search_message);
+			return false;
+		}
+		snprintf(fulluser, LDAP_LONG_LENGTH, "%s", dn);
+
+		ldap_memfree(dn);
+		ldap_msgfree(search_message);
+
+		/* Unbind and disconnect from the LDAP server */
+		r = ldap_unbind_s(ldap);
+		if (r != LDAP_SUCCESS) {
+			int error;
+
+			(void) ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &error);
+			log_warning("could not unbind after searching for user \"%s\" on server \"%s\": %s",
+				    fulluser, request->ldapserver, ldap_err2string(error));
+			return false;
+		}
+
+		/*
+		 * Need to re-initialize the LDAP connection, so that we can bind to
+		 * it with a different username.
+		 */
+		if (InitializeLDAPConnection(request, &ldap) == false) {
+			/* Error message already sent */
+			return false;
+		}
+	} else {
+		snprintf(fulluser, LDAP_LONG_LENGTH, "%s%s%s",
+			 request->ldapprefix ? request->ldapprefix : "",
+			 request->username,
+			 request->ldapsuffix ? request->ldapsuffix : "");
+	}
+
+	r = ldap_simple_bind_s(ldap, fulluser, request->password);
+	ldap_unbind(ldap);
+
+	if (r != LDAP_SUCCESS) {
+		log_warning("LDAP login failed for user %s on server %s: %s",
+			    fulluser, request->ldapserver, ldap_err2string(r));
+		return false;
+	}
+
+	return true;
+}
+
+#else /* !HAVE_LDAP */
+
+/* If LDAP is not supported then this dummy functions is used which always rejects passwords */
+
+void auth_ldap_init(void)
+{
+	/* do nothing */
+}
+
+void ldap_auth_begin(PgSocket *client, const char *passwd)
+{
+	die("LDAP authentication is not supported");
+}
+
+int ldap_poll(void)
+{
+	/* do nothing */
+	return 0;
+}
+
+#endif

--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -454,7 +454,7 @@ void ldap_auth_begin(PgSocket *client, const char *passwd)
 	 * then block until one is available.
 	 */
 	if (next_free_slot == ldap_first_taken_slot)
-		slog_debug(client, "LDAP queue is full, waiting");
+		slog_warning(client, "LDAP queue is full, waiting");
 
 	while (next_free_slot == ldap_first_taken_slot) {
 		if (ldap_poll() == 0) {

--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -614,7 +614,9 @@ static bool InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **l
 	struct timeval ts;
 
 	scheme = request->ldapscheme;
-	if (scheme == NULL)
+	if (request->ldaptls)
+		scheme = "ldaps";
+	else if (scheme == NULL)
 		scheme = "ldap";
 	/*
 	 * OpenLDAP provides a non-standard extension ldap_initialize() that takes
@@ -724,15 +726,6 @@ static bool InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **l
 		return false;
 	}
 
-	if (request->ldaptls) {
-		if ((r = ldap_start_tls_s(*ldap, NULL, NULL)) != LDAP_SUCCESS) {
-			log_warning("could not start LDAP TLS session: %s, server: %s, port: %d",
-				    ldap_err2string(r), request->ldapserver, request->ldapport);
-			ldap_unbind(*ldap);
-			return false;
-		}
-	}
-
 	return true;
 }
 /* Placeholders recognized by format_search_filter.  For now just one. */
@@ -776,11 +769,13 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 	}
 
 	if (request->ldapport == 0) {
-		if (request->ldapscheme != NULL &&
-		    strcmp(request->ldapscheme, "ldaps") == 0)
+		if (((request->ldapscheme != NULL &&
+		      strcmp(request->ldapscheme, "ldaps") == 0)) || (request->ldaptls))
 			request->ldapport = LDAPS_PORT;
 		else
 			request->ldapport = LDAP_PORT;
+	} else if (request->ldapport == LDAP_PORT && request->ldaptls) {
+		request->ldapport = LDAPS_PORT;
 	}
 
 	if (request->password[0] == '\0') {

--- a/src/main.c
+++ b/src/main.c
@@ -114,6 +114,7 @@ int cf_tcp_user_timeout;
 int cf_auth_type = AUTH_TYPE_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
+char *cf_auth_ldap_parameter;
 char *cf_auth_ident_file;
 char *cf_auth_user;
 char *cf_auth_query;
@@ -212,6 +213,9 @@ static const struct CfLookup auth_type_map[] = {
 #ifdef HAVE_PAM
 	{ "pam", AUTH_TYPE_PAM },
 #endif
+#ifdef HAVE_LDAP
+	{ "ldap", AUTH_TYPE_LDAP },
+#endif
 	{ "scram-sha-256", AUTH_TYPE_SCRAM_SHA_256 },
 	{ NULL }
 };
@@ -252,6 +256,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
+	CF_ABS("auth_ldap_parameter", CF_STR, cf_auth_ldap_parameter, 0, NULL),
 	CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),
 	CF_ABS("client_idle_timeout", CF_TIME_USEC, cf_client_idle_timeout, 0, "0"),
 	CF_ABS("client_login_timeout", CF_TIME_USEC, cf_client_login_timeout, 0, "60"),
@@ -868,6 +873,7 @@ static void main_loop_once(void)
 			log_warning("event_loop failed: %s", strerror(errno));
 	}
 	pam_poll();
+	ldap_poll();
 	per_loop_maint();
 	reuse_just_freed_objects();
 	rescue_timers();
@@ -965,6 +971,7 @@ static void cleanup(void)
 	xfree(&cf_auth_ident_file);
 	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_hba_file);
+	xfree(&cf_auth_ldap_parameter);
 	xfree(&cf_auth_query);
 	xfree(&cf_auth_user);
 	xfree(&cf_server_reset_query);
@@ -1133,6 +1140,7 @@ int main(int argc, char *argv[])
 	stats_setup();
 
 	pam_init();
+	auth_ldap_init();
 
 	if (did_takeover) {
 		takeover_finish();

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,8 +9,8 @@ SUBLOC = test
 DIST_SUBDIRS = ssl
 
 EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
-	     hba_test.eval hba_test.rules Makefile pgident.conf\
-	     test.ini stress.py userlist.txt pgbouncer_hba.conf \
+	     hba_test.eval hba_test.rules Makefile pgident.conf \
+	     test.ini stress.py userlist.txt pgbouncer_hba.conf start_openldap_server.sh \
 	     __init__.py conftest.py utils.py \
 	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
 	     test_load_balance_hosts.py test_misc.py test_no_database.py \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ import filelock
 import pytest
 
 from .utils import (
+    LDAP_SUPPORT,
     LINUX,
     LONG_PASSWORD,
     PG_SUPPORTS_SCRAM,
@@ -12,6 +13,7 @@ from .utils import (
     TLS_SUPPORT,
     USE_SUDO,
     Bouncer,
+    OpenLDAP,
     Postgres,
     Proxy,
     run,
@@ -129,6 +131,9 @@ def pg(tmp_path_factory, cert_dir):
     for i in range(8):
         pg.sql(f"create database p{i}")
 
+    if LDAP_SUPPORT:
+        pg.sql("create user ldapuser1 login password 'secret1'")
+
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
 
@@ -230,3 +235,12 @@ def pg_reset(pg):
         pg.reload()
 
     yield
+
+
+@pytest.fixture
+def openldap(tmp_path_factory):
+    """Starts an openldap server under tmp_path for tests in this process"""
+    ldap = OpenLDAP(tmp_path_factory.getbasetemp())
+    ldap.startup()
+    yield ldap
+    ldap.cleanup()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,6 +205,23 @@ async def bouncer(pg, tmp_path):
     await bouncer.cleanup()
 
 
+@pytest.mark.asyncio
+@pytest.fixture
+async def bouncer_with_openldap(pg, tmp_path, monkeypatch):
+    """Starts a new PgBouncer process"""
+    bouncer = Bouncer(pg, tmp_path / "bouncer")
+    ldap = OpenLDAP(tmp_path)
+    bouncer.ldap = ldap
+    monkeypatch.setenv("LDAPCONF", str(tmp_path / "ldap/ldap.conf"))
+    ldap.startup()
+    await bouncer.start()
+
+    yield bouncer
+
+    ldap.cleanup()
+    await bouncer.cleanup()
+
+
 @pytest.fixture(autouse=True)
 def pg_log(pg):
     """Prints the Postgres logs that were created during the test
@@ -235,12 +252,3 @@ def pg_reset(pg):
         pg.reload()
 
     yield
-
-
-@pytest.fixture
-def openldap(tmp_path_factory):
-    """Starts an openldap server under tmp_path for tests in this process"""
-    ldap = OpenLDAP(tmp_path_factory.getbasetemp())
-    ldap.startup()
-    yield ldap
-    ldap.cleanup()

--- a/test/start_openldap_server.sh
+++ b/test/start_openldap_server.sh
@@ -20,10 +20,13 @@ slapd_conf="${ldap_dir}/slapd.conf"
 slapd_pidfile="${ldap_dir}/slapd.pid"
 slapd_logfile="${ldap_dir}/slapd.log"
 ldap_conf="${ldap_dir}/ldap.conf"
+slapd_certs="${ldap_dir}/slapd-certs"
 
 ldap_server='localhost'
 ldap_port=$2
+ldaps_port=$3
 ldap_url="ldap://$ldap_server:$ldap_port"
+ldaps_url="ldaps://$ldap_server:$ldaps_port"
 ldap_basedn='dc=example,dc=net'
 ldap_rootdn='cn=Manager,dc=example,dc=net'
 ldap_rootpw='secret'
@@ -41,6 +44,11 @@ access to *
 
 database ldif
 directory $ldap_datadir
+
+TLSCACertificateFile $slapd_certs/ca.crt
+TLSCertificateFile $slapd_certs/server.crt
+TLSCertificateKeyFile $slapd_certs/server.key
+
 suffix "dc=example,dc=net"
 rootdn "$ldap_rootdn"
 rootpw $ldap_rootpw
@@ -55,6 +63,12 @@ if [ -d $ldap_datadir ];then
 	rm -rf $ldap_datadir
 fi
 mkdir -p $ldap_datadir
+mkdir -p ${slapd_certs}
+
+openssl req -new -nodes -keyout "$slapd_certs/ca.key" -x509 -out "$slapd_certs/ca.crt" -subj "/CN=CA"
+openssl req -new -nodes -keyout "$slapd_certs/server.key" -out "$slapd_certs/server.csr" -subj "/CN=server"
+openssl x509 -req -in "$slapd_certs/server.csr" -CA "$slapd_certs/ca.crt" -CAkey "$slapd_certs/ca.key" "-CAcreateserial" -out "$slapd_certs/server.crt"
+
 
 cat > $ldap_dir/ldap.ldif <<-EOF
 dn: dc=example,dc=net
@@ -79,11 +93,13 @@ mail: ldapuser1@example.net
 
 EOF
 
-echo $slapd "-f" $slapd_conf "-h" $ldap_url
-$slapd -f $slapd_conf -h $ldap_url && sleep 1
-export LDAPURI=$ldap_url
+
+export LDAPURI=$ldaps_url
 export LDAPBINDDN=$ldap_rootdn
 export LDAPCONF=$ldap_conf
+
+echo $slapd "-f" $slapd_conf "-h" "$ldap_url $ldaps_url"
+$slapd -f $slapd_conf -h "$ldap_url $ldaps_url" && sleep 1
 
 echo ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif -H $ldap_url
 ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif

--- a/test/start_openldap_server.sh
+++ b/test/start_openldap_server.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+slapd=/usr/sbin/slapd
+if [ -d '/etc/ldap/schema' ]
+then
+	ldap_schema_dir='/etc/ldap/schema'
+else
+	ldap_schema_dir='/etc/openldap/schema'
+fi
+if [ ! -e $slapd ];then
+	return 77
+fi
+
+
+ldap_dir=$1/ldap
+mkdir -p ${ldap_dir}
+ldap_datadir="${ldap_dir}/openldap-data"
+slapd_conf="${ldap_dir}/slapd.conf"
+slapd_pidfile="${ldap_dir}/slapd.pid"
+slapd_logfile="${ldap_dir}/slapd.log"
+ldap_conf="${ldap_dir}/ldap.conf"
+
+ldap_server='localhost'
+ldap_port=$2
+ldap_url="ldap://$ldap_server:$ldap_port"
+ldap_basedn='dc=example,dc=net'
+ldap_rootdn='cn=Manager,dc=example,dc=net'
+ldap_rootpw='secret'
+
+cat >$slapd_conf <<-EOF
+include $ldap_schema_dir/core.schema
+include $ldap_schema_dir/cosine.schema
+include $ldap_schema_dir/nis.schema
+include $ldap_schema_dir/inetorgperson.schema
+pidfile $slapd_pidfile
+logfile $slapd_logfile
+access to *
+        by * read
+        by anonymous auth
+
+database ldif
+directory $ldap_datadir
+suffix "dc=example,dc=net"
+rootdn "$ldap_rootdn"
+rootpw $ldap_rootpw
+EOF
+
+
+cat >$ldap_conf <<-EOF
+TLS_REQCERT never
+EOF
+
+if [ -d $ldap_datadir ];then
+	rm -rf $ldap_datadir
+fi
+mkdir -p $ldap_datadir
+
+cat > $ldap_dir/ldap.ldif <<-EOF
+dn: dc=example,dc=net
+objectClass: top
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: ExampleCo
+
+dn: uid=ldapuser1,dc=example,dc=net
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: ldapuser1
+sn: Lastname
+givenName: Firstname
+cn: First Test User
+displayName: First Test User
+uidNumber: 101
+gidNumber: 100
+homeDirectory: /home/ldapuser1
+mail: ldapuser1@example.net
+
+EOF
+
+echo $slapd "-f" $slapd_conf "-h" $ldap_url
+$slapd -f $slapd_conf -h $ldap_url && sleep 1
+export LDAPURI=$ldap_url
+export LDAPBINDDN=$ldap_rootdn
+export LDAPCONF=$ldap_conf
+
+echo ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif -H $ldap_url
+ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif
+ldappasswd -x -w $ldap_rootpw -s secret1 'uid=ldapuser1,dc=example,dc=net'
+ldapsearch -x -b "dc=example,dc=net"

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1176,14 +1176,15 @@ def test_ldap_auth(bouncer, openldap):
         )
     bouncer.admin("reload")
     bouncer.test(user="ldapuser1", password="secret1")
-    # 8 test "use ldaps in LDAP URLs"
-    with open(hba_conf_file, "w") as f:
-        f.write(
-            f"host all ldapuser1 0.0.0.0/0 ldap "
-            f'ldapurl="ldaps://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
-        )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    # # 8 test "use ldaps in LDAP URLs"
+    # LDAPs not supported yet, because the script are not started with ldaps.
+    # with open(hba_conf_file, "w") as f:
+    #     f.write(
+    #         f"host all ldapuser1 0.0.0.0/0 ldap "
+    #         f'ldapurl="ldaps://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
+    #     )
+    # bouncer.admin("reload")
+    # bouncer.test(user="ldapuser1", password="secret1")
     # 9 test "hba format"
     with open(hba_conf_file, "w") as f:
         f.write(

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1118,85 +1118,85 @@ def test_auth_user_at_db_level_with_same_forced_user(bouncer):
 @pytest.mark.skipif("MACOS", reason="OpenLDAP on OSX is difficult")
 @pytest.mark.skipif("WINDOWS", reason="We do not expect to support ldap on Windows")
 @pytest.mark.skipif(not LDAP_SUPPORT, reason="pgbouncer is built without LDAP support")
-def test_ldap_auth(bouncer, openldap):
+def test_ldap_auth(bouncer_with_openldap):
+    openldap = bouncer_with_openldap.ldap
     # 1 test "simple bind"
-    hba_conf_file = bouncer.config_dir / "ldap_hba.conf"
+    hba_conf_file = bouncer_with_openldap.config_dir / "ldap_hba.conf"
     with open(hba_conf_file, "w") as f:
         f.write(
             "host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 "
             f'ldapport={openldap.ldap_port} ldapprefix="uid=" '
             f'ldapsuffix=",dc=example,dc=net"\n'
         )
-    bouncer.write_ini(f"auth_type = hba")
-    bouncer.write_ini(f"auth_hba_file = {hba_conf_file}")
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.write_ini(f"auth_type = hba")
+    bouncer_with_openldap.write_ini(f"auth_hba_file = {hba_conf_file}")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 2 test "search+bind"
     with open(hba_conf_file, "w") as f:
         f.write(
             f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} ldapbasedn="dc=example,dc=net"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 3 test "multiple servers"
     with open(hba_conf_file, "w") as f:
         f.write(
             f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} ldapbasedn="dc=example,dc=net"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 4 test "LDAP URLs"
     with open(hba_conf_file, "w") as f:
         f.write(
             f'host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 5 test "ldapsearchattribute"
     with open(hba_conf_file, "w") as f:
         f.write(
             f"host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} "
             f'ldapbasedn="dc=example,dc=net" ldapsearchattribute=uid'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 6 test "search filters"
     with open(hba_conf_file, "w") as f:
         f.write(
             f"host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} "
             f'ldapbasedn="dc=example,dc=net" ldapsearchfilter="uid=$username"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 7 test "search filters in LDAP URLs"
     with open(hba_conf_file, "w") as f:
         f.write(
             f"host all ldapuser1 0.0.0.0/0 ldap "
             f'ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
-    # # 8 test "use ldaps in LDAP URLs"
-    # LDAPs not supported yet, because the script are not started with ldaps.
-    # with open(hba_conf_file, "w") as f:
-    #     f.write(
-    #         f"host all ldapuser1 0.0.0.0/0 ldap "
-    #         f'ldapurl="ldaps://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
-    #     )
-    # bouncer.admin("reload")
-    # bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8 test "use ldaps in LDAP URLs"
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f"host all ldapuser1 0.0.0.0/0 ldap "
+            f'ldapurl="ldaps://127.0.0.1:{openldap.ldaps_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
+        )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 9 test "hba format"
     with open(hba_conf_file, "w") as f:
         f.write(
             f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 "ldapport"={openldap.ldap_port} '
             f'ldapbasedn="dc=example,dc=net" ,ldapsearchfilter="uid=$username"'
         )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 10 test ldap auth_type
-    bouncer.write_ini(f"auth_type = ldap")
-    bouncer.write_ini(
+    bouncer_with_openldap.write_ini(f"auth_type = ldap")
+    bouncer_with_openldap.write_ini(
         f'auth_ldap_parameter = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
     )
-    bouncer.admin("reload")
-    bouncer.test(user="ldapuser1", password="secret1")
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1217,6 +1217,43 @@ def test_ldap_auth(bouncer_with_openldap):
         )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.6 test ldaps with normal ldap port, connection failed
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f"host all ldapuser1 0.0.0.0/0 ldap "
+            f'ldapurl="ldaps://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
+        )
+    bouncer_with_openldap.admin("reload")
+    with pytest.raises(psycopg.OperationalError, match="connection failed"):
+        bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.7 test ldap with ldaptls=1 with ldap ssl port, connection failed, compared with 8.2
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            "host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 "
+            f'ldapport={openldap.ldaps_port} ldapprefix="uid=" '
+            f'ldapsuffix=",dc=example,dc=net" ldaptls=1\n'
+        )
+    bouncer_with_openldap.admin("reload")
+    with pytest.raises(psycopg.OperationalError, match="connection failed"):
+        bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.8 test ldap with ldaps:// and ldaptls=1 both set with ldap port, connection failed
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f"host all ldapuser1 0.0.0.0/0 ldap "
+            f'ldapurl="ldaps://127.0.0.1:{openldap.ldaps_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))" ldaptls=1'
+        )
+    bouncer_with_openldap.admin("reload")
+    with pytest.raises(psycopg.OperationalError, match="connection failed"):
+        bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.9 test ldap with ldaps:// and ldaptls=1 both set with ldap ssl port, connection failed
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f"host all ldapuser1 0.0.0.0/0 ldap "
+            f'ldapurl="ldaps://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))" ldaptls=1'
+        )
+    bouncer_with_openldap.admin("reload")
+    with pytest.raises(psycopg.OperationalError, match="connection failed"):
+        bouncer_with_openldap.test(user="ldapuser1", password="secret1")
     # 9 test "hba format"
     with open(hba_conf_file, "w") as f:
         f.write(

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1177,11 +1177,43 @@ def test_ldap_auth(bouncer_with_openldap):
         )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")
-    # 8 test "use ldaps in LDAP URLs"
+    # 8 test ldaps
+    # 8.1 test "search filters in LDAP URLs"
     with open(hba_conf_file, "w") as f:
         f.write(
             f"host all ldapuser1 0.0.0.0/0 ldap "
             f'ldapurl="ldaps://127.0.0.1:{openldap.ldaps_port}/dc=example,dc=net??sub?(|(uid=$username)(mail=$username))"'
+        )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.2 test "simple bind"
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            "host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 "
+            f'ldapport={openldap.ldaps_port} ldapprefix="uid=" '
+            f'ldapsuffix=",dc=example,dc=net" ldaptls=1\n'
+        )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.3 test "search+bind"
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldaps_port} ldapbasedn="dc=example,dc=net" ldaptls=1'
+        )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.4 test "LDAP URLs"
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f'host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldaps://127.0.0.1:{openldap.ldaps_port}/dc=example,dc=net?uid?sub"'
+        )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 8.5 test "search filters in LDAP URLs"
+    with open(hba_conf_file, "w") as f:
+        f.write(
+            f"host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldaps_port} "
+            f'ldapbasedn="dc=example,dc=net" ldapsearchfilter="uid=$username" ldaptls=1'
         )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1190,7 +1190,7 @@ def test_ldap_auth(bouncer_with_openldap):
     with open(hba_conf_file, "w") as f:
         f.write(
             "host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 "
-            f'ldapport={openldap.ldaps_port} ldapprefix="uid=" '
+            f'ldapport={openldap.ldap_port} ldapprefix="uid=" '
             f'ldapsuffix=",dc=example,dc=net" ldaptls=1\n'
         )
     bouncer_with_openldap.admin("reload")
@@ -1198,7 +1198,7 @@ def test_ldap_auth(bouncer_with_openldap):
     # 8.3 test "search+bind"
     with open(hba_conf_file, "w") as f:
         f.write(
-            f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldaps_port} ldapbasedn="dc=example,dc=net" ldaptls=1'
+            f'host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} ldapbasedn="dc=example,dc=net" ldaptls=1'
         )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")
@@ -1212,7 +1212,7 @@ def test_ldap_auth(bouncer_with_openldap):
     # 8.5 test "search filters in LDAP URLs"
     with open(hba_conf_file, "w") as f:
         f.write(
-            f"host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldaps_port} "
+            f"host all ldapuser1 0.0.0.0/0 ldap ldapserver=127.0.0.1 ldapport={openldap.ldap_port} "
             f'ldapbasedn="dc=example,dc=net" ldapsearchfilter="uid=$username" ldaptls=1'
         )
     bouncer_with_openldap.admin("reload")

--- a/test/utils.py
+++ b/test/utils.py
@@ -42,6 +42,7 @@ NEW_SITE_SCRIPT = TEST_DIR / "ssl" / "newsite.sh"
 ENABLE_VALGRIND = bool(os.environ.get("ENABLE_VALGRIND"))
 HAVE_IPV6_LOCALHOST = bool(os.environ.get("HAVE_IPV6_LOCALHOST"))
 USE_SUDO = bool(os.environ.get("USE_SUDO"))
+START_OPENLDAP_SCRIPT = TEST_DIR / "start_openldap_server.sh"
 
 # The tests require that psql can connect to the PgBouncer admin
 # console.  On platforms that have getpeereid(), this works by
@@ -173,6 +174,15 @@ def get_tls_support():
 
 TLS_SUPPORT = get_tls_support()
 
+
+def get_ldap_support():
+    with open("../config.mak", encoding="utf-8") as f:
+        match = re.search(r"ldap_support = (\w+)", f.read())
+        assert match is not None
+        return match.group(1) == "yes"
+
+
+LDAP_SUPPORT = get_ldap_support()
 
 # this is out of ephemeral port range for many systems hence
 # it is a lower change that it will conflict with "in-use" ports
@@ -1200,3 +1210,26 @@ class Bouncer(QueryRunner):
             with self.ini_path.open("w") as f:
                 f.write(config_old)
             self.admin("RELOAD")
+
+
+class OpenLDAP:
+    def __init__(self, config_dir):
+        self.port_lock = PortLock()
+        self.config_dir = config_dir
+        self.slapd_pid_file = self.config_dir / "ldap" / "slapd.pid"
+
+    def startup(self):
+        run(f"{START_OPENLDAP_SCRIPT} {self.config_dir} {self.port_lock.port}")
+
+    @property
+    def ldap_port(self):
+        return self.port_lock.port
+
+    def stop(self):
+        with self.slapd_pid_file.open("r") as pid_file:
+            pid = pid_file.read()
+        os.kill(int(pid), signal.SIGTERM)
+
+    def cleanup(self):
+        self.stop()
+        self.port_lock.release()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1214,16 +1214,23 @@ class Bouncer(QueryRunner):
 
 class OpenLDAP:
     def __init__(self, config_dir):
-        self.port_lock = PortLock()
+        self.ldap_port_lock = PortLock()
+        self.ldaps_port_lock = PortLock()
         self.config_dir = config_dir
         self.slapd_pid_file = self.config_dir / "ldap" / "slapd.pid"
 
     def startup(self):
-        run(f"{START_OPENLDAP_SCRIPT} {self.config_dir} {self.port_lock.port}")
+        run(
+            f"{START_OPENLDAP_SCRIPT} {self.config_dir} {self.ldap_port_lock.port} {self.ldaps_port_lock.port}"
+        )
 
     @property
     def ldap_port(self):
-        return self.port_lock.port
+        return self.ldap_port_lock.port
+
+    @property
+    def ldaps_port(self):
+        return self.ldaps_port_lock.port
 
     def stop(self):
         with self.slapd_pid_file.open("r") as pid_file:
@@ -1232,4 +1239,5 @@ class OpenLDAP:
 
     def cleanup(self):
         self.stop()
-        self.port_lock.release()
+        self.ldap_port_lock.release()
+        self.ldaps_port_lock.release()


### PR DESCRIPTION
Previously the only way to support ldap is by using PAM in pgbouncer. Configuring pam with ldap is quite hard. So this commit adds ldap support to allow more users authenticate with ldap in pgbouncer. Because some of the ldap library functions are run in synchronous way, we follow the threading model that's also used for PAM.

The configuration uses the same style as Postgres, i.e. it's possible to configure LDAP through the hba file. In addition it's also possible to use a few newly introduced config keys to configure LDAP globally (in setups that don't use HBA).

The implementation is also heavily inspired by/copied from Postgres.