### PR TITLE
Make a few fields in PgSocket client only

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -414,9 +414,9 @@ struct PgSocket {
 
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */
-	usec_t query_start;	/* query start moment */
-	usec_t xact_start;	/* xact start moment */
-	usec_t wait_start;	/* waiting start moment */
+	usec_t query_start;	/* client: query start moment */
+	usec_t xact_start;	/* client: xact start moment */
+	usec_t wait_start;	/* client: waiting start moment */
 
 	uint8_t cancel_key[BACKENDKEY_LEN]; /* client: generated, server: remote */
 	PgAddr remote_addr;	/* ip:port for remote endpoint */


### PR DESCRIPTION
The doc updates in #726 made clear that some stats fields of PgSocket
were only used for clients not servers. This makes this also clear in
the code comments for those fields of PgSocket.
