### PR TITLE
Add Server-side Prepared Statements Cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ pgbouncer_SOURCES = \
 	src/hba.c \
 	src/janitor.c \
 	src/loader.c \
+	src/messages.c \
 	src/main.c \
 	src/objects.c \
 	src/pam.c \
 	src/pktbuf.c \
 	src/pooler.c \
 	src/proto.c \
+	src/ps.c \
 	src/sbuf.c \
 	src/scram.c \
 	src/server.c \
@@ -37,11 +39,13 @@ pgbouncer_SOURCES = \
 	include/iobuf.h \
 	include/janitor.h \
 	include/loader.h \
+	include/messages.h \
 	include/objects.h \
 	include/pam.h \
 	include/pktbuf.h \
 	include/pooler.h \
 	include/proto.h \
+	include/ps.h \
 	include/sbuf.h \
 	include/scram.h \
 	include/server.h \

--- a/doc/config.md
+++ b/doc/config.md
@@ -252,6 +252,27 @@ updated and how often aggregated statistics are written to the log
 
 Default: 60
 
+### disable_prepared_statement_support
+
+Enables/disables server side prepared statement support. Disabled by
+default. To enable the server-side prepared statement support change
+it to 0 (zero).
+
+Default: 1 (disabled)
+
+### prepared_statement_cache_queries
+
+Sets the number of prepared statements kept active on a single backend
+connection. Keep in mind that this will increase the memory footprint
+of each client connection on your PostgreSQL server.
+
+Tracking prepared statements does not only come with a memory cost, but
+also with increased cpu usage. Multiple PgBouncer instances can be run
+to use more than one core for processing, see `so_reuseport` socket
+option.
+
+Default: 100
+
 
 ## Authentication settings
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -355,5 +355,12 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;service_name = pgbouncer
 ;job_name = pgbouncer
 
+;; Disable support for prepared statements
+;; (P, B en C commands only together with prepareThreshold>0 in JDBC driver).
+;disable_prepared_statement_support = 1
+
+;; Number of prepared statements to cache on a backend connection.
+;prepared_statement_cache_queries = 100
+
 ;; Read additional config from other file
 ;%include /etc/pgbouncer/pgbouncer-other.ini

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -81,6 +81,14 @@ enum SSLMode {
 	SSLMODE_VERIFY_FULL
 };
 
+enum PacketCallbackFlag {
+  CB_NONE,
+  CB_WANT_COMPLETE_PACKET,
+  CB_HANDLE_COMPLETE_PACKET,
+  CB_REWRITE_PACKET
+};
+
+
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
 
 
@@ -91,8 +99,10 @@ typedef struct PgPool PgPool;
 typedef struct PgStats PgStats;
 typedef union PgAddr PgAddr;
 typedef enum SocketState SocketState;
+typedef enum PacketCallbackFlag PacketCallbackFlag;
 typedef struct PktHdr PktHdr;
 typedef struct ScramState ScramState;
+typedef struct PgPreparedStatement PgPreparedStatement;
 
 extern int cf_sbuf_len;
 
@@ -115,6 +125,8 @@ extern int cf_sbuf_len;
 #include "janitor.h"
 #include "hba.h"
 #include "pam.h"
+#include "messages.h"
+#include "ps.h"
 
 #ifndef WIN32
 #define DEFAULT_UNIX_SOCKET_DIR "/tmp"
@@ -242,6 +254,10 @@ struct PgStats {
 	usec_t xact_time;	/* total transaction time in us */
 	usec_t query_time;	/* total query time in us */
 	usec_t wait_time;	/* total time clients had to wait */
+
+  uint64_t ps_server_parse_count;
+  uint64_t ps_client_parse_count;
+  uint64_t ps_bind_count;
 };
 
 /*
@@ -372,6 +388,10 @@ struct PgDatabase {
 	struct AATree user_tree;	/* users that have been queried on this database */
 };
 
+struct OutstandingParsePacket {
+	struct List node;
+	bool ignore:1;
+};
 
 /*
  * A client or server connection.
@@ -444,6 +464,22 @@ struct PgSocket {
 	} scram_state;
 
 	VarCache vars;		/* state of interesting server parameters */
+
+  PgParsedPreparedStatement *prepared_statements;
+
+  uint64_t nextUniquePreparedStatementID;
+  PgServerPreparedStatement *server_prepared_statements;
+
+  struct List server_outstanding_parse_packets;
+
+  /* cb state during SBUF_EV_PKT_CALLBACK processing */
+  struct CallbackState {
+    PacketCallbackFlag flag:8; 
+    struct MBuf *complete_pkt;
+    PktHdr *pkt_header;
+    unsigned pkt_offset;
+  } packet_cb_state;
+
 
 	SBuf sbuf;		/* stream buffer, must be last */
 };
@@ -557,6 +593,9 @@ extern char *cf_server_tls_ca_file;
 extern char *cf_server_tls_cert_file;
 extern char *cf_server_tls_key_file;
 extern char *cf_server_tls_ciphers;
+
+extern int cf_disable_prepared_statement_support;
+extern int cf_prepared_statement_cache_queries;
 
 extern const struct CfLookup pool_mode_map[];
 

