### PR TITLE
Fix possible memory leak on TLS handshake failure

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -79,7 +79,7 @@ static void sbuf_main_loop(SBuf *sbuf, bool skip_recv);
 static bool sbuf_call_proto(SBuf *sbuf, int event) /* _MUSTCHECK */;
 static bool sbuf_actual_recv(SBuf *sbuf, size_t len)  _MUSTCHECK;
 static bool sbuf_after_connect_check(SBuf *sbuf)  _MUSTCHECK;
-static bool handle_tls_handshake(SBuf *sbuf) /* _MUSTCHECK */;
+static bool handle_tls_handshake(SBuf *sbuf) _MUSTCHECK;
 
 /* regular I/O */
 static ssize_t raw_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len);
@@ -777,7 +777,8 @@ skip_recv:
 
 	if (sbuf->tls_state == SBUF_TLS_DO_HANDSHAKE) {
 		sbuf->pkt_action = SBUF_TLS_IN_HANDSHAKE;
-		handle_tls_handshake(sbuf);
+		if (!handle_tls_handshake(sbuf))
+			sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
 	}
 }
 


### PR DESCRIPTION
On an unrelated PR a memory leak was reported by CI on a TLS test.
```
==11838== VALGRIND-ERROR-BEGIN
==11838== 71,890 (112 direct, 71,778 indirect) bytes in 1 blocks are definitely lost in loss record 178 of 178
==11838==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==11838==    by 0x15B06E: tls_new (tls.c:240)
==11838==    by 0x16210B: tls_server_conn (tls_server.c:47)
==11838==    by 0x16248E: tls_accept_fds (tls_server.c:141)
==11838==    by 0x1380EB: sbuf_tls_accept (sbuf.c:1127)
==11838==    by 0x11E15A: handle_client_startup (client.c:729)
==11838==    by 0x11EF17: client_proto (client.c:1041)
==11838==    by 0x136069: sbuf_call_proto (sbuf.c:390)
==11838==    by 0x136B58: sbuf_process_pending (sbuf.c:583)
==11838==    by 0x13722C: sbuf_main_loop (sbuf.c:763)
==11838==    by 0x134FAB: sbuf_accept (sbuf.c:137)
==11838==    by 0x12D220: accept_client (objects.c:1540)
==11838==
==11838== VALGRIND-ERROR-END
```
Source: https://cirrus-ci.com/task/5909005202096128?logs=test#L91

When running the same test multiple times locally on my own machine this
reproduced ~100 runs. After adding some logging the reason turned out to
be that we were not always handling errors from `handle_tls_handshake`.

This PR fixes that by handling handshake errors in all places that we
call `handle_tls_handshake`. I confirmed this fixed the issue by running
the originally failing test 1000 times with valgrind and all runs passed
now.
