### PR TITLE
Add intervalstyle parameter

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -202,10 +202,11 @@ Default: 0
 
 ### ignore_startup_parameters
 
-By default, PgBouncer allows only parameters it can keep track of in startup
-packets: `client_encoding`, `datestyle`, `timezone` and `standard_conforming_strings`.
-All others parameters will raise an error.  To allow others parameters, they can be
-specified here, so that PgBouncer knows that they are handled by the admin and it can ignore them.
+By default, PgBouncer allows only parameters it can keep track of in startup packets:
+`client_encoding`, `datestyle`, `intervalstyle`, `timezone` and
+`standard_conforming_strings`.  All others parameters will raise an error.  To allow
+others parameters, they can be specified here, so that PgBouncer knows that they are
+handled by the admin and it can ignore them.
 
 If you need to specify multiple values, use a comma-separated list (e.g.
 `options,extra_float_digits`)
@@ -1046,6 +1047,10 @@ Ask specific `client_encoding` from server.
 ### datestyle
 
 Ask specific `datestyle` from server.
+
+### intervalstyle
+
+Ask specific `intervalstyle` from server.
 
 ### timezone
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -6,7 +6,7 @@
 ;;
 ;; connect string params:
 ;;   dbname= host= port= user= password= auth_user=
-;;   client_encoding= datestyle= timezone=
+;;   client_encoding= datestyle= intervalstyle= timezone=
 ;;   pool_size= reserve_pool= max_db_connections=
 ;;   pool_mode= connect_query= application_name=
 [databases]

--- a/include/objects.h
+++ b/include/objects.h
@@ -59,14 +59,14 @@ bool forward_cancel_request(PgSocket *server);
 void launch_new_connection(PgPool *pool, bool evict_if_needed);
 
 bool use_client_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
