### PR TITLE
Fix calling disconnect_server on a server in BEING_CANCELED state

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -906,6 +906,7 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	case SV_TESTED:
 	case SV_USED:
 	case SV_IDLE:
+	case SV_BEING_CANCELED:
 		break;
 	case SV_LOGIN:
 		/*


### PR DESCRIPTION
Fixes a bug introduced by #717

Related to #801 (and hopefully fixes)
