### PR TITLE
Add example of multiple values for ignore_startup_parameters

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -207,6 +207,9 @@ packets: `client_encoding`, `datestyle`, `timezone` and `standard_conforming_str
 All others parameters will raise an error.  To allow others parameters, they can be
 specified here, so that PgBouncer knows that they are handled by the admin and it can ignore them.
 
+If you need to specify multiple values, use a comma-separated list (e.g.
+`options,extra_float_digits`)
+
 Default: empty
 
 ### disable_pqexec


### PR DESCRIPTION
This PR adds an example of a multiple-valued `ignore_startup_parameters`. The syntax for an array of options isn't obvious, and can result in misconfigurations. For example, see the following 2 issues on zalando/postgres-operator:

- zalando/postgres-operator#984
- zalando/postgres-operator#1029