### PR TITLE
Track connection waiting for password in a pool

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -52,6 +52,7 @@ enum SocketState {
 	CL_FREE,		/* free_client_list */
 	CL_JUSTFREE,		/* justfree_client_list */
 	CL_LOGIN,		/* login_client_list */
+	CL_AUTH,		/* pool->auth_client_list */
 	CL_WAITING,		/* pool->waiting_client_list */
 	CL_WAITING_LOGIN,	/*   - but return to CL_LOGIN instead of CL_ACTIVE */
 	CL_ACTIVE,		/* pool->active_client_list */
@@ -260,6 +261,7 @@ struct PgPool {
 	PgDatabase *db;			/* corresponding database */
 	PgUser *user;			/* user logged in as */
 
+	struct StatList auth_client_list;	/* waiting events logged but not yet authenticated in clients */
 	struct StatList active_client_list;	/* waiting events logged in clients */
 	struct StatList waiting_client_list;	/* client waits for a server to be available */
 	struct StatList cancel_req_list;	/* closed client connections with server key */
@@ -302,6 +304,7 @@ struct PgPool {
 		statlist_count(&(pool)->new_server_list))
 
 #define pool_client_count(pool) ( \
+		statlist_count(&(pool)->auth_client_list) + \
 		statlist_count(&(pool)->active_client_list) + \
 		statlist_count(&(pool)->waiting_client_list))
 

--- a/src/client.c
+++ b/src/client.c
@@ -264,6 +264,8 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	case AUTH_PAM:
 	case AUTH_SCRAM_SHA_256:
 		ok = send_client_authreq(client);
+		/* we are waiting for password packet - add to connection list, so pool is not removed */
+		change_client_state(client, CL_AUTH);
 		break;
 	case AUTH_CERT:
 		ok = login_via_cert(client);
@@ -1034,6 +1036,7 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		client->request_time = get_cached_time();
 		switch (client->state) {
 		case CL_LOGIN:
+		case CL_AUTH:
 			res = handle_client_startup(client, &pkt);
 			break;
 		case CL_ACTIVE:


### PR DESCRIPTION
After receiving `PKT_STARTUP` packet, client is associated to database
(result of `find_database` is stored in `client->db`).

For some authentication mechanisms (like plain or MD5), pgbouncer is
waiting for password packet, before it switches client to `CL_ACTIVE`
state).

If there is enough delay between these two packets, it can happen that
`do_full_maint` is called.
These clients are not linked anywhere in pool, so it can happen that
auto database can be marked as inactive.

When password packet arrives, there is no mechanism to un-mark such
database as inactive (in case of no new connections), so it can be
later killed leading to errors like:

```
Jun 27 08:46:13 node001 pgbouncer[16819]: C-0x115b218: db_001/user01@10.1.1.1:43132 pooler error: database removed severity=warning
```

Even worse is situation, when password packet arrives after
`autodb_idle_timeout`, which leads to use-after-free situation (as used
database is free). Fortunately this is not probable, as
`autodb_idle_timeout` is generally larger that delay between first two
packets.

This fix ensures, that after `PKT_STARTUP` client connection is tracked
in a pool for all cases (base on code analysis, this seemd as last place).