### PR TITLE
Add a dedicated cancel_wait_timeout

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -775,7 +775,19 @@ This setting is used to prevent unresponsive servers from grabbing up
 connections.  It also helps when the server is down or rejects
 connections for any reason.
 
-Default: 120
+Default: 120.0
+
+### cancel_wait_timeout
+
+Maximum time cancellation requests are allowed to spend waiting for execution.
+If the cancel request is not assigned to a server during that time, the client is
+disconnected.
+0 disables.  If this is disabled, cancel requests will be queued indefinitely. [seconds]
+
+This setting is used to prevent a client locking up when a cancel cannot be
+forwarded due to the server being down.
+
+Default: 10.0
 
 ### client_idle_timeout
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -266,6 +266,12 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; failure. (default: 120)
 ;query_wait_timeout = 120
 
+;; Dangerous.  Client connection is closed if the cancellation request
+;; is not assigned to a server in this time.  Should be used to limit
+;; the time a client application blocks on a queued cancel request in
+;; case of a database or network failure. (default: 120)
+;cancel_wait_timeout = 10
+
 ;; Dangerous.  Client connection is closed if no activity in this
 ;; time.  Should be used to survive network problems. (default: 0)
 ;client_idle_timeout = 0

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -619,6 +619,7 @@ extern usec_t cf_server_connect_timeout;
 extern usec_t cf_server_login_retry;
 extern usec_t cf_query_timeout;
 extern usec_t cf_query_wait_timeout;
+extern usec_t cf_cancel_wait_timeout;
 extern usec_t cf_client_idle_timeout;
 extern usec_t cf_client_login_timeout;
 extern usec_t cf_idle_transaction_timeout;

--- a/src/main.c
+++ b/src/main.c
@@ -150,6 +150,7 @@ usec_t cf_server_connect_timeout;
 usec_t cf_server_login_retry;
 usec_t cf_query_timeout;
 usec_t cf_query_wait_timeout;
+usec_t cf_cancel_wait_timeout;
 usec_t cf_client_idle_timeout;
 usec_t cf_client_login_timeout;
 usec_t cf_idle_transaction_timeout;
@@ -275,6 +276,7 @@ CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
 CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
 CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
 CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),
+CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
 CF_ABS("reserve_pool_size", CF_INT, cf_res_pool_size, 0, "0"),
 CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),


### PR DESCRIPTION
Cancellations and regular queries are quite different. So it makes sense
to have different (default) timeouts for cancellation requests than for
queries. While I already think the default query_wait_timeout of 120
seconds we have is excessively long, it doesn't make sense at all to
have such a long timeout by default for cancellation requests that are
not sent. So this introduced a new `cancel_wait_timeout` which is set to
10 seconds by default. If the cancellation request cannot be forwarded
within that time it's probably better to drop it.

One reason why it's important to relatively quickly close cancellation
requests when they are not being handled is because libpq only allows
the client to send a cancel in a blocking way. So there's no possibility
to bail out after a certain amount of seconds on the client side, if
PgBouncer keeps the connection to the client open. Both me and Marco
noticed this when testing my PgBouncer peering PR (#666), when an entry
in the `[peers]` list pointed to an unreachable host. That meant that
pgbouncer would keep the cancel connection open, and even though the
query had finished the `psql` would not display the result because it
was stuck waiting for a result to the cancel request.

To avoid race conditions of cancellations that already forwarded, but
not yet answered cancellation requests are not timed out. See #717 for
details on such race conditions.
