### PR TITLE
Fix FATAL in function server_proto(): server in bad state: 14

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -583,6 +583,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		case SV_TESTED:
 		case SV_USED:
 		case SV_ACTIVE:
+		case SV_ACTIVE_CANCEL:
 		case SV_IDLE:
 			res = handle_server_work(server, &pkt);
 			break;
@@ -618,6 +619,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 			server->resetting = false;
 			switch (server->state) {
 			case SV_ACTIVE:
+			case SV_ACTIVE_CANCEL:
 			case SV_TESTED:
 				/* keep link if client expects more Syncs */
 				if (server->link) {


### PR DESCRIPTION
In most cases the postgres server will not respond anything back to a
cancel message. It simply closes the connection. It won't even report an
error if the cancellation key is incorrect, or the PID is unknown.
However, it is possible that it sends another type of error message,
such as an OOM. Libpq actually ignores those errors and won't show them
to the user, but they might still be sent by the server. Because of the
changes in #717 this could cause a FATAL error. This fixes that by now
handling `SV_ACTIVE_CANCEL` the same as `SV_ACTIVE` in `server_proto`.

Fixes #847

Related to #717, #801, and #815