--- a/include/common/uthash.h
+++ b/include/common/uthash.h
@@ -1,0 +1,1227 @@
+/*
+Copyright (c) 2003-2018, Troy D. Hanson     http://troydhanson.github.com/uthash/
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTHASH_H
+#define UTHASH_H
+
+#define UTHASH_VERSION 2.1.0
+
+#include <string.h>   /* memcmp, memset, strlen */
+#include <stddef.h>   /* ptrdiff_t */
+#include <stdlib.h>   /* exit */
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ source) this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#if !defined(DECLTYPE) && !defined(NO_DECLTYPE)
+#if defined(_MSC_VER)   /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define DECLTYPE(x) (decltype(x))
+#else                   /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#endif
+#elif defined(__BORLANDC__) || defined(__ICCARM__) || defined(__LCC__) || defined(__WATCOMC__)
+#define NO_DECLTYPE
+#else                   /* GNU, Sun and other compilers */
+#define DECLTYPE(x) (__typeof(x))
+#endif
+#endif
+
+#ifdef NO_DECLTYPE
+#define DECLTYPE(x)
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  char **_da_dst = (char**)(&(dst));                                             \
+  *_da_dst = (char*)(src);                                                       \
+} while (0)
+#else
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  (dst) = DECLTYPE(dst)(src);                                                    \
+} while (0)
+#endif
+
+/* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#include <stdint.h>
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#include <stdint.h>
+#else
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#include <stdint.h>
+#else
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#endif
+
+#ifndef uthash_malloc
+#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#endif
+#ifndef uthash_free
+#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#endif
+#ifndef uthash_bzero
+#define uthash_bzero(a,n) memset(a,'\0',n)
+#endif
+#ifndef uthash_strlen
+#define uthash_strlen(s) strlen(s)
+#endif
+
+#ifdef uthash_memcmp
+/* This warning will not catch programs that define uthash_memcmp AFTER including uthash.h. */
+#warning "uthash_memcmp is deprecated; please use HASH_KEYCMP instead"
+#else
+#define uthash_memcmp(a,b,n) memcmp(a,b,n)
+#endif
+
+#ifndef HASH_KEYCMP
+#define HASH_KEYCMP(a,b,n) uthash_memcmp(a,b,n)
+#endif
+
+#ifndef uthash_noexpand_fyi
+#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#endif
+#ifndef uthash_expand_fyi
+#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#endif
+
+#ifndef HASH_NONFATAL_OOM
+#define HASH_NONFATAL_OOM 0
+#endif
+
+#if HASH_NONFATAL_OOM
+/* malloc failures can be recovered from */
+
+#ifndef uthash_nonfatal_oom
+#define uthash_nonfatal_oom(obj) do {} while (0)    /* non-fatal OOM error */
+#endif
+
+#define HASH_RECORD_OOM(oomed) do { (oomed) = 1; } while (0)
+#define IF_HASH_NONFATAL_OOM(x) x
+
+#else
+/* malloc failures result in lost memory, hash tables are unusable */
+
+#ifndef uthash_fatal
+#define uthash_fatal(msg) exit(-1)        /* fatal OOM error */
+#endif
+
+#define HASH_RECORD_OOM(oomed) uthash_fatal("out of memory")
+#define IF_HASH_NONFATAL_OOM(x)
+
+#endif
+
+/* initial number of buckets */
+#define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
+
+/* calculate the element whose hash handle address is hhp */
+#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+/* calculate the hash handle from element address elp */
+#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+
+#define HASH_ROLLBACK_BKT(hh, head, itemptrhh)                                   \
+do {                                                                             \
+  struct UT_hash_handle *_hd_hh_item = (itemptrhh);                              \
+  unsigned _hd_bkt;                                                              \
+  HASH_TO_BKT(_hd_hh_item->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);         \
+  (head)->hh.tbl->buckets[_hd_bkt].count++;                                      \
+  _hd_hh_item->hh_next = NULL;                                                   \
+  _hd_hh_item->hh_prev = NULL;                                                   \
+} while (0)
+
+#define HASH_VALUE(keyptr,keylen,hashv)                                          \
+do {                                                                             \
+  HASH_FCN(keyptr, keylen, hashv);                                               \
+} while (0)
+
+#define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
+do {                                                                             \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    unsigned _hf_bkt;                                                            \
+    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
+    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                         \
+      HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
+do {                                                                             \
+  unsigned _hf_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
+  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
+} while (0)
+
+#ifdef HASH_BLOOM
+#define HASH_BLOOM_BITLEN (1UL << HASH_BLOOM)
+#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8UL) + (((HASH_BLOOM_BITLEN%8UL)!=0UL) ? 1UL : 0UL)
+#define HASH_BLOOM_MAKE(tbl,oomed)                                               \
+do {                                                                             \
+  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
+  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
+  if (!(tbl)->bloom_bv) {                                                        \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                           \
+    (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                     \
+  }                                                                              \
+} while (0)
+
+#define HASH_BLOOM_FREE(tbl)                                                     \
+do {                                                                             \
+  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
+} while (0)
+
+#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8U] |= (1U << ((idx)%8U)))
+#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8U] & (1U << ((idx)%8U)))
+
+#define HASH_BLOOM_ADD(tbl,hashv)                                                \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+
+#define HASH_BLOOM_TEST(tbl,hashv)                                               \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, ((hashv) & (uint32_t)((1UL << (tbl)->bloom_nbits) - 1U)))
+
+#else
+#define HASH_BLOOM_MAKE(tbl,oomed)
+#define HASH_BLOOM_FREE(tbl)
+#define HASH_BLOOM_ADD(tbl,hashv)
+#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#define HASH_BLOOM_BYTELEN 0U
+#endif
+
+#define HASH_MAKE_TABLE(hh,head,oomed)                                           \
+do {                                                                             \
+  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(sizeof(UT_hash_table));         \
+  if (!(head)->hh.tbl) {                                                         \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero((head)->hh.tbl, sizeof(UT_hash_table));                         \
+    (head)->hh.tbl->tail = &((head)->hh);                                        \
+    (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                      \
+    (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;            \
+    (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                  \
+    (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                    \
+        HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));               \
+    (head)->hh.tbl->signature = HASH_SIGNATURE;                                  \
+    if (!(head)->hh.tbl->buckets) {                                              \
+      HASH_RECORD_OOM(oomed);                                                    \
+      uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                        \
+    } else {                                                                     \
+      uthash_bzero((head)->hh.tbl->buckets,                                      \
+          HASH_INITIAL_NUM_BUCKETS * sizeof(struct UT_hash_bucket));             \
+      HASH_BLOOM_MAKE((head)->hh.tbl, oomed);                                    \
+      IF_HASH_NONFATAL_OOM(                                                      \
+        if (oomed) {                                                             \
+          uthash_free((head)->hh.tbl->buckets,                                   \
+              HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));           \
+          uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                    \
+        }                                                                        \
+      )                                                                          \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,replaced,cmpfcn) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+    HASH_DELETE(hh, head, replaced);                                             \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn); \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add,replaced) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+    HASH_DELETE(hh, head, replaced);                                             \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
+} while (0)
+
+#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
+} while (0)
+
+#define HASH_REPLACE_INORDER(hh,head,fieldname,keylen_in,add,replaced,cmpfcn)    \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn); \
+} while (0)
+
+#define HASH_APPEND_LIST(hh, head, add)                                          \
+do {                                                                             \
+  (add)->hh.next = NULL;                                                         \
+  (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);           \
+  (head)->hh.tbl->tail->next = (add);                                            \
+  (head)->hh.tbl->tail = &((add)->hh);                                           \
+} while (0)
+
+#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
+do {                                                                             \
+  do {                                                                           \
+    if (cmpfcn(DECLTYPE(head)(_hs_iter), add) > 0) {                             \
+      break;                                                                     \
+    }                                                                            \
+  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
+} while (0)
+
+#ifdef NO_DECLTYPE
+#undef HASH_AKBI_INNER_LOOP
+#define HASH_AKBI_INNER_LOOP(hh,head,add,cmpfcn)                                 \
+do {                                                                             \
+  char *_hs_saved_head = (char*)(head);                                          \
+  do {                                                                           \
+    DECLTYPE_ASSIGN(head, _hs_iter);                                             \
+    if (cmpfcn(head, add) > 0) {                                                 \
+      DECLTYPE_ASSIGN(head, _hs_saved_head);                                     \
+      break;                                                                     \
+    }                                                                            \
+    DECLTYPE_ASSIGN(head, _hs_saved_head);                                       \
+  } while ((_hs_iter = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->next));           \
+} while (0)
+#endif
+
+#if HASH_NONFATAL_OOM
+
+#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
+do {                                                                             \
+  if (!(oomed)) {                                                                \
+    unsigned _ha_bkt;                                                            \
+    (head)->hh.tbl->num_items++;                                                 \
+    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                  \
+    HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);    \
+    if (oomed) {                                                                 \
+      HASH_ROLLBACK_BKT(hh, head, &(add)->hh);                                   \
+      HASH_DELETE_HH(hh, head, &(add)->hh);                                      \
+      (add)->hh.tbl = NULL;                                                      \
+      uthash_nonfatal_oom(add);                                                  \
+    } else {                                                                     \
+      HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                   \
+      HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                \
+    }                                                                            \
+  } else {                                                                       \
+    (add)->hh.tbl = NULL;                                                        \
+    uthash_nonfatal_oom(add);                                                    \
+  }                                                                              \
+} while (0)
+
+#else
+
+#define HASH_ADD_TO_TABLE(hh,head,keyptr,keylen_in,hashval,add,oomed)            \
+do {                                                                             \
+  unsigned _ha_bkt;                                                              \
+  (head)->hh.tbl->num_items++;                                                   \
+  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
+  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], hh, &(add)->hh, oomed);      \
+  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
+  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
+} while (0)
+
+#endif
+
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh,head,keyptr,keylen_in,hashval,add,cmpfcn) \
+do {                                                                             \
+  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
+    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                            \
+    IF_HASH_NONFATAL_OOM( } )                                                    \
+  } else {                                                                       \
+    void *_hs_iter = (head);                                                     \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    HASH_AKBI_INNER_LOOP(hh, head, add, cmpfcn);                                 \
+    if (_hs_iter) {                                                              \
+      (add)->hh.next = _hs_iter;                                                 \
+      if (((add)->hh.prev = HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev)) {     \
+        HH_FROM_ELMT((head)->hh.tbl, (add)->hh.prev)->next = (add);              \
+      } else {                                                                   \
+        (head) = (add);                                                          \
+      }                                                                          \
+      HH_FROM_ELMT((head)->hh.tbl, _hs_iter)->prev = (add);                      \
+    } else {                                                                     \
+      HASH_APPEND_LIST(hh, head, add);                                           \
+    }                                                                            \
+  }                                                                              \
+  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
+  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE_INORDER");                    \
+} while (0)
+
+#define HASH_ADD_KEYPTR_INORDER(hh,head,keyptr,keylen_in,add,cmpfcn)             \
+do {                                                                             \
+  unsigned _hs_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,cmpfcn) \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+
+#define HASH_ADD_INORDER(hh,head,fieldname,keylen_in,add,cmpfcn)                 \
+  HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE(hh,head,keyptr,keylen_in,hashval,add)        \
+do {                                                                             \
+  IF_HASH_NONFATAL_OOM( int _ha_oomed = 0; )                                     \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    HASH_MAKE_TABLE(hh, add, _ha_oomed);                                         \
+    IF_HASH_NONFATAL_OOM( if (!_ha_oomed) { )                                    \
+      (head) = (add);                                                            \
+    IF_HASH_NONFATAL_OOM( } )                                                    \
+  } else {                                                                       \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    HASH_APPEND_LIST(hh, head, add);                                             \
+  }                                                                              \
+  HASH_ADD_TO_TABLE(hh, head, keyptr, keylen_in, hashval, add, _ha_oomed);       \
+  HASH_FSCK(hh, head, "HASH_ADD_KEYPTR_BYHASHVALUE");                            \
+} while (0)
+
+#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
+do {                                                                             \
+  unsigned _ha_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add);      \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add)            \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
+
+#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
+  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
+
+#define HASH_TO_BKT(hashv,num_bkts,bkt)                                          \
+do {                                                                             \
+  bkt = ((hashv) & ((num_bkts) - 1U));                                           \
+} while (0)
+
+/* delete "delptr" from the hash table.
+ * "the usual" patch-up process for the app-order doubly-linked-list.
+ * The use of _hd_hh_del below deserves special explanation.
+ * These used to be expressed using (delptr) but that led to a bug
+ * if someone used the same symbol for the head and deletee, like
+ *  HASH_DELETE(hh,users,users);
+ * We want that to work, but by changing the head (users) below
+ * we were forfeiting our ability to further refer to the deletee (users)
+ * in the patch-up process. Solution: use scratch space to
+ * copy the deletee pointer, then the latter references are via that
+ * scratch pointer rather than through the repointed (users) symbol.
+ */
+#define HASH_DELETE(hh,head,delptr)                                              \
+    HASH_DELETE_HH(hh, head, &(delptr)->hh)
+
+#define HASH_DELETE_HH(hh,head,delptrhh)                                         \
+do {                                                                             \
+  struct UT_hash_handle *_hd_hh_del = (delptrhh);                                \
+  if ((_hd_hh_del->prev == NULL) && (_hd_hh_del->next == NULL)) {                \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets * sizeof(struct UT_hash_bucket));    \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head) = NULL;                                                               \
+  } else {                                                                       \
+    unsigned _hd_bkt;                                                            \
+    if (_hd_hh_del == (head)->hh.tbl->tail) {                                    \
+      (head)->hh.tbl->tail = HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev);     \
+    }                                                                            \
+    if (_hd_hh_del->prev != NULL) {                                              \
+      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->prev)->next = _hd_hh_del->next;   \
+    } else {                                                                     \
+      DECLTYPE_ASSIGN(head, _hd_hh_del->next);                                   \
+    }                                                                            \
+    if (_hd_hh_del->next != NULL) {                                              \
+      HH_FROM_ELMT((head)->hh.tbl, _hd_hh_del->next)->prev = _hd_hh_del->prev;   \
+    }                                                                            \
+    HASH_TO_BKT(_hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);        \
+    HASH_DEL_IN_BKT((head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);               \
+    (head)->hh.tbl->num_items--;                                                 \
+  }                                                                              \
+  HASH_FSCK(hh, head, "HASH_DELETE_HH");                                         \
+} while (0)
+
+/* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
+#define HASH_FIND_STR(head,findstr,out)                                          \
+do {                                                                             \
+    unsigned _uthash_hfstr_keylen = (unsigned)uthash_strlen(findstr);            \
+    HASH_FIND(hh, head, findstr, _uthash_hfstr_keylen, out);                     \
+} while (0)
+#define HASH_ADD_STR(head,strfield,add)                                          \
+do {                                                                             \
+    unsigned _uthash_hastr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
+    HASH_ADD(hh, head, strfield[0], _uthash_hastr_keylen, add);                  \
+} while (0)
+#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
+do {                                                                             \
+    unsigned _uthash_hrstr_keylen = (unsigned)uthash_strlen((add)->strfield);    \
+    HASH_REPLACE(hh, head, strfield[0], _uthash_hrstr_keylen, add, replaced);    \
+} while (0)
+#define HASH_FIND_INT(head,findint,out)                                          \
+    HASH_FIND(hh,head,findint,sizeof(int),out)
+#define HASH_ADD_INT(head,intfield,add)                                          \
+    HASH_ADD(hh,head,intfield,sizeof(int),add)
+#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
+#define HASH_FIND_PTR(head,findptr,out)                                          \
+    HASH_FIND(hh,head,findptr,sizeof(void *),out)
+#define HASH_ADD_PTR(head,ptrfield,add)                                          \
+    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
+#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
+#define HASH_DEL(head,delptr)                                                    \
+    HASH_DELETE(hh,head,delptr)
+
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+ */
+#ifdef HASH_DEBUG
+#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
+#define HASH_FSCK(hh,head,where)                                                 \
+do {                                                                             \
+  struct UT_hash_handle *_thh;                                                   \
+  if (head) {                                                                    \
+    unsigned _bkt_i;                                                             \
+    unsigned _count = 0;                                                         \
+    char *_prev;                                                                 \
+    for (_bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; ++_bkt_i) {           \
+      unsigned _bkt_count = 0;                                                   \
+      _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                            \
+      _prev = NULL;                                                              \
+      while (_thh) {                                                             \
+        if (_prev != (char*)(_thh->hh_prev)) {                                   \
+          HASH_OOPS("%s: invalid hh_prev %p, actual %p\n",                       \
+              (where), (void*)_thh->hh_prev, (void*)_prev);                      \
+        }                                                                        \
+        _bkt_count++;                                                            \
+        _prev = (char*)(_thh);                                                   \
+        _thh = _thh->hh_next;                                                    \
+      }                                                                          \
+      _count += _bkt_count;                                                      \
+      if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {                \
+        HASH_OOPS("%s: invalid bucket count %u, actual %u\n",                    \
+            (where), (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);         \
+      }                                                                          \
+    }                                                                            \
+    if (_count != (head)->hh.tbl->num_items) {                                   \
+      HASH_OOPS("%s: invalid hh item count %u, actual %u\n",                     \
+          (where), (head)->hh.tbl->num_items, _count);                           \
+    }                                                                            \
+    _count = 0;                                                                  \
+    _prev = NULL;                                                                \
+    _thh =  &(head)->hh;                                                         \
+    while (_thh) {                                                               \
+      _count++;                                                                  \
+      if (_prev != (char*)_thh->prev) {                                          \
+        HASH_OOPS("%s: invalid prev %p, actual %p\n",                            \
+            (where), (void*)_thh->prev, (void*)_prev);                           \
+      }                                                                          \
+      _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                         \
+      _thh = (_thh->next ? HH_FROM_ELMT((head)->hh.tbl, _thh->next) : NULL);     \
+    }                                                                            \
+    if (_count != (head)->hh.tbl->num_items) {                                   \
+      HASH_OOPS("%s: invalid app item count %u, actual %u\n",                    \
+          (where), (head)->hh.tbl->num_items, _count);                           \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+#else
+#define HASH_FSCK(hh,head,where)
+#endif
+
+/* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
+ * the descriptor to which this macro is defined for tuning the hash function.
+ * The app can #include <unistd.h> to get the prototype for write(2). */
+#ifdef HASH_EMIT_KEYS
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
+do {                                                                             \
+  unsigned _klen = fieldlen;                                                     \
+  write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                  \
+  write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen);                        \
+} while (0)
+#else
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#endif
+
+/* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
+#ifdef HASH_FUNCTION
+#define HASH_FCN HASH_FUNCTION
+#else
+#define HASH_FCN HASH_JEN
+#endif
+
+/* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
+#define HASH_BER(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hb_keylen = (unsigned)keylen;                                        \
+  const unsigned char *_hb_key = (const unsigned char*)(key);                    \
+  (hashv) = 0;                                                                   \
+  while (_hb_keylen-- != 0U) {                                                   \
+    (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;                           \
+  }                                                                              \
+} while (0)
+
+
+/* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
+ * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
+#define HASH_SAX(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _sx_i;                                                                \
+  const unsigned char *_hs_key = (const unsigned char*)(key);                    \
+  hashv = 0;                                                                     \
+  for (_sx_i=0; _sx_i < keylen; _sx_i++) {                                       \
+    hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                       \
+  }                                                                              \
+} while (0)
+/* FNV-1a variation */
+#define HASH_FNV(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _fn_i;                                                                \
+  const unsigned char *_hf_key = (const unsigned char*)(key);                    \
+  (hashv) = 2166136261U;                                                         \
+  for (_fn_i=0; _fn_i < keylen; _fn_i++) {                                       \
+    hashv = hashv ^ _hf_key[_fn_i];                                              \
+    hashv = hashv * 16777619U;                                                   \
+  }                                                                              \
+} while (0)
+
+#define HASH_OAT(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _ho_i;                                                                \
+  const unsigned char *_ho_key=(const unsigned char*)(key);                      \
+  hashv = 0;                                                                     \
+  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
+      hashv += _ho_key[_ho_i];                                                   \
+      hashv += (hashv << 10);                                                    \
+      hashv ^= (hashv >> 6);                                                     \
+  }                                                                              \
+  hashv += (hashv << 3);                                                         \
+  hashv ^= (hashv >> 11);                                                        \
+  hashv += (hashv << 15);                                                        \
+} while (0)
+
+#define HASH_JEN_MIX(a,b,c)                                                      \
+do {                                                                             \
+  a -= b; a -= c; a ^= ( c >> 13 );                                              \
+  b -= c; b -= a; b ^= ( a << 8 );                                               \
+  c -= a; c -= b; c ^= ( b >> 13 );                                              \
+  a -= b; a -= c; a ^= ( c >> 12 );                                              \
+  b -= c; b -= a; b ^= ( a << 16 );                                              \
+  c -= a; c -= b; c ^= ( b >> 5 );                                               \
+  a -= b; a -= c; a ^= ( c >> 3 );                                               \
+  b -= c; b -= a; b ^= ( a << 10 );                                              \
+  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+} while (0)
+
+#define HASH_JEN(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hj_i,_hj_j,_hj_k;                                                    \
+  unsigned const char *_hj_key=(unsigned const char*)(key);                      \
+  hashv = 0xfeedbeefu;                                                           \
+  _hj_i = _hj_j = 0x9e3779b9u;                                                   \
+  _hj_k = (unsigned)(keylen);                                                    \
+  while (_hj_k >= 12U) {                                                         \
+    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
+        + ( (unsigned)_hj_key[2] << 16 )                                         \
+        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
+    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
+        + ( (unsigned)_hj_key[6] << 16 )                                         \
+        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
+    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
+        + ( (unsigned)_hj_key[10] << 16 )                                        \
+        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
+                                                                                 \
+     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
+                                                                                 \
+     _hj_key += 12;                                                              \
+     _hj_k -= 12U;                                                               \
+  }                                                                              \
+  hashv += (unsigned)(keylen);                                                   \
+  switch ( _hj_k ) {                                                             \
+    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
+    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
+    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
+    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
+    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
+    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
+    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
+    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
+    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
+    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
+    case 1:  _hj_i += _hj_key[0];                                                \
+  }                                                                              \
+  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
+} while (0)
+
+/* The Paul Hsieh hash function */
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
+                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+#define HASH_SFH(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned const char *_sfh_key=(unsigned const char*)(key);                     \
+  uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                                \
+                                                                                 \
+  unsigned _sfh_rem = _sfh_len & 3U;                                             \
+  _sfh_len >>= 2;                                                                \
+  hashv = 0xcafebabeu;                                                           \
+                                                                                 \
+  /* Main loop */                                                                \
+  for (;_sfh_len > 0U; _sfh_len--) {                                             \
+    hashv    += get16bits (_sfh_key);                                            \
+    _sfh_tmp  = ((uint32_t)(get16bits (_sfh_key+2)) << 11) ^ hashv;              \
+    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
+    _sfh_key += 2U*sizeof (uint16_t);                                            \
+    hashv    += hashv >> 11;                                                     \
+  }                                                                              \
+                                                                                 \
+  /* Handle end cases */                                                         \
+  switch (_sfh_rem) {                                                            \
+    case 3: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 16;                                                \
+            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)]) << 18;              \
+            hashv += hashv >> 11;                                                \
+            break;                                                               \
+    case 2: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 11;                                                \
+            hashv += hashv >> 17;                                                \
+            break;                                                               \
+    case 1: hashv += *_sfh_key;                                                  \
+            hashv ^= hashv << 10;                                                \
+            hashv += hashv >> 1;                                                 \
+  }                                                                              \
+                                                                                 \
+  /* Force "avalanching" of final 127 bits */                                    \
+  hashv ^= hashv << 3;                                                           \
+  hashv += hashv >> 5;                                                           \
+  hashv ^= hashv << 4;                                                           \
+  hashv += hashv >> 17;                                                          \
+  hashv ^= hashv << 25;                                                          \
+  hashv += hashv >> 6;                                                           \
+} while (0)
+
+#ifdef HASH_USING_NO_STRICT_ALIASING
+/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
+ * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
+ * MurmurHash uses the faster approach only on CPU's where we know it's safe.
+ *
+ * Note the preprocessor built-in defines can be emitted using:
+ *
+ *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
+ *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
+ */
+#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
+#define MUR_GETBLOCK(p,i) p[i]
+#else /* non intel */
+#define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 3UL) == 0UL)
+#define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 3UL) == 1UL)
+#define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 3UL) == 2UL)
+#define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 3UL) == 3UL)
+#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
+#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
+#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#else /* assume little endian non-intel */
+#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#endif
+#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
+                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
+                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
+                                                      MUR_ONE_THREE(p))))
+#endif
+#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h) \
+do {                 \
+  _h ^= _h >> 16;    \
+  _h *= 0x85ebca6bu; \
+  _h ^= _h >> 13;    \
+  _h *= 0xc2b2ae35u; \
+  _h ^= _h >> 16;    \
+} while (0)
+
+#define HASH_MUR(key,keylen,hashv)                                     \
+do {                                                                   \
+  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
+  const int _mur_nblocks = (int)(keylen) / 4;                          \
+  uint32_t _mur_h1 = 0xf88D5353u;                                      \
+  uint32_t _mur_c1 = 0xcc9e2d51u;                                      \
+  uint32_t _mur_c2 = 0x1b873593u;                                      \
+  uint32_t _mur_k1 = 0;                                                \
+  const uint8_t *_mur_tail;                                            \
+  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+(_mur_nblocks*4)); \
+  int _mur_i;                                                          \
+  for (_mur_i = -_mur_nblocks; _mur_i != 0; _mur_i++) {                \
+    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+                                                                       \
+    _mur_h1 ^= _mur_k1;                                                \
+    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
+    _mur_h1 = (_mur_h1*5U) + 0xe6546b64u;                              \
+  }                                                                    \
+  _mur_tail = (const uint8_t*)(_mur_data + (_mur_nblocks*4));          \
+  _mur_k1=0;                                                           \
+  switch ((keylen) & 3U) {                                             \
+    case 0: break;                                                     \
+    case 3: _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */ \
+    case 2: _mur_k1 ^= (uint32_t)_mur_tail[1] << 8;  /* FALLTHROUGH */ \
+    case 1: _mur_k1 ^= (uint32_t)_mur_tail[0];                         \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+    _mur_h1 ^= _mur_k1;                                                \
+  }                                                                    \
+  _mur_h1 ^= (uint32_t)(keylen);                                       \
+  MUR_FMIX(_mur_h1);                                                   \
+  hashv = _mur_h1;                                                     \
+} while (0)
+#endif  /* HASH_USING_NO_STRICT_ALIASING */
+
+/* iterate over items in a known bucket to find desired item */
+#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
+do {                                                                             \
+  if ((head).hh_head != NULL) {                                                  \
+    DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));                     \
+  } else {                                                                       \
+    (out) = NULL;                                                                \
+  }                                                                              \
+  while ((out) != NULL) {                                                        \
+    if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
+      if (HASH_KEYCMP((out)->hh.key, keyptr, keylen_in) == 0) {              \
+        break;                                                                   \
+      }                                                                          \
+    }                                                                            \
+    if ((out)->hh.hh_next != NULL) {                                             \
+      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));                \
+    } else {                                                                     \
+      (out) = NULL;                                                              \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+/* add an item to a bucket  */
+#define HASH_ADD_TO_BKT(head,hh,addhh,oomed)                                     \
+do {                                                                             \
+  UT_hash_bucket *_ha_head = &(head);                                            \
+  _ha_head->count++;                                                             \
+  (addhh)->hh_next = _ha_head->hh_head;                                          \
+  (addhh)->hh_prev = NULL;                                                       \
+  if (_ha_head->hh_head != NULL) {                                               \
+    _ha_head->hh_head->hh_prev = (addhh);                                        \
+  }                                                                              \
+  _ha_head->hh_head = (addhh);                                                   \
+  if ((_ha_head->count >= ((_ha_head->expand_mult + 1U) * HASH_BKT_CAPACITY_THRESH)) \
+      && !(addhh)->tbl->noexpand) {                                              \
+    HASH_EXPAND_BUCKETS(addhh,(addhh)->tbl, oomed);                              \
+    IF_HASH_NONFATAL_OOM(                                                        \
+      if (oomed) {                                                               \
+        HASH_DEL_IN_BKT(head,addhh);                                             \
+      }                                                                          \
+    )                                                                            \
+  }                                                                              \
+} while (0)
+
+/* remove an item from a given bucket */
+#define HASH_DEL_IN_BKT(head,delhh)                                              \
+do {                                                                             \
+  UT_hash_bucket *_hd_head = &(head);                                            \
+  _hd_head->count--;                                                             \
+  if (_hd_head->hh_head == (delhh)) {                                            \
+    _hd_head->hh_head = (delhh)->hh_next;                                        \
+  }                                                                              \
+  if ((delhh)->hh_prev) {                                                        \
+    (delhh)->hh_prev->hh_next = (delhh)->hh_next;                                \
+  }                                                                              \
+  if ((delhh)->hh_next) {                                                        \
+    (delhh)->hh_next->hh_prev = (delhh)->hh_prev;                                \
+  }                                                                              \
+} while (0)
+
+/* Bucket expansion has the effect of doubling the number of buckets
+ * and redistributing the items into the new buckets. Ideally the
+ * items will distribute more or less evenly into the new buckets
+ * (the extent to which this is true is a measure of the quality of
+ * the hash function as it applies to the key domain).
+ *
+ * With the items distributed into more buckets, the chain length
+ * (item count) in each bucket is reduced. Thus by expanding buckets
+ * the hash keeps a bound on the chain length. This bounded chain
+ * length is the essence of how a hash provides constant time lookup.
+ *
+ * The calculation of tbl->ideal_chain_maxlen below deserves some
+ * explanation. First, keep in mind that we're calculating the ideal
+ * maximum chain length based on the *new* (doubled) bucket count.
+ * In fractions this is just n/b (n=number of items,b=new num buckets).
+ * Since the ideal chain length is an integer, we want to calculate
+ * ceil(n/b). We don't depend on floating point arithmetic in this
+ * hash, so to calculate ceil(n/b) with integers we could write
+ *
+ *      ceil(n/b) = (n/b) + ((n%b)?1:0)
+ *
+ * and in fact a previous version of this hash did just that.
+ * But now we have improved things a bit by recognizing that b is
+ * always a power of two. We keep its base 2 log handy (call it lb),
+ * so now we can write this with a bit shift and logical AND:
+ *
+ *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
+ *
+ */
+#define HASH_EXPAND_BUCKETS(hh,tbl,oomed)                                        \
+do {                                                                             \
+  unsigned _he_bkt;                                                              \
+  unsigned _he_bkt_i;                                                            \
+  struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                   \
+  UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                  \
+  _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                              \
+           2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));            \
+  if (!_he_new_buckets) {                                                        \
+    HASH_RECORD_OOM(oomed);                                                      \
+  } else {                                                                       \
+    uthash_bzero(_he_new_buckets,                                                \
+        2UL * (tbl)->num_buckets * sizeof(struct UT_hash_bucket));               \
+    (tbl)->ideal_chain_maxlen =                                                  \
+       ((tbl)->num_items >> ((tbl)->log2_num_buckets+1U)) +                      \
+       ((((tbl)->num_items & (((tbl)->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);    \
+    (tbl)->nonideal_items = 0;                                                   \
+    for (_he_bkt_i = 0; _he_bkt_i < (tbl)->num_buckets; _he_bkt_i++) {           \
+      _he_thh = (tbl)->buckets[ _he_bkt_i ].hh_head;                             \
+      while (_he_thh != NULL) {                                                  \
+        _he_hh_nxt = _he_thh->hh_next;                                           \
+        HASH_TO_BKT(_he_thh->hashv, (tbl)->num_buckets * 2U, _he_bkt);           \
+        _he_newbkt = &(_he_new_buckets[_he_bkt]);                                \
+        if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                 \
+          (tbl)->nonideal_items++;                                               \
+          if (_he_newbkt->count > _he_newbkt->expand_mult * (tbl)->ideal_chain_maxlen) { \
+            _he_newbkt->expand_mult++;                                           \
+          }                                                                      \
+        }                                                                        \
+        _he_thh->hh_prev = NULL;                                                 \
+        _he_thh->hh_next = _he_newbkt->hh_head;                                  \
+        if (_he_newbkt->hh_head != NULL) {                                       \
+          _he_newbkt->hh_head->hh_prev = _he_thh;                                \
+        }                                                                        \
+        _he_newbkt->hh_head = _he_thh;                                           \
+        _he_thh = _he_hh_nxt;                                                    \
+      }                                                                          \
+    }                                                                            \
+    uthash_free((tbl)->buckets, (tbl)->num_buckets * sizeof(struct UT_hash_bucket)); \
+    (tbl)->num_buckets *= 2U;                                                    \
+    (tbl)->log2_num_buckets++;                                                   \
+    (tbl)->buckets = _he_new_buckets;                                            \
+    (tbl)->ineff_expands = ((tbl)->nonideal_items > ((tbl)->num_items >> 1)) ?   \
+        ((tbl)->ineff_expands+1U) : 0U;                                          \
+    if ((tbl)->ineff_expands > 1U) {                                             \
+      (tbl)->noexpand = 1;                                                       \
+      uthash_noexpand_fyi(tbl);                                                  \
+    }                                                                            \
+    uthash_expand_fyi(tbl);                                                      \
+  }                                                                              \
+} while (0)
+
+
+/* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
+/* Note that HASH_SORT assumes the hash handle name to be hh.
+ * HASH_SRT was added to allow the hash handle name to be passed in. */
+#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
+#define HASH_SRT(hh,head,cmpfcn)                                                 \
+do {                                                                             \
+  unsigned _hs_i;                                                                \
+  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
+  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
+  if (head != NULL) {                                                            \
+    _hs_insize = 1;                                                              \
+    _hs_looping = 1;                                                             \
+    _hs_list = &((head)->hh);                                                    \
+    while (_hs_looping != 0U) {                                                  \
+      _hs_p = _hs_list;                                                          \
+      _hs_list = NULL;                                                           \
+      _hs_tail = NULL;                                                           \
+      _hs_nmerges = 0;                                                           \
+      while (_hs_p != NULL) {                                                    \
+        _hs_nmerges++;                                                           \
+        _hs_q = _hs_p;                                                           \
+        _hs_psize = 0;                                                           \
+        for (_hs_i = 0; _hs_i < _hs_insize; ++_hs_i) {                           \
+          _hs_psize++;                                                           \
+          _hs_q = ((_hs_q->next != NULL) ?                                       \
+            HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                   \
+          if (_hs_q == NULL) {                                                   \
+            break;                                                               \
+          }                                                                      \
+        }                                                                        \
+        _hs_qsize = _hs_insize;                                                  \
+        while ((_hs_psize != 0U) || ((_hs_qsize != 0U) && (_hs_q != NULL))) {    \
+          if (_hs_psize == 0U) {                                                 \
+            _hs_e = _hs_q;                                                       \
+            _hs_q = ((_hs_q->next != NULL) ?                                     \
+              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
+            _hs_qsize--;                                                         \
+          } else if ((_hs_qsize == 0U) || (_hs_q == NULL)) {                     \
+            _hs_e = _hs_p;                                                       \
+            if (_hs_p != NULL) {                                                 \
+              _hs_p = ((_hs_p->next != NULL) ?                                   \
+                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
+            }                                                                    \
+            _hs_psize--;                                                         \
+          } else if ((cmpfcn(                                                    \
+                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_p)),             \
+                DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl, _hs_q))              \
+                )) <= 0) {                                                       \
+            _hs_e = _hs_p;                                                       \
+            if (_hs_p != NULL) {                                                 \
+              _hs_p = ((_hs_p->next != NULL) ?                                   \
+                HH_FROM_ELMT((head)->hh.tbl, _hs_p->next) : NULL);               \
+            }                                                                    \
+            _hs_psize--;                                                         \
+          } else {                                                               \
+            _hs_e = _hs_q;                                                       \
+            _hs_q = ((_hs_q->next != NULL) ?                                     \
+              HH_FROM_ELMT((head)->hh.tbl, _hs_q->next) : NULL);                 \
+            _hs_qsize--;                                                         \
+          }                                                                      \
+          if ( _hs_tail != NULL ) {                                              \
+            _hs_tail->next = ((_hs_e != NULL) ?                                  \
+              ELMT_FROM_HH((head)->hh.tbl, _hs_e) : NULL);                       \
+          } else {                                                               \
+            _hs_list = _hs_e;                                                    \
+          }                                                                      \
+          if (_hs_e != NULL) {                                                   \
+            _hs_e->prev = ((_hs_tail != NULL) ?                                  \
+              ELMT_FROM_HH((head)->hh.tbl, _hs_tail) : NULL);                    \
+          }                                                                      \
+          _hs_tail = _hs_e;                                                      \
+        }                                                                        \
+        _hs_p = _hs_q;                                                           \
+      }                                                                          \
+      if (_hs_tail != NULL) {                                                    \
+        _hs_tail->next = NULL;                                                   \
+      }                                                                          \
+      if (_hs_nmerges <= 1U) {                                                   \
+        _hs_looping = 0;                                                         \
+        (head)->hh.tbl->tail = _hs_tail;                                         \
+        DECLTYPE_ASSIGN(head, ELMT_FROM_HH((head)->hh.tbl, _hs_list));           \
+      }                                                                          \
+      _hs_insize *= 2U;                                                          \
+    }                                                                            \
+    HASH_FSCK(hh, head, "HASH_SRT");                                             \
+  }                                                                              \
+} while (0)
+
+/* This function selects items from one hash into another hash.
+ * The end result is that the selected items have dual presence
+ * in both hashes. There is no copy of the items made; rather
+ * they are added into the new hash through a secondary hash
+ * hash handle that must be present in the structure. */
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
+do {                                                                             \
+  unsigned _src_bkt, _dst_bkt;                                                   \
+  void *_last_elt = NULL, *_elt;                                                 \
+  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
+  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
+  if ((src) != NULL) {                                                           \
+    for (_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {    \
+      for (_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;               \
+        _src_hh != NULL;                                                         \
+        _src_hh = _src_hh->hh_next) {                                            \
+        _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                         \
+        if (cond(_elt)) {                                                        \
+          IF_HASH_NONFATAL_OOM( int _hs_oomed = 0; )                             \
+          _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);                 \
+          _dst_hh->key = _src_hh->key;                                           \
+          _dst_hh->keylen = _src_hh->keylen;                                     \
+          _dst_hh->hashv = _src_hh->hashv;                                       \
+          _dst_hh->prev = _last_elt;                                             \
+          _dst_hh->next = NULL;                                                  \
+          if (_last_elt_hh != NULL) {                                            \
+            _last_elt_hh->next = _elt;                                           \
+          }                                                                      \
+          if ((dst) == NULL) {                                                   \
+            DECLTYPE_ASSIGN(dst, _elt);                                          \
+            HASH_MAKE_TABLE(hh_dst, dst, _hs_oomed);                             \
+            IF_HASH_NONFATAL_OOM(                                                \
+              if (_hs_oomed) {                                                   \
+                uthash_nonfatal_oom(_elt);                                       \
+                (dst) = NULL;                                                    \
+                continue;                                                        \
+              }                                                                  \
+            )                                                                    \
+          } else {                                                               \
+            _dst_hh->tbl = (dst)->hh_dst.tbl;                                    \
+          }                                                                      \
+          HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);      \
+          HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt], hh_dst, _dst_hh, _hs_oomed); \
+          (dst)->hh_dst.tbl->num_items++;                                        \
+          IF_HASH_NONFATAL_OOM(                                                  \
+            if (_hs_oomed) {                                                     \
+              HASH_ROLLBACK_BKT(hh_dst, dst, _dst_hh);                           \
+              HASH_DELETE_HH(hh_dst, dst, _dst_hh);                              \
+              _dst_hh->tbl = NULL;                                               \
+              uthash_nonfatal_oom(_elt);                                         \
+              continue;                                                          \
+            }                                                                    \
+          )                                                                      \
+          HASH_BLOOM_ADD(_dst_hh->tbl, _dst_hh->hashv);                          \
+          _last_elt = _elt;                                                      \
+          _last_elt_hh = _dst_hh;                                                \
+        }                                                                        \
+      }                                                                          \
+    }                                                                            \
+  }                                                                              \
+  HASH_FSCK(hh_dst, dst, "HASH_SELECT");                                         \
+} while (0)
+
+#define HASH_CLEAR(hh,head)                                                      \
+do {                                                                             \
+  if ((head) != NULL) {                                                          \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head) = NULL;                                                               \
+  }                                                                              \
+} while (0)
+
+#define HASH_OVERHEAD(hh,head)                                                   \
+ (((head) != NULL) ? (                                                           \
+ (size_t)(((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +             \
+          ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +             \
+           sizeof(UT_hash_table)                                   +             \
+           (HASH_BLOOM_BYTELEN))) : 0U)
+
+#ifdef NO_DECLTYPE
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL)); \
+  (el) != NULL; ((el)=(tmp)), ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#else
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));      \
+  (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#endif
+
+/* obtain a count of items in the hash */
+#define HASH_COUNT(head) HASH_CNT(hh,head)
+#define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)
+
+typedef struct UT_hash_bucket {
+   struct UT_hash_handle *hh_head;
+   unsigned count;
+
+   /* expand_mult is normally set to 0. In this situation, the max chain length
+    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+    * the bucket's chain exceeds this length, bucket expansion is triggered).
+    * However, setting expand_mult to a non-zero value delays bucket expansion
+    * (that would be triggered by additions to this particular bucket)
+    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+    * (The multiplier is simply expand_mult+1). The whole idea of this
+    * multiplier is to reduce bucket expansions, since they are expensive, in
+    * situations where we know that a particular bucket tends to be overused.
+    * It is better to let its chain length grow to a longer yet-still-bounded
+    * value, than to do an O(n) bucket expansion too often.
+    */
+   unsigned expand_mult;
+
+} UT_hash_bucket;
+
+/* random signature used only to find hash tables in external analysis */
+#define HASH_SIGNATURE 0xa0111fe1u
+#define HASH_BLOOM_SIGNATURE 0xb12220f2u
+
+typedef struct UT_hash_table {
+   UT_hash_bucket *buckets;
+   unsigned num_buckets, log2_num_buckets;
+   unsigned num_items;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+
+   /* in an ideal situation (all buckets used equally), no bucket would have
+    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+   unsigned ideal_chain_maxlen;
+
+   /* nonideal_items is the number of items in the hash whose chain position
+    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+    * hash distribution; reaching them in a chain traversal takes >ideal steps */
+   unsigned nonideal_items;
+
+   /* ineffective expands occur when a bucket doubling was performed, but
+    * afterward, more than half the items in the hash had nonideal chain
+    * positions. If this happens on two consecutive expansions we inhibit any
+    * further expansion, as it's not helping; this happens when the hash
+    * function isn't a good fit for the key domain. When expansion is inhibited
+    * the hash will still work, albeit no longer in constant time. */
+   unsigned ineff_expands, noexpand;
+
+   uint32_t signature; /* used only to find hash tables in external analysis */
+#ifdef HASH_BLOOM
+   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+   uint8_t *bloom_bv;
+   uint8_t bloom_nbits;
+#endif
+
+} UT_hash_table;
+
+typedef struct UT_hash_handle {
+   struct UT_hash_table *tbl;
+   void *prev;                       /* prev element in app order      */
+   void *next;                       /* next element in app order      */
+   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
+   void *key;                        /* ptr to enclosing struct's key  */
+   unsigned keylen;                  /* enclosing struct's key len     */
+   unsigned hashv;                   /* result of hash-fcn(key)        */
+} UT_hash_handle;
+
+#endif /* UTHASH_H */

--- a/include/messages.h
+++ b/include/messages.h
@@ -1,0 +1,46 @@
+typedef struct PgParsePacket
+{
+  unsigned int len;
+  char *name;
+  char *query;
+  uint16_t num_parameters;
+  uint8_t *parameter_types_bytes;
+} PgParsePacket;
+
+typedef struct PgBindPacket
+{
+  unsigned int len;
+  char *portal;
+  char *name;
+} PgBindPacket;
+
+typedef struct PgDescribePacket
+{
+  char type;
+  char *name;
+} PgDescribePacket;
+
+typedef struct PgClosePacket
+{
+	char type;
+  char* name;
+} PgClosePacket;
+
+bool inspect_parse_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action);
+bool inspect_bind_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action);
+bool inspect_describe_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action);
+
+bool unmarshall_parse_packet(PgSocket *client, PktHdr *pkt, PgParsePacket **parse_packet_p);
+bool unmarshall_bind_packet(PgSocket *client, PktHdr *pkt, PgBindPacket **bind_packet_p);
+bool unmarshall_describe_packet(PgSocket *client, PktHdr *pkt, PgDescribePacket **describe_packet_p);
+bool unmarshall_close_packet(PgSocket *client, PktHdr *pkt, PgClosePacket **close_packet_p);
+
+bool is_close_statement_packet(PgClosePacket *close_packet);
+
+PktBuf *create_parse_packet(char *statement, PgParsePacket *parse_packet);
+PktBuf *create_parse_complete_packet(void);
+PktBuf *create_describe_packet(char *statement);
+PktBuf *create_close_packet(char *statement);
+PktBuf *create_close_complete_packet(void);
+
+void parse_packet_free(PgParsePacket *pkt);

