### PR TITLE
Provide SQLSTATE

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -50,6 +50,7 @@ bool check_fast_fail(PgSocket *client)		_MUSTCHECK;
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _PRINTF(3, 4);
+void disconnect_client_sqlstate(PgSocket *client, bool notify, const char *sqlstate, const char *reason);
 
 PgDatabase * add_peer(const char *name, int peer_id) _MUSTCHECK;
 PgDatabase * add_database(const char *name) _MUSTCHECK;

--- a/include/proto.h
+++ b/include/proto.h
@@ -39,9 +39,9 @@ struct PktHdr {
 
 bool get_header(struct MBuf *data, PktHdr *pkt) _MUSTCHECK;
 
-bool send_pooler_error(PgSocket *client, bool send_ready, bool level_fatal, const char *msg)  /*_MUSTCHECK*/;
+bool send_pooler_error(PgSocket *client, bool send_ready, const char *sqlstate, bool level_fatal, const char *msg)  /*_MUSTCHECK*/;
 void log_server_error(const char *note, PktHdr *pkt);
-void parse_server_error(PktHdr *pkt, const char **level_p, const char **msg_p);
+void parse_server_error(PktHdr *pkt, const char **level_p, const char **msg_p, const char **sqlstate_p);
 
 bool add_welcome_parameter(PgPool *pool, const char *key, const char *val) _MUSTCHECK;
 void finish_welcome_msg(PgSocket *server);

--- a/include/server.h
+++ b/include/server.h
@@ -17,7 +17,7 @@
  */
 
 bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
-void kill_pool_logins(PgPool *pool, const char *msg);
+void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);
 int pool_pool_mode(PgPool *pool) _MUSTCHECK;
 int pool_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_min_pool_size(PgPool *pool) _MUSTCHECK;

--- a/src/admin.c
+++ b/src/admin.c
@@ -108,7 +108,7 @@ bool admin_error(PgSocket *admin, const char *fmt, ...)
 
 	log_error("%s", str);
 	if (admin)
-		res = send_pooler_error(admin, true, false, str);
+		res = send_pooler_error(admin, true, NULL, false, str);
 	return res;
 }
 

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -158,7 +158,7 @@ bool pktbuf_send_queued(PktBuf *buf, PgSocket *sk)
 
 	if (buf->failed) {
 		pktbuf_free(buf);
-		return send_pooler_error(sk, true, false, "result prepare failed");
+		return send_pooler_error(sk, true, NULL, false, "result prepare failed");
 	} else {
 		buf->sending = true;
 		buf->queued_dst = sk;


### PR DESCRIPTION
PgBouncer currently uses SQLSTATE 08P01 (protocol_violation) as default error code to send error messages to client. There are cases that this SQLSTATE is different from what Postgres provides. Since the goal is to be as transparent as possible, PgBouncer should report the SQLSTATE provided by Postgres. Issue #778 exposes one case that if you connect to a database that doesn't exist, Postgres reports 3D000 (invalid_catalog_name) but PgBouncer reports 08P01. The npgsql driver relies on the SQLSTATE to check if the database already exists and this behavior breaks it. PgBouncer will use the SQLSTATE that Postgres provides.

Fix issue #778.