### PR TITLE
Add an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# top-most EditorConfig file
+root = true
+
+# basic rules for all files
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.c]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+tab_width = 4
+
+[*.{yml,sh}]
+indent_style = space
+indent_size = 2
+tab_width = 2
+


### PR DESCRIPTION
This allows many editors to be configured with correct indentation
styles for the different filetypes that we have. Github also parses this
file and uses it for its web-based editor as well as for displaying
files.