--- a/include/proto.h
+++ b/include/proto.h
@@ -54,6 +54,13 @@ bool send_sslreq_packet(PgSocket *server) _MUSTCHECK;
 
 int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...) _MUSTCHECK;
 
+static inline void free_header(PktHdr *pkt)
+{
+  mbuf_free(&pkt->data);
+  pkt->type = 0;
+  pkt->len = 0;
+}
+
 /* is packet completely in our buffer */
 static inline bool incomplete_pkt(const PktHdr *pkt)
 {

--- a/include/ps.h
+++ b/include/ps.h
@@ -1,0 +1,28 @@
+#include "common/uthash.h"
+
+#define PS_IGNORE 0
+#define PS_HANDLE 1
+
+typedef struct PgParsedPreparedStatement
+{
+	const char *name;
+  uint64_t query_hash[2];
+  PgParsePacket *pkt;
+  UT_hash_handle hh;
+} PgParsedPreparedStatement;
+
+typedef struct PgServerPreparedStatement
+{
+  const uint64_t query_hash[2];
+  char *name;
+  uint64_t bind_count;
+  UT_hash_handle hh;
+} PgServerPreparedStatement;
+
+bool handle_parse_command(PgSocket *client, PktHdr *pkt);
+bool handle_bind_command(PgSocket *client, PktHdr *pkt_hdr, unsigned offset, struct MBuf *data, PktBuf *pkt);
+bool handle_describe_command(PgSocket *client, PktHdr *pkt);
+bool handle_close_statement_command(PgSocket *client, PktHdr *pkt, PgClosePacket *close_packet);
+
+void ps_client_free(PgSocket *client);
+void ps_server_free(PgSocket *server);

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -118,6 +118,8 @@ bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);
 bool sbuf_close(SBuf *sbuf) _MUSTCHECK;
 