-		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,
-		       const char *password,
+		       const char *client_end, const char *std_string, const char *datestyle, const char *intervalstyle,
+		       const char *timezone, const char *password,
 		       const char *scram_client_key, int scram_client_key_len,
 		       const char *scram_server_key, int scram_server_key_len)
 			_MUSTCHECK;
 bool use_server_socket(int fd, PgAddr *addr, const char *dbname, const char *username, uint64_t ckey, int oldfd, int linkfd,
-		       const char *client_end, const char *std_string, const char *datestyle, const char *timezone,
-		       const char *password,
+		       const char *client_end, const char *std_string, const char *datestyle, const char *intervalstyle,
+		       const char *timezone, const char *password,
 		       const char *scram_client_key, int scram_client_key_len,
 		       const char *scram_server_key, int scram_server_key_len)
 			_MUSTCHECK;

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -2,6 +2,7 @@
 
 enum VarCacheIdx {
 	VDateStyle = 0,
+	VIntervalStyle,
 	VClientEncoding,
 	VTimeZone,
 	VStdStr,

--- a/src/admin.c
+++ b/src/admin.c
@@ -171,6 +171,7 @@ static const struct FakeParam fake_param_list[] = {
 	{ "default_transaction_isolation", "read committed" },
 	{ "standard_conforming_strings", "on" },
 	{ "datestyle", "ISO" },
+	{ "intervalstyle", "postgres" },
 	{ "timezone", "GMT" },
 	{ NULL },
 };
@@ -260,6 +261,7 @@ static bool send_one_fd(PgSocket *admin,
 			const char *client_enc,
 			const char *std_strings,
 			const char *datestyle,
+			const char *intervalstyle,
 			const char *timezone,
 			const char *password,
 			const uint8_t *scram_client_key,
@@ -275,10 +277,10 @@ static bool send_one_fd(PgSocket *admin,
 
 	struct PktBuf *pkt = pktbuf_temp();
 
-	pktbuf_write_DataRow(pkt, "issssiqisssssbb",
+	pktbuf_write_DataRow(pkt, "issssiqissssssbb",
 		      fd, task, user, db, addr, port, ckey, link,
-		      client_enc, std_strings, datestyle, timezone,
-		      password,
+		      client_enc, std_strings, datestyle, intervalstyle,
+		      timezone, password,
 		      scram_client_key_len, scram_client_key,
 		      scram_server_key_len, scram_server_key);
 	if (pkt->failed)
@@ -332,6 +334,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	const struct PStr *client_encoding = v->var_list[VClientEncoding];
 	const struct PStr *std_strings = v->var_list[VStdStr];
 	const struct PStr *datestyle = v->var_list[VDateStyle];
+	const struct PStr *intervalstyle = v->var_list[VIntervalStyle];
 	const struct PStr *timezone = v->var_list[VTimeZone];
 	char addrbuf[PGADDR_BUF];
 	const char *password = NULL;
@@ -366,6 +369,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 			   client_encoding ? client_encoding->str : NULL,
 			   std_strings ? std_strings->str : NULL,
 			   datestyle ? datestyle->str : NULL,
+			   intervalstyle ? intervalstyle->str : NULL,
 			   timezone ? timezone->str : NULL,
 			   password,
 			   send_scram_keys ? sk->pool->user->scram_ClientKey : NULL,
@@ -380,7 +384,7 @@ static bool show_pooler_cb(void *arg, int fd, const PgAddr *a)
 
 	return send_one_fd(arg, fd, "pooler", NULL, NULL,
 			   pga_ntop(a, buf, sizeof(buf)), pga_port(a), 0, 0,
-			   NULL, NULL, NULL, NULL, NULL, NULL, -1, NULL, -1);
+			   NULL, NULL, NULL, NULL, NULL, NULL, NULL, -1, NULL, -1);
 }
 
 /* send a row with sendmsg, optionally attaching a fd */
@@ -446,13 +450,14 @@ static bool admin_show_fds(PgSocket *admin, const char *arg)
 	/*
 	 * send resultset
 	 */
-	SEND_RowDescription(res, admin, "issssiqisssssbb",
+	SEND_RowDescription(res, admin, "issssiqissssssbb",
 				 "fd", "task",
 				 "user", "database",
 				 "addr", "port",
 				 "cancel", "link",
 				 "client_encoding", "std_strings",
-				 "datestyle", "timezone", "password",
+				 "datestyle", "intervalstyle",
+				 "timezone", "password",
 				 "scram_client_key", "scram_server_key");
 	if (res)
 		res = show_pooler_fds(admin);

--- a/src/loader.c
+++ b/src/loader.c
@@ -206,6 +206,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	char *auth_dbname = NULL;
 	char *client_encoding = NULL;
 	char *datestyle = NULL;
+	char *intervalstyle = NULL;
 	char *timezone = NULL;
 	char *connect_query = NULL;
 	char *appname = NULL;
@@ -264,6 +265,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			client_encoding = val;
 		} else if (strcmp("datestyle", key) == 0) {
 			datestyle = val;
+		} else if (strcmp("intervalstyle", key) == 0) {
+			intervalstyle = val;
 		} else if (strcmp("timezone", key) == 0) {
 			timezone = val;
 		} else if (strcmp("pool_size", key) == 0) {
@@ -365,6 +368,11 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	if (datestyle) {
 		pktbuf_put_string(msg, "datestyle");
 		pktbuf_put_string(msg, datestyle);
+	}
+
+	if (intervalstyle) {
+		pktbuf_put_string(msg, "intervalstyle");
+		pktbuf_put_string(msg, intervalstyle);
 	}
 
 	if (timezone) {

--- a/src/objects.c
+++ b/src/objects.c
@@ -1619,8 +1619,8 @@ bool use_client_socket(int fd, PgAddr *addr,
 		       const char *dbname, const char *username,
 		       uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_enc, const char *std_string,
-		       const char *datestyle, const char *timezone,
-		       const char *password,
+		       const char *datestyle, const char *intervalstyle,
+		       const char *timezone, const char *password,
 		       const char *scram_client_key, int scram_client_key_len,
 		       const char *scram_server_key, int scram_server_key_len)
 {
@@ -1688,6 +1688,7 @@ bool use_client_socket(int fd, PgAddr *addr,
 	varcache_set(&client->vars, "client_encoding", client_enc);
 	varcache_set(&client->vars, "standard_conforming_strings", std_string);
 	varcache_set(&client->vars, "datestyle", datestyle);
+	varcache_set(&client->vars, "intervalstyle", intervalstyle);
 	varcache_set(&client->vars, "timezone", timezone);
 
 	return true;
@@ -1697,8 +1698,8 @@ bool use_server_socket(int fd, PgAddr *addr,
 		       const char *dbname, const char *username,
 		       uint64_t ckey, int oldfd, int linkfd,
 		       const char *client_enc, const char *std_string,
-		       const char *datestyle, const char *timezone,
-		       const char *password,
+		       const char *datestyle, const char *intervalstyle,
+		       const char *timezone, const char *password,
 		       const char *scram_client_key, int scram_client_key_len,
 		       const char *scram_server_key, int scram_server_key_len)
 {
@@ -1769,6 +1770,7 @@ bool use_server_socket(int fd, PgAddr *addr,
 	varcache_set(&server->vars, "client_encoding", client_enc);
 	varcache_set(&server->vars, "standard_conforming_strings", std_string);
 	varcache_set(&server->vars, "datestyle", datestyle);
+	varcache_set(&server->vars, "intervalstyle", intervalstyle);
 	varcache_set(&server->vars, "timezone", timezone);
 
 	return true;

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -93,8 +93,8 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 {
 	int fd;
 	char *task, *saddr, *user, *db;
-	char *client_enc, *std_string, *datestyle, *timezone, *password,
-		*scram_client_key, *scram_server_key;
+	char *client_enc, *std_string, *datestyle, *intervalstyle, *timezone,
+		*password, *scram_client_key, *scram_server_key;
 	int scram_client_key_len, scram_server_key_len;
 	int oldfd, port, linkfd;
 	int got;
@@ -116,9 +116,10 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	}
 
 	/* parse row contents */
-	got = scan_text_result(pkt, "issssiqisssssbb", &oldfd, &task, &user, &db,
+	got = scan_text_result(pkt, "issssiqissssssbb", &oldfd, &task, &user, &db,
 			       &saddr, &port, &ckey, &linkfd,
-			       &client_enc, &std_string, &datestyle, &timezone,
+			       &client_enc, &std_string, &datestyle,
+			       &intervalstyle, &timezone,
 			       &password,
 			       &scram_client_key_len,
 			       &scram_client_key,
@@ -148,13 +149,13 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	/* decide what to do with it */
 	if (strcmp(task, "client") == 0) {
 		res = use_client_socket(fd, &addr, db, user, ckey, oldfd, linkfd,
-				  client_enc, std_string, datestyle, timezone,
-				  password,
+				  client_enc, std_string, datestyle,
+				  intervalstyle, timezone, password,
 				  scram_client_key, scram_client_key_len,
 				  scram_server_key, scram_server_key_len);
 	} else if (strcmp(task, "server") == 0) {
 		res = use_server_socket(fd, &addr, db, user, ckey, oldfd, linkfd,
-				  client_enc, std_string, datestyle, timezone,
+				  client_enc, std_string, datestyle, intervalstyle, timezone,
 				  password,
 				  scram_client_key, scram_client_key_len,
 				  scram_server_key, scram_server_key_len);

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -32,6 +32,7 @@ struct var_lookup {
 static const struct var_lookup lookup [] = {
  {"client_encoding",             VClientEncoding },
  {"DateStyle",                   VDateStyle },
+ {"IntervalStyle",               VIntervalStyle },
  {"TimeZone",                    VTimeZone },
  {"standard_conforming_strings", VStdStr },
  {"application_name",            VAppName },


### PR DESCRIPTION
It's common for client connection libraries to set `intervalstyle` when using interval types, the same as `datestyle`. The parameter can become desychronised in transaction pooling modes. So teach pgbouncer to pay attention to the parameter, the same as `datestyle`, to be sure it is consistent.

We were [bitten by this recently](https://github.com/pgbouncer/pgbouncer/issues/470#issuecomment-1480435000), and it looks like a few other folks have been as well. Using the interval type without this is prone to error. We're working around it using a connect query for the moment, but would love to see this tracked the same as `datestyle` for consistency, and to avoid future travellers experiencing the same bug.

Fixes #470