### PR TITLE
Rename wait_cancels state to being_canceled

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -253,7 +253,7 @@ database
 state
 :   State of the pgbouncer server connection, one of **active**,
     **idle**, **used**, **tested**, **new**, **active_cancel**,
-    **wait_cancels**.
+    **being_canceled**.
 
 addr
 :   IP address of PostgreSQL server.
@@ -394,7 +394,7 @@ sv_active
 sv_active_cancel
 :   Server connections that are currently forwarding a cancel request.
 
-sv_wait_cancels
+sv_being_canceled
 :   Servers that normally could become idle but are waiting to do so until
     all in-flight cancel requests have completed that were sent to cancel
     a query on this server.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -61,7 +61,7 @@ enum SocketState {
 	SV_FREE,		/* free_server_list */
 	SV_JUSTFREE,		/* justfree_server_list */
 	SV_LOGIN,		/* pool->new_server_list */
-	SV_WAIT_CANCELS,	/* pool->wait_cancels_server_list */
+	SV_BEING_CANCELED,	/* pool->being_canceled_server_list */
 	SV_IDLE,		/* pool->idle_server_list */
 	SV_ACTIVE,		/* pool->active_server_list */
 	SV_ACTIVE_CANCEL,	/* pool->active_cancel_server_list */
@@ -313,7 +313,7 @@ struct PgPool {
 	 * thus not be reused) until all in-flight cancel requests for it have
 	 * completed.
 	 */
-	struct StatList wait_cancels_server_list;
+	struct StatList being_canceled_server_list;
 
 	/*
 	 * Servers connections that are ready to be linked with clients. These will
@@ -383,7 +383,7 @@ struct PgPool {
  */
 #define pool_connected_server_count(pool) ( \
 		statlist_count(&(pool)->active_server_list) + \
-		statlist_count(&(pool)->wait_cancels_server_list) + \
+		statlist_count(&(pool)->being_canceled_server_list) + \
 		statlist_count(&(pool)->idle_server_list) + \
 		statlist_count(&(pool)->tested_server_list) + \
 		statlist_count(&(pool)->used_server_list))

--- a/src/admin.c
+++ b/src/admin.c
@@ -732,7 +732,7 @@ static bool admin_show_servers(PgSocket *admin, const char *arg)
 		show_socket_list(buf, &pool->tested_server_list, "tested", false);
 		show_socket_list(buf, &pool->new_server_list, "new", false);
 		show_socket_list(buf, &pool->active_cancel_server_list, "active_cancel", false);
-		show_socket_list(buf, &pool->wait_cancels_server_list, "wait_cancels", false);
+		show_socket_list(buf, &pool->being_canceled_server_list, "being_canceled", false);
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;
@@ -834,7 +834,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				    "cl_waiting_cancel_req",
 				    "sv_active",
 				    "sv_active_cancel",
-				    "sv_wait_cancels",
+				    "sv_being_canceled",
 				    "sv_idle",
 				    "sv_used", "sv_tested",
 				    "sv_login", "maxwait",
@@ -852,7 +852,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				     statlist_count(&pool->waiting_cancel_req_list),
 				     statlist_count(&pool->active_server_list),
 				     statlist_count(&pool->active_cancel_server_list),
-				     statlist_count(&pool->wait_cancels_server_list),
+				     statlist_count(&pool->being_canceled_server_list),
 				     statlist_count(&pool->idle_server_list),
 				     statlist_count(&pool->used_server_list),
 				     statlist_count(&pool->tested_server_list),

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -691,7 +691,7 @@ void kill_pool(PgPool *pool)
 
 	close_server_list(&pool->active_server_list, reason);
 	close_server_list(&pool->active_cancel_server_list, reason);
-	close_server_list(&pool->wait_cancels_server_list, reason);
+	close_server_list(&pool->being_canceled_server_list, reason);
 	close_server_list(&pool->idle_server_list, reason);
 	close_server_list(&pool->used_server_list, reason);
 	close_server_list(&pool->tested_server_list, reason);


### PR DESCRIPTION
After merging #717 it was noted that the `wait_cancels` name was quite
confusing. This changes that name to `being_canceled`. This makes it
more clear that this is not a server that is canceling itself, but
instead it's the target of a cancellation request.

Another option would be to rename it to waiting_cancel to be symetric 
with the client state. However, not being symetric is kind of the point 
of the newly suggested name. 

sv_wait_cancel would suggest that it's waiting for a cancel that it sent itself:
- active_cancel_req_list, is a list of clients that are sending a cancel themselves
- waiting_cancel_req_list, is a list of clients that are waiting for a server connection needed to for the cancel
- active_cancel_server_list, is the list of server connections on which a cancel is currently being sent

Thus (to me) waiting_cancel_server_list would suggest that any server in this list is waiting to send a cancel. But that is not what it means to be in this list. Servers in the list in question are currently being cancelled by another server connection. To make this difference clear is why I suggested `being_cancelled_server_list`.