+bool sbuf_flush(SBuf *sbuf);
+
 /* proto_fn can use those functions to order behaviour */
 void sbuf_prepare_send(SBuf *sbuf, SBuf *dst, unsigned amount);
 void sbuf_prepare_skip(SBuf *sbuf, unsigned amount);

--- a/src/client.c
+++ b/src/client.c
@@ -880,6 +880,8 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 {
 	SBuf *sbuf = &client->sbuf;
 	int rfq_delta = 0;
+  uint8_t ps_action = PS_IGNORE;
+  PgClosePacket *close_packet;
 
 	switch (pkt->type) {
 
@@ -913,10 +915,60 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	 * to buffer packets until sync or flush is sent by client
 	 */
 	case 'P':		/* Parse */
+    if (!cf_disable_prepared_statement_support) {
+      if (!inspect_parse_packet(client, pkt, &ps_action))
+        return false;
+      
+      if (ps_action == PS_HANDLE && incomplete_pkt(pkt)) {
+        client->packet_cb_state.flag = CB_WANT_COMPLETE_PACKET;
+        sbuf_prepare_fetch(sbuf, pkt->len);
+        return true;
+      }
+    }
+    break;
+
 	case 'E':		/* Execute */
+    break;
+
 	case 'C':		/* Close */
+    if (!cf_disable_prepared_statement_support) {
+      if (!unmarshall_close_packet(client, pkt, &close_packet))
+        return false;
+
+      if (close_packet && is_close_statement_packet(close_packet)) {
+        if (!handle_close_statement_command(client, pkt, close_packet))
+          return false;
+
+        client->pool->stats.client_bytes += pkt->len;
+
+        free(close_packet->name);
+        free(close_packet);
+
+        /* No further processing required */
+        return true;
+      }
+
+      if (close_packet) {
+        free(close_packet->name);
+        free(close_packet);
+      }
+    }
+    break;
+
 	case 'B':		/* Bind */
+    if (!cf_disable_prepared_statement_support) {
+      if (!inspect_bind_packet(client, pkt, &ps_action))
+        return false;
+    }
+    break;
+
 	case 'D':		/* Describe */
+    if (!cf_disable_prepared_statement_support) {
+      if (!inspect_describe_packet(client, pkt, &ps_action))
+        return false;
+    }
+    break;
+
 	case 'd':		/* CopyData(F/B) */
 		break;
 
@@ -930,7 +982,7 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 		return false;
 	}
 
-	/* update stats */
+  /* update stats */
 	if (!client->query_start) {
 		client->pool->stats.query_count++;
 		client->query_start = get_cached_time();
@@ -960,10 +1012,58 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	client->link->ready = false;
 	client->link->idle_tx = false;
 
+  if (ps_action == PS_HANDLE) {
+    switch (pkt->type)
+    {
+      case 'P':
+        if (!handle_parse_command(client, pkt))
+          return false;
+
+        if (client->packet_cb_state.flag == CB_HANDLE_COMPLETE_PACKET) {
+          /* pkt already read from sbuf with cb */
+          client->packet_cb_state.flag = CB_NONE;
+        } else {
+          sbuf_prepare_skip(sbuf, pkt->len);
+        }
+        return true;
+
+      case 'B':
+        client->packet_cb_state.flag = CB_REWRITE_PACKET;
+        sbuf_prepare_fetch(sbuf, pkt->len);
+        return true;
+
+      case 'D':
+        if (!handle_describe_command(client, pkt))
+          return false;
+
+        return true;
+    }
+  }
+
 	/* forward the packet */
 	sbuf_prepare_send(sbuf, &client->link->sbuf, pkt->len);
 
 	return true;
+}
+
+static bool handle_partial_client_work(PgSocket *client, PktHdr *pkt_hdr, unsigned offset, struct MBuf *data)
+{
+	struct PktBuf *pkt = pktbuf_temp();
+
+  switch (pkt_hdr->type) {
+    case 'B':
+      if (offset == 0) {
+        if (!handle_bind_command(client, pkt_hdr, offset, data, pkt))
+          return false;
+      }
+      pktbuf_put_bytes(pkt, data->data + mbuf_consumed(data) , mbuf_avail_for_read(data));
+      break;
+  }
+
+  if (!pktbuf_send_immediate(pkt, client->link))
+    return false;
+
+  return true;
 }
 
 /* callback from SBuf */
@@ -1052,8 +1152,67 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		/* client is not interested in it */
 		break;
 	case SBUF_EV_PKT_CALLBACK:
-		/* unused ATM */
-		break;
+  {
+    bool first = false;
+    if (client->packet_cb_state.pkt_header->type == 0) {
+      first = true;
+      if (!get_header(data, client->packet_cb_state.pkt_header)) {
+        char hex[8*2 + 1];
+		  	disconnect_client(client, true, "bad packet header: '%s'",
+              hdr2hex(data, hex, sizeof(hex)));
+		  	return false;
+		  }
+      mbuf_rewind_reader(data);
+    }
+
+    switch (client->packet_cb_state.flag) {
+      case CB_WANT_COMPLETE_PACKET:
+        if (first) {
+          slog_debug(client, "buffering complete packet, pkt='%c' len=%d incomplete=%s available=%d", pkt_desc(client->packet_cb_state.pkt_header), client->packet_cb_state.pkt_header->len, incomplete_pkt(client->packet_cb_state.pkt_header) ? "true" : "false", mbuf_avail_for_read(data));
+          mbuf_init_dynamic(client->packet_cb_state.complete_pkt);
+          if (!mbuf_make_room(client->packet_cb_state.complete_pkt, client->packet_cb_state.pkt_header->len))
+            return false;
+        }
+
+        res = mbuf_write_raw_mbuf(client->packet_cb_state.complete_pkt, data);
+
+        if (res && sbuf->pkt_remain == mbuf_avail_for_read(data)) {
+          if (!get_header(client->packet_cb_state.complete_pkt, &pkt)) {
+            char hex[8*2 + 1];
+            disconnect_client(client, true, "bad packet header: '%s'",
+                  hdr2hex(data, hex, sizeof(hex)));
+            return false;
+          }          
+          slog_debug(client, "complete packet buffered, pkt='%c' len=%d incomplete=%s", pkt_desc(&pkt), pkt.len, incomplete_pkt(&pkt) ? "true" : "false");
+
+          client->packet_cb_state.flag = CB_HANDLE_COMPLETE_PACKET;
+          res = handle_client_work(client, &pkt);
+   
+          mbuf_free(client->packet_cb_state.complete_pkt);
+          free_header(client->packet_cb_state.pkt_header);
+        }
+        break;
+      case CB_REWRITE_PACKET:
+      {
+        unsigned avail = mbuf_avail_for_read(data);
+        if (first) {
+          client->packet_cb_state.pkt_offset = 0;
+        }
+      
+        res = handle_partial_client_work(client, client->packet_cb_state.pkt_header, client->packet_cb_state.pkt_offset, data);
+        client->packet_cb_state.pkt_offset += avail;
+
+        if (client->packet_cb_state.pkt_header->len == client->packet_cb_state.pkt_offset) {
+          client->packet_cb_state.flag = CB_NONE;
+          free_header(client->packet_cb_state.pkt_header);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    break;
+  }
 	case SBUF_EV_TLS_READY:
 		sbuf_continue(&client->sbuf);
 		res = true;

--- a/src/main.c
+++ b/src/main.c
@@ -184,6 +184,9 @@ char *cf_server_tls_cert_file;
 char *cf_server_tls_key_file;
 char *cf_server_tls_ciphers;
 
+int cf_disable_prepared_statement_support;
+int cf_prepared_statement_cache_queries;
+
 /*
  * config file description
  */
@@ -317,6 +320,9 @@ CF_ABS("unix_socket_mode", CF_INT, cf_unix_socket_mode, CF_NO_RELOAD, "0777"),
 CF_ABS("user", CF_STR, cf_username, CF_NO_RELOAD, NULL),
 #endif
 CF_ABS("verbose", CF_INT, cf_verbose, 0, NULL),
+
+CF_ABS("disable_prepared_statement_support", CF_INT, cf_disable_prepared_statement_support, 0, "1"),
+CF_ABS("prepared_statement_cache_queries", CF_INT, cf_prepared_statement_cache_queries, 0, "100"),
 
 {NULL}
 };

--- a/src/messages.c
+++ b/src/messages.c
@@ -1,0 +1,278 @@
+#include "bouncer.h"
+
+/* Inspect Parse packet to see if it defines a named prepared statement */
+bool inspect_parse_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action)
+{
+  const char *statement;
+
+  if (!mbuf_get_string(&pkt->data, &statement))
+    return false;
+
+  if (strlen(statement) > 0) {
+    slog_noise(client, "inspect_parse_packet: type=%c, len=%d, statement=%s", pkt->type, pkt->len, statement);
+    *ps_action = PS_HANDLE;
+  } else {
+    slog_noise(client, "inspect_parse_packet: type=%c, len=%d, statement=<empty>", pkt->type, pkt->len);
+    *ps_action = PS_IGNORE;
+  }
+  
+  return true;
+}
+
+/* Inspect Bind packet to see if it defines a named prepared statement */
+bool inspect_bind_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action)
+{
+  const char *portal;
+  const char *statement;
+
+  if (!mbuf_get_string(&pkt->data, &portal))
+    return false;
+
+  if (!mbuf_get_string(&pkt->data, &statement))
+    return false;
+
+  if (strlen(statement) > 0) {
+    slog_noise(client, "inspect_bind_packet: type=%c, len=%d, statement=%s", pkt->type, pkt->len, statement);
+    *ps_action = PS_HANDLE;
+  } else {
+    slog_noise(client, "inspect_bind_packet: type=%c, len=%d, statement=<empty>", pkt->type, pkt->len);
+    *ps_action = PS_IGNORE;
+  }
+  
+  return true;
+}
+
+/* Inspect Describe packet to see if it defines a named prepared statement */
+bool inspect_describe_packet(PgSocket *client, PktHdr *pkt, uint8_t *ps_action)
+{
+  char describe;
+  const char *statement;
+
+  if (!mbuf_get_char(&pkt->data, &describe))
+    return false;
+
+  if (describe == 'S') {
+    if (!mbuf_get_string(&pkt->data, &statement))
+      return false;
+
+    if (strlen(statement) > 0) {
+      slog_noise(client, "inspect_describe_packet: type=%c, len=%d, P/S=%c, statement=%s", pkt->type, pkt->len, describe, statement);
+      *ps_action = PS_HANDLE;
+    } else {
+      slog_noise(client, "inspect_descibe_packet: type=%c, len=%d, P/S=%c, statement=<empty>", pkt->type, pkt->len, describe);
+      *ps_action = PS_IGNORE;
+    }
+  } else {
+    slog_noise(client, "inspect_descibe_packet: type=%c, len=%d, P/S=%c", pkt->type, pkt->len, describe);
+    *ps_action = PS_IGNORE;
+  }
+
+  return true;
+}
+
+/* Unmarshall Parse packet into PgParsePacket struct for further processing */
+bool unmarshall_parse_packet(PgSocket *client, PktHdr *pkt, PgParsePacket **parse_packet_p)
+{
+  const uint8_t *ptr;
+  const char* statement;
+  const char* query;
+  uint16_t num_parameters;
+  const uint8_t *parameter_types_bytes;
+
+  mbuf_rewind_reader(&pkt->data);
+
+  /* Skip first 5 bytes, because we skip the 'P' and the 4 bytes which are the length of the message */
+  if (!mbuf_get_bytes(&pkt->data, 5, &ptr))
+    goto failed;
+
+  if (!mbuf_get_string(&pkt->data, &statement))
+    goto failed;
+
+  if (!mbuf_get_string(&pkt->data, &query))
+    goto failed;
+    
+  /* number of parameter data types */
+  if (!mbuf_get_uint16be(&pkt->data, &num_parameters))
+    goto failed;
+
+  if (!mbuf_get_bytes(&pkt->data, num_parameters * 4, &parameter_types_bytes))
+    goto failed;
+ 
+  *parse_packet_p = (PgParsePacket *)malloc(sizeof(PgParsePacket));
+  (*parse_packet_p)->len = pkt->len;
+  (*parse_packet_p)->name = strdup(statement);
+  (*parse_packet_p)->query = strdup(query);
+  (*parse_packet_p)->num_parameters = num_parameters;
+  (*parse_packet_p)->parameter_types_bytes = (uint8_t *)malloc(4 * num_parameters);
+  memcpy((*parse_packet_p)->parameter_types_bytes, parameter_types_bytes, num_parameters * 4);
+
+  return true;
+
+	failed:
+    disconnect_client(client, true, "broken Parse packet");
+	  return false;
+}
+
+/* Unmarshall (partial) Bind packet into PgBindPacket struct for further processing */
+bool unmarshall_bind_packet(PgSocket *client, PktHdr *pkt, PgBindPacket **bind_packet_p)
+{
+  const uint8_t *ptr;
+  const char *portal;
+  const char *statement;
+
+  mbuf_rewind_reader(&pkt->data);
+
+  /* Skip first 5 bytes, because we skip the 'B' and the 4 bytes which are the length of the message */
+  if (!mbuf_get_bytes(&pkt->data, 5, &ptr))
+    goto failed;
+
+  if (!mbuf_get_string(&pkt->data, &portal))
+    goto failed;
+
+  if (!mbuf_get_string(&pkt->data, &statement))
+    goto failed;
+
+  *bind_packet_p = (PgBindPacket *)malloc(sizeof(PgBindPacket));
+  (*bind_packet_p)->len = pkt->len;
+  (*bind_packet_p)->portal = strdup(portal);
+  (*bind_packet_p)->name = strdup(statement);
+
+  return true;
+
+  failed:
+    disconnect_client(client, true, "broken Bind packet");
+	  return false;
+}
+
+/* Unmarshall Describe packet into PgDescribePacket struct for further processing */
+bool unmarshall_describe_packet(PgSocket *client, PktHdr *pkt, PgDescribePacket **describe_packet_p)
+{
+  const uint8_t *ptr;
+  char describe;
+  const char *statement;
+
+  if (incomplete_pkt(pkt))
+    return false;
+
+  mbuf_rewind_reader(&pkt->data);
+
+  /* Skip first 5 bytes, because we skip the 'D' and the 4 bytes which are the length of the message */
+  if (!mbuf_get_bytes(&pkt->data, 5, &ptr))
+    goto failed;
+
+  if (!mbuf_get_char(&pkt->data, &describe))
+    goto failed;
+
+  if (!mbuf_get_string(&pkt->data, &statement))
+    goto failed;
+
+  *describe_packet_p = (PgDescribePacket *)malloc(sizeof(PgDescribePacket));
+  (*describe_packet_p)->type = describe;
+  (*describe_packet_p)->name = strdup(statement);
+
+  return true;
+
+  failed:
+    disconnect_client(client, true, "broken Describe packet");
+	  return false;
+}
+
+/* Unmarshall Close packet into PgClosePacket struct for further processing */
+bool unmarshall_close_packet(PgSocket *client, PktHdr *pkt, PgClosePacket **close_packet_p)
+{
+  const uint8_t *ptr;
+  char type;
+  const char *name;
+
+  if (incomplete_pkt(pkt))
+    return false;
+
+  mbuf_rewind_reader(&pkt->data);
+  
+  if (!mbuf_get_bytes(&pkt->data, 5, &ptr))
+    goto failed;
+
+  if (!mbuf_get_char(&pkt->data, &type))
+    return true;
+
+  if (!mbuf_get_string(&pkt->data, &name))
+    name = "";
+
+  *close_packet_p = (PgClosePacket *)malloc(sizeof(*close_packet_p));
+  (*close_packet_p)->type = type;
+  (*close_packet_p)->name = strdup(name);
+
+  slog_noise(client, "unmarshall_close_packet: type=%c, len=%d, S/P=%c, name=%s", pkt->type, pkt->len, type, name);
+
+  return true;
+
+	failed:
+    disconnect_client(client, true, "broken Close packet");
+	  return false;
+}
+
+bool is_close_statement_packet(PgClosePacket *close_packet)
+{
+  return close_packet->type == 'S' && strlen(close_packet->name) > 0;
+}
+
+PktBuf *create_parse_packet(char *statement, PgParsePacket *pkt)
+{
+  PktBuf *buf;
+  buf = pktbuf_dynamic(pkt->len - strlen(pkt->name + strlen(statement)));
+  pktbuf_start_packet(buf, 'P');
+  pktbuf_put_string(buf, statement);
+  pktbuf_put_string(buf, pkt->query);
+  pktbuf_put_uint16(buf, pkt->num_parameters);
+  pktbuf_put_bytes(buf, pkt->parameter_types_bytes, pkt->num_parameters * 4);
+  pktbuf_finish_packet(buf);
+  return buf;
+}
+
+PktBuf *create_parse_complete_packet(void)
+{
+  PktBuf *buf;
+  buf = pktbuf_dynamic(5);
+  pktbuf_start_packet(buf, '1');
+  pktbuf_finish_packet(buf);
+  return buf;
+}
+
+PktBuf *create_describe_packet(char *statement)
+{
+  PktBuf *buf;
+  buf = pktbuf_dynamic(6 + strlen(statement));
+  pktbuf_start_packet(buf, 'D');
+  pktbuf_put_char(buf, 'S');
+  pktbuf_put_string(buf, statement);
+  pktbuf_finish_packet(buf);
+  return buf;
+}
+
+PktBuf *create_close_packet(char *statement)
+{
+  PktBuf *buf;
+  buf = pktbuf_dynamic(6 + strlen(statement));
+  pktbuf_start_packet(buf, 'C');
+  pktbuf_put_char(buf, 'S');
+  pktbuf_put_string(buf, statement);
+  pktbuf_finish_packet(buf);
+  return buf;
+}
+
+PktBuf *create_close_complete_packet(void)
+{
+  PktBuf *buf;
+  buf = pktbuf_dynamic(5);
+  pktbuf_start_packet(buf, '3');
+  pktbuf_finish_packet(buf);
+  return buf;
+}
+
+void parse_packet_free(PgParsePacket *pkt)
+{
+  free(pkt->name);
+  free(pkt->query);
+  free(pkt->parameter_types_bytes);
+  free(pkt);
+}

--- a/src/objects.c
+++ b/src/objects.c
@@ -87,7 +87,10 @@ static void construct_client(void *obj)
 	memset(client, 0, sizeof(PgSocket));
 	list_init(&client->head);
 	sbuf_init(&client->sbuf, client_proto);
+  client->packet_cb_state.complete_pkt = malloc(sizeof(struct MBuf));
+  client->packet_cb_state.pkt_header = malloc(sizeof(struct PktHdr));
 	client->state = CL_FREE;
+  client->prepared_statements = NULL;
 }
 
 static void construct_server(void *obj)
