### PR TITLE
CI: Use new MacOS instance

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -189,16 +189,15 @@ task:
 
 task:
   name: macOS
-  osx_instance:
-    matrix:
-      - image: monterey-base
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:
     HAVE_IPV6_LOCALHOST: yes
   setup_script:
     - brew install autoconf automake bash libevent libtool openssl pandoc pkg-config postgresql
   env:
-    CPPFLAGS: -I/usr/local/opt/openssl/include
-    LDFLAGS: -L/usr/local/opt/openssl/lib
+    CPPFLAGS: -I/opt/homebrew/opt/openssl@3/include
+    LDFLAGS: -L/opt/homebrew/opt/openssl@3/lib
   build_script:
     - ./autogen.sh
     - ./configure --prefix=$HOME/install --enable-werror


### PR DESCRIPTION
While debugging some unrelated CI issue I noticed this message in the
interface:

> We are sunsetting support for Intel-based macOS instances! Please migrate before January 1st 2023.

This updates our config to migrate to the new macOS instances.
