### PR TITLE
Improve warning when connection to unix socket fails

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -150,6 +150,7 @@ bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_
 {
 	int res, sock;
 	struct timeval timeout;
+	char buf[128];
 	bool is_unix = sa->sa_family == AF_UNIX;
 
 	Assert(iobuf_empty(sbuf->io) && sbuf->sock == 0);
@@ -189,7 +190,8 @@ bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_
 	}
 
 failed:
-	log_warning("sbuf_connect failed: %s", strerror(errno));
+	log_warning("sbuf_connect failed to connect to %s: %s",
+			sa2str(sa, buf, sizeof(buf)), strerror(errno));
 
 	if (sock >= 0)
 		safe_close(sock);


### PR DESCRIPTION
PgBouncer is hard to debug when it's trying to connect to Postgres
server over a UNIX socket but that connection fails. You would get an
unhelpful error message like this:
```
WARNING sbuf_connect failed: No such file or directory
```

This change starts including the path in the error message:
```
WARNING sbuf_connect failed to connect to UNIX socket /aaaaa/.s.PGSQL.5432: No such file or directory
```

It also includes the address+port for IPv4/IPv6 connection attempts.

Fixes #835