@@ -98,6 +101,9 @@ static void construct_server(void *obj)
 	list_init(&server->head);
 	sbuf_init(&server->sbuf, server_proto);
 	server->state = SV_FREE;
+  server->nextUniquePreparedStatementID = 1;
+  server->server_prepared_statements = NULL;
+  list_init(&server->server_outstanding_parse_packets);
 }
 
 /* compare string with PgUser->name, for usage with btree */
@@ -183,6 +189,9 @@ void change_client_state(PgSocket *client, SocketState newstate)
 	case CL_FREE:
 		varcache_clean(&client->vars);
 		slab_free(client_cache, client);
+    free(client->packet_cb_state.complete_pkt);
+    free(client->packet_cb_state.pkt_header);
+    ps_client_free(client);
 		break;
 	case CL_JUSTFREE:
 		statlist_append(&justfree_client_list, &client->head);
@@ -244,6 +253,7 @@ void change_server_state(PgSocket *server, SocketState newstate)
 	case SV_FREE:
 		varcache_clean(&server->vars);
 		slab_free(server_cache, server);
+    ps_server_free(server);
 		break;
 	case SV_JUSTFREE:
 		statlist_append(&justfree_server_list, &server->head);

--- a/src/ps.c
+++ b/src/ps.c
@@ -1,0 +1,336 @@
+#include "bouncer.h"
+
+#include <usual/crypto/csrandom.h>
+#include <usual/hashing/spooky.h>
+#include <usual/hashtab-impl.h>
+
+static PgParsedPreparedStatement *create_prepared_statement(PgParsePacket *parse_packet)
+{
+  static bool initialized;
+	static uint32_t rand_seed;
+  PgParsedPreparedStatement *s = NULL;
+
+	if (!initialized) {
+		initialized = true;
+		rand_seed = csrandom();
+	}
+
+  s = (PgParsedPreparedStatement *)malloc(sizeof(*s));
+  s->name = parse_packet->name;
+  s->pkt = parse_packet;
+  s->query_hash[0] = rand_seed;
+	s->query_hash[1] = 0;
+	spookyhash(parse_packet->query, strlen(parse_packet->query), &s->query_hash[0], &s->query_hash[1]);
+  
+  return s;
+}
+
+static PgServerPreparedStatement *create_server_prepared_statement(PgSocket *client, PgParsedPreparedStatement *ps)
+{
+  PgServerPreparedStatement *s = NULL;
+  char statement[23];
+
+  s = (PgServerPreparedStatement *)malloc(sizeof(*s));
+  *(uint64_t *)&s->query_hash[0] = ps->query_hash[0];
+  *(uint64_t *)&s->query_hash[1] = ps->query_hash[1];
+  s->bind_count = 0;
+
+  // FIXME: length??
+  snprintf(statement, 23, "B_%ld", client->link->nextUniquePreparedStatementID++);
+  s->name = strdup(statement);
+
+  return s;
+}
+
+static int bind_count_sort(struct PgServerPreparedStatement *a, struct PgServerPreparedStatement *b) {
+    return (a->bind_count - b->bind_count);
+}
+
+static bool register_prepared_statement(PgSocket *server, PgServerPreparedStatement *stmt)
+{
+  struct PgServerPreparedStatement *current, *tmp;
+  PktBuf *buf;
+  unsigned int cached_query_count = HASH_COUNT(server->server_prepared_statements);
+
+  if (cached_query_count >= (unsigned int)cf_prepared_statement_cache_queries)
+  {
+    HASH_SORT(server->server_prepared_statements, bind_count_sort);
+    HASH_ITER(hh, server->server_prepared_statements, current, tmp) {
+      HASH_DEL(server->server_prepared_statements, current);
+      cached_query_count--;
+
+      buf = create_close_packet(current->name);
+
+      if (!pktbuf_send_immediate(buf, server)) {
+        pktbuf_free(buf);
+        return false;
+      }
+
+      pktbuf_free(buf);
+
+      slog_noise(server, "prepared statement '%s' deleted from server cache", current->name);
+      free(current->name);
+      free(current);
+      break;
+    }
+  }
+
+  slog_noise(server, "prepared statement '%s' added to server cache, %d cached items", stmt->name, cached_query_count + 1);
+  HASH_ADD(hh, server->server_prepared_statements, query_hash, sizeof(stmt->query_hash), stmt);
+
+  return true;
+}
+
+bool handle_parse_command(PgSocket *client, PktHdr *pkt)
+{
+  PgSocket *server = client->link;
+  PgParsePacket *pp;
+  PgParsedPreparedStatement *ps = NULL;
+  PgServerPreparedStatement *link_ps = NULL;
+  PktBuf *buf;
+  struct OutstandingParsePacket *opp = NULL;
+
+  Assert(server);
+
+  if (!unmarshall_parse_packet(client, pkt, &pp))
+    return false;
+
+  /* update stats */
+  client->pool->stats.ps_client_parse_count++;
+
+  ps = create_prepared_statement(pp);
+  HASH_FIND(hh, server->server_prepared_statements, ps->query_hash, sizeof(ps->query_hash), link_ps);
+  if (link_ps) {
+    /* Statement already prepared on this link, do not forward packet */
+    slog_debug(client, "handle_parse_command: mapping statement '%s' to '%s' (query hash '%ld%ld')", ps->name, link_ps->name, ps->query_hash[0], ps->query_hash[1]);
+
+    buf = create_parse_complete_packet();
+    if (!pktbuf_send_immediate(buf, client)) {
+      pktbuf_free(buf);
+      return false;
+    }
+
+    pktbuf_free(buf);
+    
+    /* Register statement on client link */
+    HASH_ADD_KEYPTR(hh, client->prepared_statements, ps->name, strlen(ps->name), ps);
+  } else {
+    /* Statement not prepared on this link, sent modified P packet */
+    link_ps = create_server_prepared_statement(client, ps);
+
+    slog_debug(client, "handle_parse_command: creating mapping for statement '%s' to '%s' (query hash '%ld%ld')", ps->name, link_ps->name, ps->query_hash[0], ps->query_hash[1]);
+
+    buf = create_parse_packet(link_ps->name, ps->pkt);
+
+    /* update stats */
+    client->pool->stats.ps_server_parse_count++;
+
+    /* Track Parse command sent to server */
+    opp = calloc(sizeof *opp, 1);
+    opp->ignore = false;
+    list_append(&server->server_outstanding_parse_packets, &opp->node);
+    
+    /* Register statement on client and server link */
+    HASH_ADD_KEYPTR(hh, client->prepared_statements, ps->name, strlen(ps->name), ps);
+    if (!register_prepared_statement(server, link_ps))
+      return false;
+
+    if (!pktbuf_send_queued(buf, server)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool handle_bind_command(PgSocket *client, PktHdr *pkt_hdr, unsigned offset, struct MBuf *data, PktBuf *pkt)
+{
+  PgSocket *server = client->link;
+  struct PgBindPacket *bp;
+  PgParsedPreparedStatement *ps = NULL;
+  PgServerPreparedStatement *link_ps = NULL;
+  PktBuf *buf;
+  struct OutstandingParsePacket *opp = NULL;
+
+  const uint8_t *ptr;
+  uint32_t len;
+
+  Assert(server);
+
+  if (!unmarshall_bind_packet(client, pkt_hdr, &bp))
+    return false;
+
+  /* update stats */
+  client->pool->stats.ps_bind_count++;
+
+  HASH_FIND_STR(client->prepared_statements, bp->name, ps);
+  if (!ps) {
+    disconnect_client(client, true, "prepared statement '%s' not found", bp->name);
+	  return false;
+  }
+
+  HASH_FIND(hh, server->server_prepared_statements, ps->query_hash, sizeof(ps->query_hash), link_ps);
+
+  if (!link_ps) {
+    /* Statement is not prepared on this link, sent P packet first */
+    link_ps = create_server_prepared_statement(client, ps);
+    
+    slog_debug(server, "handle_bind_command: prepared statement '%s' (query hash '%ld%ld') not available on server, preparing '%s' before bind", ps->name, ps->query_hash[0], ps->query_hash[1], link_ps->name);
+
+    buf = create_parse_packet(link_ps->name, ps->pkt);
+
+    /* update stats */
+    client->pool->stats.ps_server_parse_count++;
+
+    /* Track Parse command sent to server */    
+    opp = calloc(sizeof *opp, 1);
+    opp->ignore = true;
+    list_append(&server->server_outstanding_parse_packets, &opp->node);
+    if (!pktbuf_send_queued(buf, server)) {
+      return false;
+    }
+
+    /* Register statement on server link */
+    if (!register_prepared_statement(server, link_ps))
+      return false;
+  }
+
+  slog_debug(client, "handle_bind_command: mapped statement '%s' (query hash '%ld%ld') to '%s'", ps->name, ps->query_hash[0], ps->query_hash[1], link_ps->name);
+
+  len = pkt_hdr->len - strlen(ps->name) + strlen(link_ps->name);
+  pktbuf_put_char(pkt, pkt_hdr->type);
+  pktbuf_put_uint32(pkt, len - 1); /* length does not include type byte */
+  pktbuf_put_string(pkt, bp->portal);
+  pktbuf_put_string(pkt, link_ps->name);
+
+  /* Skip original bytes we replaced */
+  if (!mbuf_get_bytes(data, pkt->write_pos - strlen(link_ps->name) + strlen(ps->name), &ptr))
+    return false;
+
+  /* update stats */
+  link_ps->bind_count++;
+
+  free(bp->portal);
+  free(bp->name);
+  free(bp);
+
+  return true;
+}
+
+bool handle_describe_command(PgSocket *client, PktHdr *pkt)
+{
+  SBuf *sbuf = &client->sbuf;
+  PgSocket *server = client->link;
+  PgDescribePacket *dp;
+  PgParsedPreparedStatement *ps = NULL;
+  PgServerPreparedStatement *link_ps = NULL;
+  PktBuf *buf;
+
+  Assert(server);
+
+  if (!unmarshall_describe_packet(client, pkt, &dp))
+    return false;
+
+
+      // if (ps_name) {
+      //   HASH_FIND_STR(client->prepared_statements, ps_name, ps);
+      //   if (!ps) {
+      //     slog_error(client, "lookup failed for prepared statement '%s'", ps_name);
+      //     disconnect_client(client, true, "prepared statement '%s' not found", ps_name);
+      //     return false;
+      //   }
+      // }
+
+  Assert(dp->type == 'S');
+
+  HASH_FIND_STR(client->prepared_statements, dp->name, ps);
+  if (!ps) {
+    disconnect_client(client, true, "prepared statement '%s' not found", dp->name);
+	  return false;
+  }
+
+  HASH_FIND(hh, client->link->server_prepared_statements, ps->query_hash, sizeof(ps->query_hash), link_ps);
+
+  // TODO: link_ps missing -> no parse, should not be possible
+
+  sbuf_prepare_skip(sbuf, pkt->len);
+  if (!sbuf_flush(sbuf))
+    return false;
+
+  slog_debug(client, "handle_describe_command: mapped statement '%s' (query hash '%ld%ld') to '%s'", ps->name, ps->query_hash[0], ps->query_hash[1], link_ps->name);
+
+  buf = create_describe_packet(link_ps->name);
+
+  if (!pktbuf_send_immediate(buf, server)) {
+    pktbuf_free(buf);
+    return false;
+  }
+
+  pktbuf_free(buf);
+
+  return true;
+}
+
+bool handle_close_statement_command(PgSocket *client, PktHdr *pkt, PgClosePacket *close_packet)
+{
+  SBuf *sbuf = &client->sbuf;
+  PgParsedPreparedStatement *ps = NULL;
+  PktBuf *buf;
+
+  HASH_FIND_STR(client->prepared_statements, close_packet->name, ps);
+  if (ps) {
+    slog_noise(client, "handle_close_command: removed '%s' from cached prepared statements, items remaining %u", close_packet->name, HASH_COUNT(client->prepared_statements));
+    HASH_DELETE(hh, client->prepared_statements, ps);
+    parse_packet_free(ps->pkt);
+    free(ps);
+
+    /* Do not forward packet to server */
+    sbuf_prepare_skip(sbuf, pkt->len);
+    if (!sbuf_flush(sbuf))
+      return false;
+    
+    buf = create_close_complete_packet();
+
+    if (!pktbuf_send_immediate(buf, client)) {
+      pktbuf_free(buf);
+      return false;
+    }
+
+    pktbuf_free(buf);
+  }
+
+  return true;
+}
+
+void ps_client_free(PgSocket *client)
+{
+  struct PgParsedPreparedStatement *current, *tmp;
+
+  HASH_ITER(hh, client->prepared_statements, current, tmp) {
+    HASH_DEL(client->prepared_statements, current);
+    parse_packet_free(current->pkt);
+    free(current);
+  }
+
+  free(client->prepared_statements);
+}
+
+void ps_server_free(PgSocket *server)
+{
+  struct PgServerPreparedStatement *current, *tmp_s;
+  struct List *el, *tmp_l;
+	struct OutstandingParsePacket *opp;
+
+  HASH_ITER(hh, server->server_prepared_statements, current, tmp_s) {
+    HASH_DEL(server->server_prepared_statements, current);
+    free(current->name);
+    free(current);
+  }
+
+  list_for_each_safe(el, &server->server_outstanding_parse_packets, tmp_l) {
+		opp = container_of(el, struct OutstandingParsePacket, node);
+		list_del(&opp->node);
+		free(opp);
+	}
+  free(server->server_prepared_statements);
+}

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -501,6 +501,13 @@ static bool sbuf_queue_send(SBuf *sbuf)
 	return true;
 }
 
+bool sbuf_flush(SBuf *sbuf) {
+  if (sbuf->io) {
+    return sbuf_send_pending(sbuf);
+  }
+  return true;
+}
+
 /*
  * There's data in buffer to be sent. Returns bool if processing can continue.
  *

--- a/src/stats.c
+++ b/src/stats.c
@@ -30,6 +30,10 @@ static void reset_stats(PgStats *stat)
 	stat->xact_count = 0;
 	stat->xact_time = 0;
 	stat->wait_time = 0;
+
+  stat->ps_client_parse_count = 0;
+  stat->ps_server_parse_count = 0;
+  stat->ps_bind_count = 0;
 }
 
 static void stat_add(PgStats *total, PgStats *stat)
@@ -41,12 +45,19 @@ static void stat_add(PgStats *total, PgStats *stat)
 	total->xact_count += stat->xact_count;
 	total->xact_time += stat->xact_time;
 	total->wait_time += stat->wait_time;
+
+  total->ps_client_parse_count += stat->ps_client_parse_count;
+  total->ps_server_parse_count += stat->ps_server_parse_count;
+  total->ps_bind_count += stat->ps_bind_count;
 }
 
 static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
 {
 	uint64_t query_count;
 	uint64_t xact_count;
+  uint64_t ps_client_parse_count;
+  uint64_t ps_server_parse_count;
+  uint64_t ps_bind_count;
 
 	usec_t dur = get_cached_time() - old_stamp;
 
@@ -71,6 +82,14 @@ static void calc_average(PgStats *avg, PgStats *cur, PgStats *old)
 		avg->xact_time = (cur->xact_time - old->xact_time) / xact_count;
 
 	avg->wait_time = USEC * (cur->wait_time - old->wait_time) / dur;
+
+  ps_client_parse_count = cur->ps_client_parse_count - old->ps_client_parse_count;
+  ps_server_parse_count = cur->ps_server_parse_count - old->ps_server_parse_count;
+  ps_bind_count = cur->ps_bind_count - old->ps_bind_count;
+
+  avg->ps_client_parse_count = USEC * ps_client_parse_count / dur;
+  avg->ps_server_parse_count = USEC * ps_server_parse_count / dur;
+  avg->ps_bind_count = USEC * ps_bind_count / dur;
 }
 
 static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
@@ -369,6 +388,18 @@ static void refresh_stats(evutil_socket_t s, short flags, void *arg)
 			 avg.client_bytes, avg.server_bytes,
 			 avg.xact_time, avg.query_time,
 			 avg.wait_time);
+    
+    if (!cf_disable_prepared_statement_support) {
+      log_info("prepared statement stats: %" PRIu64 " client parses/s (total %" PRIu64 "),"
+          " %" PRIu64 " server parses/s (total %" PRIu64 "),"
+          " %" PRIu64 " binds/s (total %" PRIu64 ")",
+          avg.ps_client_parse_count,
+          cur_total.ps_client_parse_count,
+          avg.ps_server_parse_count,
+          cur_total.ps_server_parse_count,
+          avg.ps_bind_count,
+          cur_total.ps_bind_count);
+    }
 	}
 
 	sd_notifyf(0,


### PR DESCRIPTION
Unfortunately [PgBouncer](https://www.pgbouncer.org/) does not support prepared statements in transaction pooling mode, as stated in the FAQ:

> To make prepared statements work in this mode would need PgBouncer to keep track of them internally, which it does not do. So the only way to keep using PgBouncer in this mode is to disable prepared statements in the client.

This patch introduces [prepared statement tracking](#how-it-works), allowing to run PgBouncer in transaction pooling mode with server side prepared statements. It **only** supports the extended query protocol parse, bind, execute and close [message formats](https://www.postgresql.org/docs/12/protocol-message-formats.html) E.g. the flow used by the PostgreSQL JDBC driver to create server prepared statements.

## How it works

PgBouncer has client connections (application :left_right_arrow: PgBouncer) and server connections (PgBouncer :left_right_arrow: PostgreSQL). Prepared statements received with a 'parse' command are stored on the receiving client connection together with a hash of the SQL. Parse commands sent to PostgreSQL are modified to have a unique prepared statement name for the server connection. The server connection stores the SQL hash and the prepared statement name unique to that server connection.

Whenever a client connection receives a command involving a prepared statement, it does a lookup to get the prepared statement metadata (SQL sent by the parse command and the SQL hash). The server connection maps this SQL hash to the prepared statement name unique to that server connection and modifies the prepared statement name before sending the command to PostgreSQL. If the SQL hash cannot be found for the server connection, this means we are on a different server connection than the one we originally issued the parse command on. In this case, a parse command is generated and sent first.

## Configuration

Create a configuration file, using `./etc/pgbouncer.ini` as a starting point.

By default, prepared statement support is not enabled. To enable it just add the following to your pgbouncer-ps configuration:

```
disable_prepared_statement_support = 0
```

The number of prepared statements kept active on a single backend connection is defined by the following configuration:

```
prepared_statement_cache_queries = 100
```

Note: keep in mind that this will increase the memory footprint of each client connection on your PostgreSQL server.

Tracking prepared statements does not only come with a memory cost, but also with increased CPU usage. Multiple PgBouncer instances can be run to use more than one core for processing, see `so_reuseport` socket option.

## Connect the application

Configure your client application as though you were connecting directly to a PostgreSQL database.

Example - JDBC driver

```
jdbc:postgresql://pgbouncer-ps:6432/postgres?prepareThreshold=10&preparedStatementCacheQueries=512&preparedStatementCacheSizeMiB=10
```

Note: Cached prepared statements by the JDBC driver will increase the memory footprint of each JDBC connection in your application and each front-end connection in PgBouncer.