### PR TITLE
Change default server_tls_sslmode to prefer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -297,7 +297,7 @@ CF_ABS("server_tls_cert_file", CF_STR, cf_server_tls_cert_file, 0, ""),
 CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, 0, "fast"),
 CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, 0, ""),
 CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, 0, "secure"),
-CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, 0, "disable"),
+CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, 0, "prefer"),
 #ifdef WIN32
 CF_ABS("service_name", CF_STR, cf_jobname, CF_NO_RELOAD, NULL), /* alias for job_name */
 #endif

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -136,6 +136,15 @@ def pg_reset(pg):
     """Resets any changes to Postgres settings from previous tests"""
     pg.reset_hba()
     os.truncate(pg.pgdata / "postgresql.auto.conf", 0)
-    pg.reload()
+
+    # If a previous test restarted postgres, it was probably because of some
+    # config that could only be changed across restarts. To reset those, we'll
+    # have to restart it again. In other cases a reload should be enough to
+    # reset the configuration.
+    if pg.restarted:
+        pg.restart()
+        pg.restarted = False
+    else:
+        pg.reload()
 
     yield

--- a/test/utils.py
+++ b/test/utils.py
@@ -455,6 +455,7 @@ class Postgres(QueryRunner):
         self.log_path = self.pgdata / "pg.log"
         self.connections = {}
         self.cursors = {}
+        self.restarted = False
 
     def initdb(self):
         run(
@@ -501,6 +502,7 @@ class Postgres(QueryRunner):
         self.port_lock.release()
 
     def restart(self):
+        self.restarted = True
         self.stop()
         self.start()
 


### PR DESCRIPTION
libpq has been defaulting to prefer for a long time already. Obviously
connecting over TLS is more secure, than without.

The current approach of defaulting to `disable` actually breaks
connecting if your server requires TLS, which many cloud providers are
doing (by default at least).

Fixes #843
