### PR TITLE
Add files required to run python based tests to release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ dist_man_MANS = doc/pgbouncer.1 doc/pgbouncer.5
 
 # files in tgz
 EXTRA_DIST = AUTHORS COPYRIGHT Makefile config.mak.in config.sub config.guess \
+	     pyproject.toml requirements.txt \
 	     install-sh autogen.sh configure configure.ac \
 	     etc/mkauth.py etc/optscan.sh etc/example.debian.init.sh \
 	     win32/Makefile \


### PR DESCRIPTION
This is useful for distro package maintainers, as well as anyone else
that wants to run tests on the published sources.

Fixes #851
