### PR TITLE
Add option to ignore SIGTERM

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -212,6 +212,15 @@ If you need to specify multiple values, use a comma-separated list (e.g.
 
 Default: empty
 
+### ignore_sigterm
+
+Ignore any received TERM signals, useful for running in cloud environments like Herko & AWS which
+send TERM signals on container shutdown while rerouting new requests.  Ignoring the signal allows
+process to respond to last queries instead of terminating immediately.  AWS provides 30s after sending
+TERM to finish responding to in-flight requests.
+
+Default: 0
+
 ### disable_pqexec
 
 Disable the Simple Query protocol (PQexec).  Unlike the Extended Query protocol, Simple Query

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -161,6 +161,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; packet.  Newer JDBC versions require the extra_float_digits here.
 ;ignore_startup_parameters = extra_float_digits
 
+;; If set then ignore TERM signals and continue to serve
+;ignore_sigterm = 0
+
 ;; When taking idle server into use, this query is run first.
 ;server_check_query = select 1
 

--- a/src/main.c
+++ b/src/main.c
@@ -138,6 +138,7 @@ char *cf_resolv_conf;
 unsigned int cf_max_packet_size;
 
 char *cf_ignore_startup_params;
+int  cf_ignore_sigterm;
 
 char *cf_autodb_connstr; /* here is "" different from NULL */
 
@@ -254,6 +255,7 @@ CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
 CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
+CF_ABS("ignore_sigterm", CF_INT, cf_ignore_sigterm, CF_NO_RELOAD, "0"),
 CF_ABS("job_name", CF_STR, cf_jobname, CF_NO_RELOAD, "pgbouncer"),
 CF_ABS("listen_addr", CF_STR, cf_listen_addr, CF_NO_RELOAD, ""),
 CF_ABS("listen_backlog", CF_INT, cf_listen_backlog, CF_NO_RELOAD, "128"),
@@ -447,6 +449,10 @@ static struct event ev_sigint;
 
 static void handle_sigterm(evutil_socket_t sock, short flags, void *arg)
 {
+	if (cf_ignore_sigterm) {
+		log_info("got SIGTERM, ignoring");
+		return;
+	}
 	log_info("got SIGTERM, fast exit");
 	/* pidfile cleanup happens via atexit() */
 	exit(1);


### PR DESCRIPTION
This is useful for running in cloud environments like AWS & Heroku where TERM is sent to all processes expecting them to shutdown gracefully.  AWS stops routing requests to these instances when TERM is sent, so pgbouncer can serve any requests in-flight and then terminate once the container exits.

https://github.com/pgbouncer/pgbouncer/issues/770