### PR TITLE
Add cancel requests to SHOW CLIENTS/SERVERS

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -252,7 +252,8 @@ database
 
 state
 :   State of the pgbouncer server connection, one of **active**,
-    **idle**, **used**, **tested**, **new**.
+    **idle**, **used**, **tested**, **new**, **active_cancel**,
+    **wait_cancels**.
 
 addr
 :   IP address of PostgreSQL server.
@@ -316,7 +317,8 @@ database
 :   Database name.
 
 state
-:   State of the client connection, one of **active** or **waiting**.
+:   State of the client connection, one of **active**, **waiting**,
+    **active_cancel_req** or **waiting_cancel_req**.
 
 addr
 :   IP address of client.
@@ -379,12 +381,12 @@ cl_active
 cl_waiting
 :   Client connections that have sent queries but have not yet got a server connection.
 
-cl_waiting_cancel_req
-:   Client connections that have not forwarded query cancellations to the server yet.
-
 cl_active_cancel_req
 :   Client connections that have forwarded query cancellations to the server and
     are waiting for the server response.
+
+cl_waiting_cancel_req
+:   Client connections that have not forwarded query cancellations to the server yet.
 
 sv_active
 :   Server connections that are linked to a client.

--- a/src/admin.c
+++ b/src/admin.c
@@ -702,6 +702,8 @@ static bool admin_show_clients(PgSocket *admin, const char *arg)
 
 		show_socket_list(buf, &pool->active_client_list, "active", false);
 		show_socket_list(buf, &pool->waiting_client_list, "waiting", false);
+		show_socket_list(buf, &pool->active_cancel_req_list, "active_cancel_req", false);
+		show_socket_list(buf, &pool->waiting_cancel_req_list, "waiting_cancel_req", false);
 	}
 
 	admin_flush(admin, buf, "SHOW");
@@ -729,6 +731,8 @@ static bool admin_show_servers(PgSocket *admin, const char *arg)
 		show_socket_list(buf, &pool->used_server_list, "used", false);
 		show_socket_list(buf, &pool->tested_server_list, "tested", false);
 		show_socket_list(buf, &pool->new_server_list, "new", false);
+		show_socket_list(buf, &pool->active_cancel_server_list, "active_cancel", false);
+		show_socket_list(buf, &pool->wait_cancels_server_list, "wait_cancels", false);
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;


### PR DESCRIPTION
When debugging issues it can be useful to see the clients and servers
that are involved in cancel requests.
