### PR TITLE
Add GSS/KRB5 Encryption support when connecting to a backend server

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,9 +64,14 @@ task:
         image: debian:oldstable
       env:
         PGVERSION: 11
+    - container:
+        image: ubuntu:22.04
+      env:
+        configure_args: '--with-server-gssenc'
   setup_script:
     - apt-get update
-    - apt-get -y install curl gnupg lsb-release
+    - env DEBIAN_FRONTEND=noninteractive apt-get -y install curl gnupg lsb-release krb5-kdc krb5-admin-server krb5-user libkrb5-dev
+    - ./test/gss/newkdc.sh
     - curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
     - apt-get update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,7 +150,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 wget
+    - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - adduser --disabled-password user

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,22 @@ if test "$with_systemd" = yes; then
   AC_SEARCH_LIBS(sd_notify, systemd)
 fi
 
+dnl Check for server GSSAPI Encryption support
+server_gssenc_support=no
+AC_ARG_WITH(server-gssenc,
+  AC_HELP_STRING([--with-server-gssenc], [build with server GSSAPI Encryption support]),
+  [ GSS=
+    if test "$withval" != no; then
+      # Look for GSSAPI header and lib
+      AC_CHECK_HEADERS(gssapi.h, [have_gss_header=y])
+      AC_SEARCH_LIBS(gss_accept_sec_context, [gssapi_krb5 gssapi], [have_libgss=t])
+      if test x"${have_gss_header}" != x -a x"${have_libgss}" != x; then
+        server_gssenc_support=yes
+        AC_DEFINE(HAVE_SERVER_GSSENC, 1, [Server GSSAPI Encryption support])
+      fi
+    fi
+  ], [])
+
 ##
 ## DNS backend
 ##
@@ -236,4 +252,5 @@ fi
 echo "  pam     = $pam_support"
 echo "  systemd = $with_systemd"
 echo "  tls     = $tls_support"
+echo "  servergssenc     = $server_gssenc_support"
 echo ""

--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ if test "$with_systemd" = yes; then
 fi
 
 dnl Check for server GSSAPI Encryption support
