### PR TITLE
Fix obscure compiler warning

### DIFF
--- a/src/scram.c
+++ b/src/scram.c
@@ -971,6 +971,16 @@ char *build_server_final_message(ScramState *scram_state)
 		goto failed;
 
 	len = 2 + strlen(server_signature) + 1;
+
+	/*
+	 * Avoid compiler warning at snprintf() below because len
+	 * could in theory overflow snprintf() result.  If this
+	 * happened in practice, it would surely be some crazy
+	 * corruption, so treat it as an error.
+	 */
+	if (len >= INT_MAX)
+		goto failed;
+
 	result = malloc(len);
 	if (!result)
 		goto failed;


### PR DESCRIPTION
This comes from gcc-12 complaining that a size_t might overflow an int.  Catch it to make the code compile cleanly, but it's not a problem in practice.

closes #790