### PR TITLE
Add Python style checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -257,3 +257,13 @@ task:
     configure_artifacts:
       path: "config.log"
       type: text/plain
+
+task:
+  name: Python check
+  container:
+    image: ubuntu:20.04
+  setup_script:
+    - apt-get update
+    - apt-get -y install flake8
+  test_script:
+    - flake8

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E265, F401, F541
+max-line-length = 150

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import filelock
 import shutil
-from .utils import *
+from .utils import run, Bouncer, Postgres, LONG_PASSWORD, PG_SUPPORTS_SCRAM, TEST_DIR, TLS_SUPPORT
 
 
 def create_certs(cert_dir):

--- a/test/stress.py
+++ b/test/stress.py
@@ -1,8 +1,5 @@
 #! /usr/bin/env python3
 
-import sys
-import os
-import re
 import time
 import psycopg2
 import threading

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -1,5 +1,4 @@
 import time
-import os
 import pytest
 import psycopg
 import platform

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,12 +12,10 @@ import psycopg
 import os
 import re
 import sys
-import shutil
 import time
 import asyncio
 import socket
-from tempfile import TemporaryDirectory, gettempdir
-import multiprocessing
+from tempfile import gettempdir
 import filelock
 import typing
 import signal
@@ -365,7 +363,7 @@ class QueryRunner:
                     f"pfctl -E", stderr=subprocess.PIPE, text=True
                 ).stderr
                 match = re.search(r"^Token : (\d+)", command_stderr, flags=re.MULTILINE)
-                assert match != None
+                assert match is not None
                 fw_token = match.group(1)
             sudo(
                 'bash -c "'
@@ -489,7 +487,7 @@ class Postgres(QueryRunner):
     def start(self):
         try:
             self.pgctl(f'-o "-p {self.port}" -l {self.log_path} start')
-        except:
+        except Exception:
             print("\n\nPG_LOG\n")
             with self.log_path.open() as f:
                 print(f.read())
@@ -558,7 +556,7 @@ class Postgres(QueryRunner):
         """Remove any HBA rules that were added after the last call to commit_hba"""
         with self.hba_path.open() as f:
             hba_contents = f.read()
-        committed = hba_contents[hba_contents.find("# committed-rules\n") :]
+        committed = hba_contents[hba_contents.find("# committed-rules\n"):]
         with self.hba_path.open("w") as f:
             f.write(committed)
 


### PR DESCRIPTION
Now that we have a lot more Python code, add some project-wide style checking configuration, using flake8.

A couple of easy violations are fixed here, but some that are more difficult are just disabled and might be addressed later (or never).