-server_gssenc_support=no
+server_gssenc_support=yes
 AC_ARG_WITH(server-gssenc,
   AC_HELP_STRING([--with-server-gssenc], [build with server GSSAPI Encryption support]),
   [ GSS=
@@ -105,6 +105,9 @@ AC_ARG_WITH(server-gssenc,
       if test x"${have_gss_header}" != x -a x"${have_libgss}" != x; then
         server_gssenc_support=yes
         AC_DEFINE(HAVE_SERVER_GSSENC, 1, [Server GSSAPI Encryption support])
+      else
+        server_gssenc_support=no
+        AC_DEFINE(HAVE_SERVER_GSSENC, 0, [Server GSSAPI Encryption support])
       fi
     fi
   ], [])

--- a/doc/config.md
+++ b/doc/config.md
@@ -739,6 +739,18 @@ Default: `fast`
 
 ### server_gssencmode
 
+This option determines whether or with what priority a secure GSS TCP/IP connection will be negotiated with the server. There are three modes:
+
+disable
+:   only try a non-GSSAPI-encrypted connection
+
+prefer (default)
+:   if there are GSSAPI credentials present (i.e., in a credentials cache), first try a GSSAPI-encrypted connection; if that fails or there are no credentials, try a non-GSSAPI-encrypted connection. This is the default when pgbouncer has been compiled with GSSAPI support.
+
+require
+:only try a GSSAPI-encrypted connection
+
+server_gssencmode is ignored for Unix domain socket communication. If pgbouncer is compiled without GSSAPI support, using the require option will cause an error, while prefer will be accepted but pgbouncer will not actually attempt a GSSAPI-encrypted connection.
 
 ## Dangerous timeouts
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -737,6 +737,8 @@ version 1.3 connections.
 
 Default: `fast`
 
+### server_gssencmode
+
 
 ## Dangerous timeouts
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -107,6 +107,13 @@ listen_port = 6432
 ;; fast, normal, secure, legacy, <ciphersuite string>
 ;server_tls_ciphers = fast
 
+;;; 
+;;; GSSAPI settings for connecting to backend databases
+;;;
+
+;; disable, allow, require
+;server_gssencmode = disable
+
 ;;;
 ;;; Authentication settings
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -81,6 +81,12 @@ enum SSLMode {
 	SSLMODE_VERIFY_FULL
 };
 
+//enum ServerGSSEncMode {
+//        SERVER_GSSENCMODE_DISABLED,
+//        SERVER_GSSENCMODE_ENABLED,
+//        SERVER_GSSENCMODE_REQUIRE
+//};
+
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
 
 
@@ -409,6 +415,7 @@ struct PgSocket {
 	bool wait_for_response:1;/* console client: waits for completion of PAUSE/SUSPEND cmd */
 
 	bool wait_sslchar:1;	/* server: waiting for ssl response: S/N */
+	bool wait_gssencchar:1;	/* server: waiting for gss enc response: G/N */
 
 	int expect_rfq_count;	/* client: count of ReadyForQuery packets client should see */
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -42,6 +42,13 @@
 #define sd_notifyf(ue, f, ...)
 #endif
 
+#ifdef HAVE_GSSAPI_H
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_ext.h>
+#include <gssapi/gssapi_krb5.h>
+#endif
+
+
 
 /* global libevent handle */
 extern struct event_base *pgb_event_base;
@@ -81,11 +88,12 @@ enum SSLMode {
 	SSLMODE_VERIFY_FULL
 };
 
-//enum ServerGSSEncMode {
-//        SERVER_GSSENCMODE_DISABLED,
-//        SERVER_GSSENCMODE_ENABLED,
-//        SERVER_GSSENCMODE_REQUIRE
-//};
+enum ServerGSSEncMode {
+        SERVER_GSSENCMODE_DISABLED,
+        SERVER_GSSENCMODE_ALLOW,
+        SERVER_GSSENCMODE_PREFER,
+        SERVER_GSSENCMODE_REQUIRE
+};
 
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -363,6 +363,7 @@ struct PgDatabase {
 	int pool_mode;		/* pool mode for this database */
 	int max_db_connections;	/* max server connections between all pools */
 	char *connect_query;	/* startup commands to send to server after connect */
+	char *gssapi_spn; /* GSSAPI SPN (Service Principal Name) */
 
 	struct PktBuf *startup_params; /* partial StartupMessage (without user) be sent to server */
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -88,11 +88,10 @@ enum SSLMode {
 	SSLMODE_VERIFY_FULL
 };
 
-enum ServerGSSEncMode {
-        SERVER_GSSENCMODE_DISABLED,
-        SERVER_GSSENCMODE_ALLOW,
-        SERVER_GSSENCMODE_PREFER,
-        SERVER_GSSENCMODE_REQUIRE
+enum GSSEncMode {
+    GSSENCMODE_DISABLE,
+    GSSENCMODE_PREFER,
+    GSSENCMODE_REQUIRE
 };
 
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
@@ -573,6 +572,9 @@ extern char *cf_server_tls_ca_file;
 extern char *cf_server_tls_cert_file;
 extern char *cf_server_tls_key_file;
 extern char *cf_server_tls_ciphers;
+
+extern int cf_server_gssencmode;
+
 
 extern const struct CfLookup pool_mode_map[];
 

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -115,6 +115,9 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 #define pktbuf_write_SSLRequest(buf) \
 	pktbuf_write_generic(buf, PKT_SSLREQ, "")
 
+#define pktbuf_write_GSSEncRequest(buf) \
+	pktbuf_write_generic(buf, PKT_GSSENCREQ, "")
+
 /*
  * Shortcut for creating DataRow in memory.
  */

--- a/include/proto.h
+++ b/include/proto.h
@@ -50,6 +50,7 @@ bool welcome_client(PgSocket *client) _MUSTCHECK;
 bool answer_authreq(PgSocket *server, PktHdr *pkt) _MUSTCHECK;
 
 bool send_startup_packet(PgSocket *server) _MUSTCHECK;
+bool send_gssencreq_packet(PgSocket *server) _MUSTCHECK;
 bool send_sslreq_packet(PgSocket *server) _MUSTCHECK;
 
 int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...) _MUSTCHECK;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -29,6 +29,7 @@ typedef enum {
 	SBUF_EV_CONNECT_OK,	/* got connection */
 	SBUF_EV_FLUSH,		/* data is sent, buffer empty */
 	SBUF_EV_PKT_CALLBACK,	/* next part of pkt data */
+	SBUF_EV_GSSENC_READY,	/* GSSENC was established */
 	SBUF_EV_TLS_READY	/* TLS was established */
 } SBufEvent;
 
@@ -73,7 +74,7 @@ struct SBuf {
 	uint8_t wait_type;	/* track wait state */
 	uint8_t pkt_action;	/* method for handling current pkt */
 	uint8_t tls_state;	/* progress of tls */
-	uint8_t gss_state;	/* progress of gss */
+	uint8_t gssenc_state;	/* progress of gssenc */
 
 	int sock;		/* fd for this socket */
 

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -73,6 +73,7 @@ struct SBuf {
 	uint8_t wait_type;	/* track wait state */
 	uint8_t pkt_action;	/* method for handling current pkt */
 	uint8_t tls_state;	/* progress of tls */
+	uint8_t gss_state;	/* progress of gss */
 
 	int sock;		/* fd for this socket */
 
@@ -84,8 +85,9 @@ struct SBuf {
 
 	IOBuf *io;		/* data buffer, lazily allocated */
 
-	const SBufIO *ops;	/* normal vs. TLS */
+	const SBufIO *ops;	/* normal vs. TLS vs. GSS */
 	struct tls *tls;	/* TLS context */
+	struct gss_ctx_id_struct *gss;
 	const char *tls_host;	/* target hostname */
 };
 
@@ -110,6 +112,7 @@ extern int client_accept_sslmode;
  */
 extern int server_connect_sslmode;
 
+bool sbuf_gssenc_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -43,7 +43,7 @@ typedef enum {
  */
 #define SBUF_SMALL_PKT	64
 
-#ifdef HAVE_SERVER_GSSENC
+#ifdef HAVE_GSSAPI_H
 
 #define GSSENC_WANT_POLLOUT -3
 #define GSSENC_WANT_POLLIN -2
@@ -98,7 +98,7 @@ struct SBuf {
 	const SBufIO *ops;	/* normal vs. TLS vs. GSS */
 	struct tls *tls;	/* TLS context */
 	struct gss_ctx_id_struct *gss;
-#ifdef HAVE_SERVER_GSSENC
+#ifdef HAVE_GSSAPI_H
 	char	   *gss_SendBuffer; /* Encrypted data waiting to be sent */
 	int			gss_SendLength; /* End of data available in gss_SendBuffer */
 	int			gss_SendNext;	/* Next index to send a byte from
@@ -135,15 +135,20 @@ bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_
  * usually you should use this variable over cf_client_tls_sslmode.
  */
 extern int client_accept_sslmode;
+
 /*
  * Same as client_accept_sslmode, but for server connections.
  */
 extern int server_connect_sslmode;
 
+extern int server_connect_gssencmode;
+
 bool sbuf_gssenc_connect(SBuf *sbuf, char *gssapi_spn)  _MUSTCHECK;
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
+
+bool sbuf_gssenc_setup(void);
 
 bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -140,7 +140,7 @@ extern int client_accept_sslmode;
  */
 extern int server_connect_sslmode;
 
-bool sbuf_gssenc_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
+bool sbuf_gssenc_connect(SBuf *sbuf, char *gssapi_spn)  _MUSTCHECK;
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;

--- a/src/admin.c
+++ b/src/admin.c
@@ -292,7 +292,7 @@ static bool send_one_fd(PgSocket *admin,
 	msg.msg_iovlen = 1;
 
 	/* attach a fd */
-	if (pga_is_unix(&admin->remote_addr) && admin->own_user && !admin->sbuf.tls) {
+	if (pga_is_unix(&admin->remote_addr) && admin->own_user && !admin->sbuf.tls && !admin->sbuf.gss) {
 		msg.msg_control = cntbuf;
 		msg.msg_controllen = sizeof(cntbuf);
 
@@ -339,6 +339,10 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 
 	/* Skip TLS sockets */
 	if (sk->sbuf.tls || (sk->link && sk->link->sbuf.tls))
+		return true;
+
+	/* Skip GSSENC sockets */
+	if (sk->sbuf.gss || (sk->link && sk->link->sbuf.gss))
 		return true;
 
 	mbuf_init_fixed_reader(&tmp, sk->cancel_key, 8);

--- a/src/admin.c
+++ b/src/admin.c
@@ -242,6 +242,10 @@ static bool admin_set(PgSocket *admin, const char *key, const char *val)
 				if (!sbuf_tls_setup())
 					pktbuf_write_Notice(buf, "TLS settings could not be applied, still using old configuration");
 			}
+			if (strstr(key, "_gss") != NULL) {
+				if (!sbuf_gssenc_setup())
+					pktbuf_write_Notice(buf, "GSSENC settings could not be applied, still using old configuration")
+			}
 			snprintf(tmp, sizeof(tmp), "SET %s=%s", key, val);
 			return admin_flush(admin, buf, tmp);
 		} else {
@@ -988,6 +992,8 @@ static bool admin_cmd_reload(PgSocket *admin, const char *arg)
 	load_config();
 	if (!sbuf_tls_setup())
 		log_error("TLS configuration could not be reloaded, keeping old configuration");
+	if (!sbuf_gssenc_setup())
+		log_error("GSSENC configuration could not be reloaded, keeping old configuration");
 	return admin_ready(admin, "RELOAD");
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -985,6 +985,7 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 	switch (evtype) {
 	case SBUF_EV_CONNECT_OK:
 	case SBUF_EV_CONNECT_FAILED:
+	case SBUF_EV_GSSENC_READY:
 		/* ^ those should not happen */
 	case SBUF_EV_RECV_FAILED:
 		/*

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -709,6 +709,7 @@ void kill_database(PgDatabase *db)
 	if (db->forced_user)
 		slab_free(user_cache, db->forced_user);
 	free(db->connect_query);
+	free(db->gssapi_spn);
 	if (db->inactive_time) {
 		statlist_remove(&autodatabase_idle_list, &db->head);
 	} else {

--- a/src/loader.c
+++ b/src/loader.c
@@ -172,6 +172,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	char *datestyle = NULL;
 	char *timezone = NULL;
 	char *connect_query = NULL;
+	char *gssapi_spn = NULL;
 	char *appname = NULL;
 
 	cv.value_p = &pool_mode;
@@ -247,6 +248,12 @@ bool parse_database(void *base, const char *name, const char *connstr)
 				log_error("out of memory");
 				goto fail;
 			}
+		} else if (strcmp("gssapi_spn", key) == 0) {
+			gssapi_spn = strdup(val);
+			if (!gssapi_spn) {
+				log_error("out of memory");
+				goto fail;
+			}
 		} else if (strcmp("application_name", key) == 0) {
 			appname = val;
 		} else {
@@ -286,6 +293,9 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		} else if (!!connect_query != !!db->connect_query
 			   || (connect_query && strcmp(connect_query, db->connect_query) != 0))	{
 			changed = true;
+		} else if (!!gssapi_spn != !!db->gssapi_spn
+			   || (gssapi_spn && strcmp(gssapi_spn, db->gssapi_spn) != 0))	{
+			changed = true;
 		}
 		if (changed)
 			tag_database_dirty(db);
@@ -301,6 +311,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	db->max_db_connections = max_db_connections;
 	free(db->connect_query);
 	db->connect_query = connect_query;
+	free(db->gssapi_spn);
+	db->gssapi_spn = gssapi_spn;
 
 	if (db->startup_params) {
 		msg = db->startup_params;

--- a/src/main.c
+++ b/src/main.c
@@ -225,10 +225,9 @@ const struct CfLookup sslmode_map[] = {
 };
 
 const struct CfLookup gssencmode_map[] = {
-	{ "disable", SERVER_GSSENCMODE_DISABLED },
-	{ "allow", SERVER_GSSENCMODE_ALLOW },
-	{ "prefer", SERVER_GSSENCMODE_PREFER },
-	{ "require", SERVER_GSSENCMODE_REQUIRE },
+	{ "disable", GSSENCMODE_DISABLE },
+	{ "prefer", GSSENCMODE_PREFER },
+	{ "require", GSSENCMODE_REQUIRE },
 	{ NULL }
 };
 
@@ -290,7 +289,7 @@ CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
 CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
 CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
 CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
-CF_ABS("server_gssencmode", CF_LOOKUP(gssencmode_map), cf_server_gssencmode, 0, "disable"),
+CF_ABS("server_gssencmode", CF_LOOKUP(gssencmode_map), cf_server_gssencmode, 0, "prefer"), /* libpq default */
 CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
 CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 CF_ABS("server_reset_query", CF_STR, cf_server_reset_query, 0, "DISCARD ALL"),
@@ -519,6 +518,8 @@ static void handle_sighup(int sock, short flags, void *arg)
 	load_config();
 	if (!sbuf_tls_setup())
 		log_error("TLS configuration could not be reloaded, keeping old configuration");
+	if (!sbuf_gssenc_setup())
+		log_error("GSSENC configuration could not be reloaded, keeping old configuration");
 	sd_notify(0, "READY=1");
 }
 #endif
@@ -953,6 +954,9 @@ int main(int argc, char *argv[])
 
 	if (!sbuf_tls_setup())
 		die("TLS setup failed");
+
+	if (!sbuf_gssenc_setup())
+		die("GSSENC setup failed");
 
 	/* prefer cmdline over config for username */
 	if (arg_username) {

--- a/src/main.c
+++ b/src/main.c
@@ -177,6 +177,8 @@ char *cf_client_tls_ciphers;
 char *cf_client_tls_dheparams;
 char *cf_client_tls_ecdhecurve;
 
+int cf_server_gssencmode;
+
 int cf_server_tls_sslmode;
 char *cf_server_tls_protocols;
 char *cf_server_tls_ca_file;
@@ -219,6 +221,14 @@ const struct CfLookup sslmode_map[] = {
 	{ "require", SSLMODE_REQUIRE },
 	{ "verify-ca", SSLMODE_VERIFY_CA },
 	{ "verify-full", SSLMODE_VERIFY_FULL },
+	{ NULL }
+};
+
+const struct CfLookup gssencmode_map[] = {
+	{ "disable", SERVER_GSSENCMODE_DISABLED },
+	{ "allow", SERVER_GSSENCMODE_ALLOW },
+	{ "prefer", SERVER_GSSENCMODE_PREFER },
+	{ "require", SERVER_GSSENCMODE_REQUIRE },
 	{ NULL }
 };
 
@@ -280,6 +290,7 @@ CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "select 1"),
 CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
 CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
 CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
+CF_ABS("server_gssencmode", CF_LOOKUP(gssencmode_map), cf_server_gssencmode, 0, "disable"),
 CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
 CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 CF_ABS("server_reset_query", CF_STR, cf_server_reset_query, 0, "DISCARD ALL"),

--- a/src/proto.c
+++ b/src/proto.c
@@ -576,6 +576,13 @@ bool send_sslreq_packet(PgSocket *server)
 	return res;
 }
 
+bool send_gssencreq_packet(PgSocket *server)
+{
+	int res;
+	SEND_wrap(16, pktbuf_write_GSSEncRequest, res, server);
+	return res;
+}
+
 /*
  * decode DataRow packet (opposite of pktbuf_write_DataRow)
  *

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -104,6 +104,19 @@ static const SBufIO tls_sbufio_ops = {
 static void sbuf_tls_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf);
 #endif
 
+/* I/O over GSS Enc */
+//#ifdef USE_TLS
+static ssize_t gssenc_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len);
+static ssize_t gssenc_sbufio_send(struct SBuf *sbuf, const void *data, size_t len);
+static int gssenc_sbufio_close(struct SBuf *sbuf);
+static const SBufIO gssenc_sbufio_ops = {
+	gssenc_sbufio_recv,
+	gssenc_sbufio_send,
+	gssenc_sbufio_close
+};
+static void sbuf_gssenc_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf);
+//#endif
+
 /*********************************
  * Public functions
  *********************************/

--- a/src/server.c
+++ b/src/server.c
@@ -430,6 +430,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 	return true;
 }
 
+#ifdef HAVE_GSSAPI_H
 /*
  * Check if we can acquire credentials at all (and yield them if so).
  */
@@ -449,6 +450,7 @@ static bool pg_GSS_have_cred_cache(gss_cred_id_t *cred_out)
 	*cred_out = cred;
 	return true;
 }
+#endif
 
 /* got connection, decide what to do */
 static bool handle_connect(PgSocket *server)
@@ -483,11 +485,13 @@ static bool handle_connect(PgSocket *server)
 			res = send_sslreq_packet(server);
 			if (res)
 				server->wait_sslchar = true;
+#ifdef HAVE_GSSAPI_H
         } else if (server_connect_gssencmode > GSSENCMODE_DISABLE && !is_unix && pg_GSS_have_cred_cache(&cred)) {
 			slog_noise(server, "P: GSSEnc request");
 			res = send_gssencreq_packet(server);
 			if (res)
 				server->wait_gssencchar = true;
+#endif
 		} else {
 			slog_noise(server, "P: startup");
 			res = send_startup_packet(server);

--- a/src/server.c
+++ b/src/server.c
@@ -686,6 +686,23 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		else
 			disconnect_server(server, false, "TLS startup failed");
 		break;
+	case SBUF_EV_GSSENC_READY:
+		Assert(server->state == SV_LOGIN);
+
+//		tls_get_connection_info(server->sbuf.tls, infobuf, sizeof infobuf);
+//		if (cf_log_connections) {
+//			slog_info(server, "SSL established: %s", infobuf);
+//		} else {
+//			slog_noise(server, "SSL established: %s", infobuf);
+//		}
+
+		server->request_time = get_cached_time();
+		res = send_startup_packet(server);
+		if (res)
+			sbuf_continue(&server->sbuf);
+		else
+			disconnect_server(server, false, "GSSENC startup failed");
+		break;
 	}
 	if (!res && pool->db->admin)
 		takeover_login_failed();

--- a/src/server.c
+++ b/src/server.c
@@ -544,7 +544,7 @@ static bool handle_gssencchar(PgSocket *server, struct MBuf *data)
 
 	if (gchar == 'G') {
 		slog_noise(server, "launching gssenc");
-		ok = sbuf_tls_connect(&server->sbuf, server->pool->db->host);
+		ok = sbuf_gssenc_connect(&server->sbuf, server->pool->db->host);
 // TODO: allow refusal
 //	} else if (server_connect_sslmode >= GSSENCMODE_REQUIRE) {
 //		disconnect_server(server, false, "server refused GSSEnc");

--- a/src/server.c
+++ b/src/server.c
@@ -459,7 +459,9 @@ static bool handle_connect(PgSocket *server)
 	PgPool *pool = server->pool;
 	char buf[PGADDR_BUF + 32];
 	bool is_unix = pga_is_unix(&server->remote_addr);
+#ifdef HAVE_GSSAPI_H
 	gss_cred_id_t cred = GSS_C_NO_CREDENTIAL;
+#endif
 
 	fill_local_addr(server, sbuf_socket(&server->sbuf), is_unix);
 

--- a/src/server.c
+++ b/src/server.c
@@ -462,7 +462,7 @@ static bool handle_connect(PgSocket *server)
 			res = send_sslreq_packet(server);
 			if (res)
 				server->wait_sslchar = true;
-                } else if (!is_unix) { // TODO: make it work like SSLMODE_ENABLED above
+        } else if (!is_unix) { // TODO: make it work like SSLMODE_ENABLED above
 			slog_noise(server, "P: GSSEnc request");
 			res = send_gssencreq_packet(server);
 			if (res)

--- a/src/server.c
+++ b/src/server.c
@@ -502,7 +502,7 @@ static bool handle_sslchar(PgSocket *server, struct MBuf *data)
 
 	if (schar == 'S') {
 		slog_noise(server, "launching tls");
-		ok = sbuf_gssenc_connect(&server->sbuf, server->pool->db->host);
+		ok = sbuf_tls_connect(&server->sbuf, server->pool->db->host);
 	} else if (server_connect_sslmode >= SSLMODE_REQUIRE) {
 		disconnect_server(server, false, "server refused SSL");
 		return false;

--- a/src/server.c
+++ b/src/server.c
@@ -544,7 +544,7 @@ static bool handle_gssencchar(PgSocket *server, struct MBuf *data)
 
 	if (gchar == 'G') {
 		slog_noise(server, "launching gssenc");
-		ok = sbuf_gssenc_connect(&server->sbuf, server->pool->db->host);
+		ok = sbuf_gssenc_connect(&server->sbuf, server->pool->db->gssapi_spn);
 // TODO: allow refusal
 //	} else if (server_connect_sslmode >= GSSENCMODE_REQUIRE) {
 //		disconnect_server(server, false, "server refused GSSEnc");

--- a/src/server.c
+++ b/src/server.c
@@ -690,11 +690,13 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		Assert(server->state == SV_LOGIN);
 
 //		tls_get_connection_info(server->sbuf.tls, infobuf, sizeof infobuf);
-//		if (cf_log_connections) {
+		if (cf_log_connections) {
 //			slog_info(server, "SSL established: %s", infobuf);
-//		} else {
+			slog_info(server, "GSSENC established");
+		} else {
 //			slog_noise(server, "SSL established: %s", infobuf);
-//		}
+			slog_noise(server, "GSSENC established");
+		}
 
 		server->request_time = get_cached_time();
 		res = send_startup_packet(server);

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,3 +38,7 @@ check: all
 ifeq ($(tls_support),yes)
 	$(MAKE) -C ssl check
 endif
+
+ifeq ($(server_gssenc_support),yes)
+        $(MAKE) -C gss check
+endif

--- a/test/README.md
+++ b/test/README.md
@@ -28,6 +28,12 @@ Various ways to test PgBouncer:
 
     This test is run by `make check` if TLS support is enabled.
 
+- `gss/test.sh`
+
+    Tests GSS functionality.  Otherwise very similar to `test.sh`.
+
+    This test is run by `make check` if GSS support is enabled.
+
 - `hba_test`
 
     Tests hba parsing.  Run `make all` to build and `./hba_test` to execute.

--- a/test/gss/Makefile
+++ b/test/gss/Makefile
@@ -1,0 +1,9 @@
+EXTRA_DIST = test.sh Makefile
+
+SUBLOC = test/gss
+
+include ../../config.mak
+include ../../lib/mk/antimake.mk
+
+check: all
+	./test.sh

--- a/test/gss/newkdc.sh
+++ b/test/gss/newkdc.sh
@@ -1,0 +1,88 @@
+#! /bin/sh
+
+# TODO: do not run if /etc/krb5.conf exists, kdc or kadmin is running, or if /var/lib/krb5kdc exists
+
+# TODO: remove after debugging
+apt-get update
+env DEBIAN_FRONTEND=noninteractive apt-get -y install curl gnupg lsb-release krb5-kdc krb5-admin-server krb5-user
+
+cd $(dirname $0)
+
+REALM=EXAMPLE.COM
+SUPPORTED_ENCRYPTION_TYPES=aes256-cts-hmac-sha1-96:normal
+KADMIN_PRINCIPAL=kadmin/admin
+KADMIN_PASSWORD=51rb0unc3r
+KDC_KADMIN_SERVER=$(hostname -f)
+
+LOGDIR=log
+PG_LOG=$LOGDIR/krb.log
+
+ulimit -c unlimited
+
+configure_kdc() {
+	# Assumes packages are installed; krb5-kdc and krb5-admin-server on debian
+	command -v krb5kdc > /dev/null || {
+	        echo "krb5kdc not found, need kerberos tools in PATH"
+        	exit 0
+	}
+	KADMIN_PRINCIPAL_FULL=$KADMIN_PRINCIPAL@$REALM
+	cat << EOF > /etc/krb5.conf
+[libdefaults]
+        default_realm = $REALM
+        rdns = false
+
+[realms]
+        $REALM = {
+                kdc_ports = 88,750
+                kadmind_port = 749
+                kdc = $KDC_KADMIN_SERVER
+                admin_server = $KDC_KADMIN_SERVER
+        }
+EOF
+
+	cat << EOF > /etc/krb5kdc/kdc.conf
+[realms]
+        $REALM = {
+                acl_file = /etc/krb5kdc/kadm5.acl
+                max_renewable_life = 7d 0h 0m 0s
+                supported_enctypes = $SUPPORTED_ENCRYPTION_TYPES
+                default_principal_flags = +preauth
+        }
+EOF
+	cat << EOF > /etc/krb5kdc/kadm5.acl
+$KADMIN_PRINCIPAL_FULL *
+EOF
+	MASTER_PASSWORD=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1)
+	# This command also starts the krb5-kdc and krb5-admin-server services
+	krb5_newrealm <<EOF
+$MASTER_PASSWORD
+$MASTER_PASSWORD
+EOF
+	kadmin.local -q "delete_principal -force $KADMIN_PRINCIPAL_FULL"
+	kadmin.local -q "addprinc -pw $KADMIN_PASSWORD $KADMIN_PRINCIPAL_FULL"
+}
+
+add_users () {
+	export KDC_KADMIN_SERVER=$(hostname -f)
+	rm -f /krb5.keytab
+	rm -f /bouncer.keytab
+	kadmin.local -q "delete_principal -force postgres"
+	kadmin.local -q "delete_principal -force postgres/${KDC_KADMIN_SERVER}"
+	kadmin.local -q "delete_principal -force bouncer"
+	kadmin.local -q "delete_principal -force bouncer/${KDC_KADMIN_SERVER}"
+
+	kadmin.local -q "addprinc -randkey postgres"
+	kadmin.local -q "addprinc -randkey postgres/${KDC_KADMIN_SERVER}"
+	kadmin.local -q "ktadd -k /krb5.keytab postgres/${KDC_KADMIN_SERVER}"
+	kadmin.local -q "ktadd -k /krb5.keytab postgres"
+	chmod 644 /krb5.keytab
+
+	kadmin.local -q "addprinc -randkey bouncer"
+	kadmin.local -q "addprinc -randkey bouncer/${KDC_KADMIN_SERVER}"
+	kadmin.local -q "ktadd -k /bouncer.keytab bouncer/${KDC_KADMIN_SERVER}"
+	kadmin.local -q "ktadd -k /bouncer.keytab bouncer"
+	chmod 644 /bouncer.keytab
+}
+
+configure_kdc
+add_users

--- a/test/gss/test.ini
+++ b/test/gss/test.ini
@@ -1,6 +1,6 @@
 [databases]
-p0 = port=6666 host=localhost dbname=p0 user=bouncer pool_size=2 gssapi_spn=postgres/ip-172-31-19-107.us-east-2.compute.internal@EXAMPLE.COM
-p1 = port=6666 host=localhost dbname=p1 user=bouncer gssapi_spn=postgres/ip-172-31-19-107.us-east-2.compute.internal@EXAMPLE.COM
+p0 = port=6666 host=localhost dbname=p0 user=bouncer pool_size=2 gssapi_spn=postgres/FQDN@EXAMPLE.COM
+p1 = port=6666 host=localhost dbname=p1 user=bouncer gssapi_spn=postgres/FQDN@EXAMPLE.COM
 
 [pgbouncer]
 logfile = test.log
@@ -23,5 +23,4 @@ server_lifetime = 120
 server_idle_timeout = 60
 
 pkt_buf = 16384
-verbose=999
-server_gssencmode = require
+server_gssenc_mode = require

--- a/test/gss/test.ini
+++ b/test/gss/test.ini
@@ -1,0 +1,27 @@
+[databases]
+p0 = port=6666 host=localhost dbname=p0 user=bouncer pool_size=2 gssapi_spn=postgres/ip-172-31-19-107.us-east-2.compute.internal@EXAMPLE.COM
+p1 = port=6666 host=localhost dbname=p1 user=bouncer gssapi_spn=postgres/ip-172-31-19-107.us-east-2.compute.internal@EXAMPLE.COM
+
+[pgbouncer]
+logfile = test.log
+pidfile = test.pid
+
+listen_addr = 127.0.0.1
+listen_port = 6667
+unix_socket_dir = /tmp
+
+;auth_type = trust
+auth_file = tmp/userlist.txt
+
+pool_mode = transaction
+
+server_check_delay = 10
+max_client_conn = 10
+default_pool_size = 5
+
+server_lifetime = 120
+server_idle_timeout = 60
+
+pkt_buf = 16384
+verbose=999
+server_gssencmode = require

--- a/test/gss/test.sh
+++ b/test/gss/test.sh
@@ -1,0 +1,223 @@
+#! /bin/sh
+
+cd $(dirname $0)
+
+export PGDATA=$PWD/pgdata
+export PGHOST=localhost
+export PGPORT=6667
+export EF_ALLOW_MALLOC_0=1
+export LC_ALL=C
+export POSIXLY_CORRECT=1
+
+mkdir -p tmp
+
+BOUNCER_LOG=test.log
+BOUNCER_INI=test.ini
+BOUNCER_PID=test.pid
+BOUNCER_PORT=`sed -n '/^listen_port/s/listen_port.*=[^0-9]*//p' $BOUNCER_INI`
+BOUNCER_EXE="$BOUNCER_EXE_PREFIX ../../pgbouncer"
+
+KRB5_REALM=EXAMPLE.COM
+
+LOGDIR=log
+PG_PORT=6666
+PG_LOG=$LOGDIR/pg.log
+
+sed -i "s/FQDN/$(hostname -f)/g" $BOUNCER_INI
+
+pgctl() {
+	pg_ctl -w -o "-p $PG_PORT" -D $PGDATA $@ >>$PG_LOG 2>&1
+}
+
+ulimit -c unlimited
+
+SED_ERE_OP='-E'
+case `uname` in
+Linux)
+	SED_ERE_OP='-r'
+	;;
+esac
+
+pg_majorversion=$(initdb --version | sed -n $SED_ERE_OP 's/.* ([0-9]+).*/\1/p')
+if test $pg_majorversion -ge 10; then
+	pg_supports_scram=true
+else
+	pg_supports_scram=false
+fi
+
+stopit() {
+	local pid
+	if test -f "$1"; then
+		pid=`head -n1 "$1"`
+		kill $pid
+		while kill -0 $pid 2>/dev/null; do sleep 0.1; done
+		rm -f "$1"
+	fi
+}
+
+stopit test.pid
+stopit pgdata/postmaster.pid
+
+mkdir -p $LOGDIR
+rm -f $BOUNCER_LOG $PG_LOG
+rm -rf $PGDATA
+
+if [ ! -d $PGDATA ]; then
+	echo "initdb"
+	mkdir $PGDATA
+	initdb -A trust --nosync >> $PG_LOG
+	echo "unix_socket_directories = '/tmp'" >> pgdata/postgresql.conf
+	echo "port = $PG_PORT" >> pgdata/postgresql.conf
+	# We need to make the log go to stderr so that the tests can
+	# check what is being logged.  This should be the default, but
+	# some packagings change the default configuration.
+	echo "logging_collector = off" >> pgdata/postgresql.conf
+	echo "log_destination = stderr" >> pgdata/postgresql.conf
+	echo "log_connections = on" >> pgdata/postgresql.conf
+	echo "log_disconnections = on" >> pgdata/postgresql.conf
+	cp pgdata/postgresql.conf pgdata/postgresql.conf.orig
+	cp pgdata/pg_hba.conf pgdata/pg_hba.conf.orig
+	cp pgdata/pg_ident.conf pgdata/pg_ident.conf.orig
+
+	cp /krb5.keytab pgdata/krb5.keytab
+        chmod 600 pgdata/krb5.keytab
+
+	echo '"bouncer" "zzz"' > tmp/userlist.txt
+
+	chmod 600 tmp/userlist.txt
+fi
+
+pgctl start
+
+echo "createdb"
+psql -X -p $PG_PORT -l | grep p0 > /dev/null || {
+	psql -X -o /dev/null -p $PG_PORT -c "create user bouncer" template1
+	createdb -p $PG_PORT p0
+	createdb -p $PG_PORT p1
+}
+
+reconf_bouncer() {
+	cp test.ini tmp/test.ini
+	for ln in "$@"; do
+		echo "$ln" >> tmp/test.ini
+	done
+	test -f test.pid && kill `cat test.pid`
+	sleep 1
+	$BOUNCER_EXE -v -v -v -d tmp/test.ini
+}
+
+reconf_pgsql() {
+	cp pgdata/postgresql.conf.orig pgdata/postgresql.conf
+	for ln in "$@"; do
+		echo "$ln" >> pgdata/postgresql.conf
+	done
+	pgctl stop
+	pgctl start
+	sleep 1
+}
+
+
+#
+#  fw hacks
+#
+
+#
+# util functions
+#
+
+complete() {
+	test -f $BOUNCER_PID && kill `cat $BOUNCER_PID` >/dev/null 2>&1
+	pgctl -m fast stop
+	rm -f $BOUNCER_PID
+}
+
+die() {
+	echo $@
+	complete
+	exit 1
+}
+
+admin() {
+	psql -X -h /tmp -U pgbouncer -d pgbouncer -c "$@;" || die "Cannot contact bouncer!"
+}
+
+runtest() {
+	local status
+
+	$BOUNCER_EXE -d $BOUNCER_INI
+	until psql -X -h /tmp -U pgbouncer -d pgbouncer -c "show version" 2>/dev/null 1>&2; do sleep 0.1; done
+
+	printf "`date` running $1 ... "
+	eval $1 >$LOGDIR/$1.out 2>&1
+	status=$?
+
+	# Detect fatal errors from PgBouncer (which are internal
+	# errors), but not those from PostgreSQL (which could be
+	# normal, such as authentication failures)
+	if grep 'FATAL @' $BOUNCER_LOG >> $LOGDIR/$1.out; then
+		status=1
+	fi
+
+	if [ $status -eq 0 ]; then
+		echo "ok"
+	elif [ $status -eq 77 ]; then
+		echo "skipped"
+		status=0
+	else
+		echo "FAILED"
+		cat $LOGDIR/$1.out | sed 's/^/# /'
+	fi
+	date >> $LOGDIR/$1.out
+
+	# allow background processing to complete
+	wait
+
+	stopit test.pid
+	mv $BOUNCER_LOG $LOGDIR/$1.log
+
+	return $status
+}
+
+psql_pg() {
+	psql -X -U bouncer -h 127.0.0.1 -p $PG_PORT "$@"
+}
+
+psql_bouncer() {
+	PGUSER=bouncer PGPASSWORD=zzz psql -X "$@"
+}
+
+test_server_gss() {
+	reconf_bouncer "server_gssencmode = require"
+#	reconf_bouncer "server_gssencmode = prefer"
+#	reconf_bouncer "server_gssencmode = disable"
+	echo "hostgssenc all all 0.0.0.0/0 gss include_realm=0 krb_realm=EXAMPLE.COM" > pgdata/pg_hba.conf
+	echo "hostgssenc all all ::/0 gss include_realm=0 krb_realm=EXAMPLE.COM" >> pgdata/pg_hba.conf
+	reconf_pgsql "krb_server_keyfile = '$PGDATA/krb5.keytab'"
+        psql_bouncer -q -d p0 -c 'SELECT pid, gss_authenticated, encrypted, principal from pg_stat_gssapi where pid = pg_backend_pid();' | tee tmp/test.tmp1
+        grep -Eq 't.*t.*bouncer@EXAMPLE.COM' tmp/test.tmp1
+        rc=$?
+        return $rc
+}
+
+testlist="
+test_server_gss
+"
+if [ $# -gt 0 ]; then
+	testlist="$*"
+fi
+
+total_status=0
+for test in $testlist
+do
+	runtest $test
+	status=$?
+	if [ $status -ne 0 ]; then
+		total_status=1
+	fi
+done
+
+complete
+
+exit $total_status
+
+# vim: sts=0 sw=8 noet nosmarttab:


### PR DESCRIPTION
Hello, we have used this code to successfully connect to a GSSAPI/Kerberos authenticated and encrypted PostgreSQL server from pgbouncer, while allowing a non-GSSAPI/Kerberos client to avail itself of a kerberized PostgreSQL in addition to the other pgbouncer functions.

I added a couple fields to pgbouncer.ini:

server_gssencmode (need to flesh this out; I should be able to do that this week; the goal is to allow requiring GSSAPI authentication and encryption from pgbouncer's side, not just having "hostgssenc" in pg_hba.conf)
gssapi_spn (GSSAPI/Kerberos Service Principal Name; per-database in [databases] section)

I initially created a synchronized I/O version of this patch. Right now sending/receiving data is asynchronous I/O except for the initial connection. I could probably re-engineer that at some point. Most of the async code is a modified copy of how libpq does a GSSAPI Authenticated+Encrypted connection. I considered using the libpq-fe.h API directly but it doesn't seem to be a great match for pgbouncer as-is. I imagine there is some history related to libpq that I'm not aware of.

At this time it does not support, say, making a server connection with GSSAPI auth alone or with any other method (i.e. TLS). It does not add any abilities to client connections.

I have this working in both Vagrant and docker-compose with a minimal KDC; after some cleanup I should be able to share those as well, for automated testing purposes.

I am sure there are bugs and some rough edges in the code, but so far I can't get my connections to fail or crash. I'd be happy to help smooth anything out, if this patch is of any value to the community.

N.B. So far I've only tested with pkt_buf = 16384; per the postgresql.org spec, that is how long GSSAPI encrypted messages can be.