### PR TITLE
Make manpages only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,4 +168,4 @@ htmls:
 	done
 
 doc/pgbouncer.1 doc/pgbouncer.5:
-	$(MAKE) -C doc
+	$(MAKE) -C doc $(@F)


### PR DESCRIPTION
We currently make manpages twice, which can fail under concurrency:

```
make[1]: Leaving directory '/build/pgbouncer-1.17.0'
make -C doc
make[1]: Entering directory '/build/pgbouncer-1.17.0'
gcc  -DHAVE_CONFIG_H -Iinclude -Ilib -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -fdebug-prefix-map=/build/pgbouncer-1.17.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wdeclaration-after-statement -Wold-style-definition -Wstrict-prototypes -Wundef -Wformat=2 -Wuninitialized -Wmissing-format-attribute -MD -MP -MT .objs/pgbouncer/lib/usual/tls/tls_ocsp.o -MF .objs/pgbouncer/lib/usual/tls/tls_ocsp.o.d -c -o .objs/pgbouncer/lib/usual/tls/tls_ocsp.o lib/usual/tls/tls_ocsp.c
make[1]: Leaving directory '/build/pgbouncer-1.17.0'
make -C doc
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
pandoc -s -t man -o pgbouncer.1 pgbouncer_1.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
python3 filter.py frag-usage-man.md usage.md >pgbouncer_1.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
python3 filter.py frag-config-man.md config.md >pgbouncer_5.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
pandoc -s -t man -o pgbouncer.5 pgbouncer_5.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
rm pgbouncer_5.md
...
make[1]: Leaving directory '/build/pgbouncer-1.17.0'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
python3 filter.py frag-config-man.md config.md >pgbouncer_5.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
pandoc -s -t man -o pgbouncer.5 pgbouncer_5.md
Makefile:23: recipe for target 'pgbouncer.5' failed
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
pandoc: pgbouncer_5.md: openFile: does not exist (No such file or directory)
make[2]: *** [pgbouncer.5] Error 1
make[2]: *** Waiting for unfinished jobs....
...
make[1]: Leaving directory '/build/pgbouncer-1.17.0'
make[2]: Entering directory '/build/pgbouncer-1.17.0/doc'
pandoc -s -t man -o pgbouncer.1 pgbouncer_1.md
make[2]: Leaving directory '/build/pgbouncer-1.17.0/doc'
rm pgbouncer_1.md
```

The above output shows one invocation of `make -C doc` delete the `pgbouncer_5.md` file, which the other invocation was about to use.