### PR TITLE
Run make in CI in parallel

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,9 @@ build_script:
   - set PATH=C:/msys64/usr/bin;%PATH%
   - sh -l -c "./autogen.sh"
   - sh -l -c "./configure --enable-werror LDFLAGS=-static LIBS=-liphlpapi PKG_CONFIG='pkg-config --static'"
-  - sh -l -c "make"
-  - sh -l -c "make install"
-  - sh -l -c "make zip"
+  - sh -l -c "make -j4"
+  - sh -l -c "make -j4 install"
+  - sh -l -c "make -j4 zip"
 
 artifacts:
   - path: '*.zip'
@@ -26,7 +26,7 @@ artifacts:
 test_script:
   - set HOME=.
   - set PATH=C:/msys64/usr/bin;%PATH%
-  - sh -l -c "make check tls_support=no"
+  - sh -l -c "make -j4 check tls_support=no"
   - sh -l -c "windres pgbouncer.exe"
 
 on_failure:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,13 +76,13 @@ task:
   build_script:
     - su user -c "./autogen.sh"
     - su user -c "${use_scan_build:+scan-build} ./configure --prefix=$HOME/install --enable-cassert --enable-werror --without-cares --with-systemd $configure_args"
-    - su user -c "${use_scan_build:+scan-build} make"
+    - su user -c "${use_scan_build:+scan-build} make -j4"
   test_script:
     - |
       if [ x"$use_valgrind" = x"yes" ]; then
         export BOUNCER_EXE_PREFIX="valgrind --quiet --leak-check=full --show-reachable=no --track-origins=yes --error-markers=VALGRIND-ERROR-BEGIN,VALGRIND-ERROR-END --log-file=/tmp/valgrind.%p.log"
       fi
-    - su user -c "PATH=/usr/lib/postgresql/${PGVERSION}/bin:$PATH make check"
+    - su user -c "PATH=/usr/lib/postgresql/${PGVERSION}/bin:$PATH make -j4 check"
     - |
       if [ x"$use_valgrind" = x"yes" ]; then
         if grep -q VALGRIND-ERROR /tmp/valgrind.*.log; then
@@ -91,15 +91,15 @@ task:
         fi
       fi
   install_script:
-    - make install
+    - make -j4 install
   dist_script:
-    - make dist
+    - make -j4 dist
     - PACKAGE_VERSION=$(sed -n 's/PACKAGE_VERSION = //p' config.mak)
     - tar -x -v -f pgbouncer-${PACKAGE_VERSION}.tar.gz
     - cd pgbouncer-${PACKAGE_VERSION}/
     - ./configure --prefix=$HOME/install2 --enable-werror --without-cares $configure_args
-    - make
-    - make install
+    - make -j4
+    - make -j4 install
   tarball_artifacts:
     path: "pgbouncer-*.tar.gz"
   always:
@@ -124,12 +124,12 @@ task:
   build_script:
     - su user -c "./autogen.sh"
     - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-systemd"
-    - su user -c "make"
+    - su user -c "make -j4"
   test_script:
 # XXX: postgresql too old on centos7
-    - if cat /etc/centos-release | grep -q ' 7'; then true; else su user -c "make check"; fi
+    - if cat /etc/centos-release | grep -q ' 7'; then true; else su user -c "make -j4 check"; fi
   install_script:
-    - make install
+    - make -j4 install
   always:
     configure_artifacts:
       path: "config.log"
@@ -150,11 +150,11 @@ task:
   build_script:
     - su user -c "./autogen.sh"
     - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror"
-    - su user -c "make"
+    - su user -c "make -j4"
   test_script:
-    - su user -c "make check"
+    - su user -c "make -j4 check"
   install_script:
-    - make install
+    - make -j4 install
   always:
     configure_artifacts:
       path: "config.log"
@@ -177,11 +177,11 @@ task:
   build_script:
     - su user -c "./autogen.sh"
     - su user -c "./configure --prefix=$HOME/install --enable-werror"
-    - su user -c "gmake"
+    - su user -c "gmake -j4"
   test_script:
-    - su user -c "gmake check"
+    - su user -c "gmake -j4 check"
   install_script:
-    - gmake install
+    - gmake -j4 install
   always:
     configure_artifacts:
       path: "config.log"
@@ -201,11 +201,11 @@ task:
   build_script:
     - ./autogen.sh
     - ./configure --prefix=$HOME/install --enable-werror
-    - make
+    - make -j4
   test_script:
-    - make check
+    - make -j4 check
   install_script:
-    - make install
+    - make -j4 install
   always:
     configure_artifacts:
       path: "config.log"
@@ -231,14 +231,14 @@ task:
   build_script:
     - sh -l -c "./autogen.sh"
     - sh -l -c "./configure --prefix=$HOME/install --enable-werror PANDOC=/c/programdata/chocolatey/bin/pandoc LDFLAGS=-static LIBS=-liphlpapi PKG_CONFIG='pkg-config --static'"
-    - sh -l -c "make"
+    - sh -l -c "make -j4"
   test_script:
-    - sh -l -c "make check tls_support=no"
+    - sh -l -c "make -j4 check tls_support=no"
     - sh -l -c "windres pgbouncer.exe"
   install_script:
-    - sh -l -c "make install"
+    - sh -l -c "make -j4 install"
   dist_script:
-    - sh -l -c "make zip"
+    - sh -l -c "make -j4 zip"
   zip_artifacts:
     path: "pgbouncer-*.zip"
   always:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /config.status
 /config.sub
 /configure
+/doc/pgbouncer_1.md
+/doc/pgbouncer_5.md
 /install-sh
 /pgbouncer
 /.objs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,7 +28,5 @@ pgbouncer_1.md: filter.py frag-usage-man.md usage.md
 pgbouncer_5.md: filter.py frag-config-man.md config.md
 	$(PYTHON) $^ >$@
 
-.INTERMEDIATE: pgbouncer_1.md pgbouncer_5.md
-
 web:
 	$(MAKE) -C ../../pgbouncer.github.io


### PR DESCRIPTION
To speed up compilation. All CI machines have 2 or 4 cores, it's unclear
if those numbers include hyperthreads or not. For simplicity we start
using 4 threads everywhere. In my experience it's much worse if you less
parallelism than can be handled, but having a bit more doesn't matter
too much for the total compilation time. Also if any of these tasks are
I/O bound instead of CPU bound, then you want more parallelism than your
amount of cores anyway.

As an example of speedup this improves the speed of the build step 
on windows CI from 3 minutes to 2 minutes.