### PR TITLE
Don't process buffered payload when EV_CLOSED is detected

### DIFF
--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -144,27 +144,27 @@ async def test_close_detection(bouncer):
     aconn = await bouncer.aconn()
     sock = socket.fromfd(aconn.fileno(), socket.AF_INET, socket.SOCK_STREAM)
     with bouncer.admin_runner.cur() as cur:
-        cur.execute('SHOW STATS_TOTALS')
+        cur.execute("SHOW STATS_TOTALS")
         result = cur.fetchall()[0]
-        assert result[0] == 'p0'
+        assert result[0] == "p0"
         assert result[1] == 0
         with bouncer.drop_traffic():
-            query_task = aconn.execute('select 1')
+            query_task = aconn.execute("select 1")
             done, pending = await asyncio.wait([query_task], timeout=1)
             assert done == set()
             assert len(pending) == 1
             sock.shutdown(socket.SHUT_RDWR)
 
-        cur.execute('SHOW CLIENTS')
+        cur.execute("SHOW CLIENTS")
         client_num = len(cur.fetchall())
         while client_num > 1:
             time.sleep(1)
-            cur.execute('SHOW CLIENTS')
+            cur.execute("SHOW CLIENTS")
             client_num = len(cur.fetchall())
 
-        cur.execute('SHOW STATS_TOTALS')
+        cur.execute("SHOW STATS_TOTALS")
         result = cur.fetchall()[0]
-        assert result[0] == 'p0'
+        assert result[0] == "p0"
         assert result[1] == 0
 
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -1,11 +1,12 @@
 import asyncio
 import platform
+import socket
 import time
 
 import psycopg
 import pytest
 
-from .utils import USE_SUDO
+from .utils import USE_SUDO, HAS_EPOLL
 
 
 def test_server_lifetime(pg, bouncer):
@@ -132,6 +133,39 @@ def test_tcp_user_timeout(pg, bouncer):
                 match=r"server closed the connection unexpectedly|Software caused connection abort",
             ):
                 bouncer.test(connect_timeout=10)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif("not USE_SUDO")
+@pytest.mark.skipif(
+    "not HAS_EPOLL", reason="Early close detection is only available with epoll"
+)
+async def test_close_detection(bouncer):
+    aconn = await bouncer.aconn()
+    sock = socket.fromfd(aconn.fileno(), socket.AF_INET, socket.SOCK_STREAM)
+    with bouncer.admin_runner.cur() as cur:
+        cur.execute('SHOW STATS_TOTALS')
+        result = cur.fetchall()[0]
+        assert result[0] == 'p0'
+        assert result[1] == 0
+        with bouncer.drop_traffic():
+            query_task = aconn.execute('select 1')
+            done, pending = await asyncio.wait([query_task], timeout=1)
+            assert done == set()
+            assert len(pending) == 1
+            sock.shutdown(socket.SHUT_RDWR)
+
+        cur.execute('SHOW CLIENTS')
+        client_num = len(cur.fetchall())
+        while client_num > 1:
+            time.sleep(1)
+            cur.execute('SHOW CLIENTS')
+            client_num = len(cur.fetchall())
+
+        cur.execute('SHOW STATS_TOTALS')
+        result = cur.fetchall()[0]
+        assert result[0] == 'p0'
+        assert result[1] == 0
 
 
 @pytest.mark.skipif("not USE_SUDO")

--- a/test/utils.py
+++ b/test/utils.py
@@ -40,7 +40,7 @@ NEW_SITE_SCRIPT = TEST_DIR / "ssl" / "newsite.sh"
 ENABLE_VALGRIND = bool(os.environ.get("ENABLE_VALGRIND"))
 HAVE_IPV6_LOCALHOST = bool(os.environ.get("HAVE_IPV6_LOCALHOST"))
 USE_SUDO = bool(os.environ.get("USE_SUDO"))
-HAS_EPOLL = hasattr(select, 'epoll')
+HAS_EPOLL = hasattr(select, "epoll")
 
 # The tests require that psql can connect to the PgBouncer admin
 # console.  On platforms that have getpeereid(), this works by

--- a/test/utils.py
+++ b/test/utils.py
@@ -12,6 +12,7 @@ import asyncio
 import os
 import platform
 import re
+import select
 import signal
 import socket
 import sys
@@ -39,6 +40,7 @@ NEW_SITE_SCRIPT = TEST_DIR / "ssl" / "newsite.sh"
 ENABLE_VALGRIND = bool(os.environ.get("ENABLE_VALGRIND"))
 HAVE_IPV6_LOCALHOST = bool(os.environ.get("HAVE_IPV6_LOCALHOST"))
 USE_SUDO = bool(os.environ.get("USE_SUDO"))
+HAS_EPOLL = hasattr(select, 'epoll')
 
 # The tests require that psql can connect to the PgBouncer admin
 # console.  On platforms that have getpeereid(), this works by


### PR DESCRIPTION
Some drivers close the connection to PgBouncer on timeout ([pq-timeout](https://github.com/Kount/pq-timeouts) for example).
When PgBouncer is loaded (due to churning TLS connections for example), this can lead to sockets piling up with buffered query and already closed by the client.

```
CLOSE-WAIT 52     0      10.12.16.24:5433   10.12.16.199:48878 users:(("pgbouncer",pid=2047465,fd=629)) timer:(keepalive,119min,0)
CLOSE-WAIT 52     0      10.12.16.24:5433   10.12.16.199:41310 users:(("pgbouncer",pid=2047465,fd=537)) timer:(keepalive,119min,0)
CLOSE-WAIT 52     0      10.12.16.24:5433   10.12.16.199:48910 users:(("pgbouncer",pid=2047465,fd=633)) timer:(keepalive,119min,0)
CLOSE-WAIT 52     0      10.12.16.24:5433   10.12.16.199:45086 users:(("pgbouncer",pid=2047465,fd=514)) timer:(keepalive,119min,0)
```

PgBouncer will still pop the buffered event, open a server connection, send the query and immediately close the server connection as it's not in a reusable state.
Detecting early closure with EV_CLOSED when it's available can help recover from this situation by avoiding wasting time on queries that are not gonna be used.