### PR TITLE
Support replication connections through PgBouncer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,7 +108,7 @@ task:
 #       - image: rockylinux:8
 #       - image: centos:centos7
 #   setup_script:
-#     - yum -y install autoconf automake diffutils file libevent-devel libtool make openssl-devel pkg-config postgresql-server systemd-devel wget
+#     - yum -y install autoconf automake diffutils file libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib systemd-devel wget
 #     - if cat /etc/centos-release | grep -q ' 7'; then yum -y install python python-pip; else yum -y install python3 python3-pip sudo iptables; fi
 #     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
 #     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
@@ -138,7 +138,7 @@ task:
 #       - image: alpine:latest
 #   setup_script:
 #     - apk update
-#     - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 py3-pip wget sudo iptables
+#     - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip wget sudo iptables
 #     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
 #     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
 #     - python3 -m pip install -r requirements.txt
@@ -166,7 +166,7 @@ task:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true
   setup_script:
-    - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool pkgconf postgresql12-server python devel/py-pip sudo
+    - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool pkgconf postgresql12-server postgresql12-contrib python devel/py-pip sudo
     - pip install -r requirements.txt
     - kldload pf
     - echo 'anchor "pgbouncer_test/*"' >> /etc/pf.conf

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ pgbouncer_SOURCES = \
 	src/util.c \
 	src/varcache.c \
 	src/common/base64.c \
+	src/common/bool.c \
+	src/common/pgstrcasecmp.c \
 	src/common/saslprep.c \
 	src/common/scram-common.c \
 	src/common/unicode_norm.c \
@@ -55,6 +57,7 @@ pgbouncer_SOURCES = \
 	include/util.h \
 	include/varcache.h \
 	include/common/base64.h \
+	include/common/builtins.h \
 	include/common/pg_wchar.h \
 	include/common/postgres_compat.h \
 	include/common/saslprep.h \

--- a/doc/config.md
+++ b/doc/config.md
@@ -1436,7 +1436,7 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 (see <https://www.postgresql.org/docs/current/auth-pg-hba-conf.html>).
 
 * Supported record types: `local`, `host`, `hostssl`, `hostnossl`.
-* Database field: Supports `all`, `sameuser`, `@file`, multiple names.  Not supported: `replication`, `samerole`, `samegroup`.
+* Database field: Supports `all`, `replication`, `sameuser`, `@file`, multiple names.  Not supported: `samerole`, `samegroup`.
 * User name field: Supports `all`, `@file`, multiple names.  Not supported: `+groupname`.
 * Address field: Supports IPv4, IPv6.  Not supported: DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -252,6 +252,9 @@ user
 database
 :   Database name.
 
+replication
+:   If server connection uses replication. Can be **none**, **logical** or **physical**.
+
 state
 :   State of the pgbouncer server connection, one of **active**,
     **idle**, **used**, **tested**, **new**, **active_cancel**,
@@ -321,6 +324,9 @@ user
 
 database
 :   Database name.
+
+replication
+:   If client connection uses replication. Can be **none**, **logical** or **physical**.
 
 state
 :   State of the client connection, one of **active**, **waiting**,

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -140,6 +140,7 @@ typedef struct PktBuf PktBuf;
 typedef struct ScramState ScramState;
 typedef struct PgPreparedStatement PgPreparedStatement;
 typedef enum ResponseAction ResponseAction;
+typedef enum ReplicationType ReplicationType;
 
 extern int cf_sbuf_len;
 
@@ -610,6 +611,14 @@ typedef struct OutstandingRequest {
 	uint64_t server_ps_query_id;
 } OutstandingRequest;
 
+enum ReplicationType {
+	REPLICATION_NONE = 0,
+	REPLICATION_LOGICAL,
+	REPLICATION_PHYSICAL,
+};
+
+extern const char *replication_type_parameters[3];
+
 /*
  * A client or server connection.
  *
@@ -653,6 +662,9 @@ struct PgSocket {
 	/* server: received an ErrorResponse, waiting for ReadyForQuery to clear
 	 * the outstanding requests until the next Sync */
 	bool query_failed : 1;
+
+	ReplicationType replication;	/* If this is a replication connection */
+	char *startup_options;	/* only tracked for replication connections */
 
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */

--- a/include/common/builtins.h
+++ b/include/common/builtins.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * builtins.h
+ *	  Declarations for operations on built-in types.
+ *
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * include/common/builtins.h
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/* bool.c */
+extern bool parse_bool(const char *value, bool *result);
+extern bool parse_bool_with_len(const char *value, size_t len, bool *result);
+extern int pg_strncasecmp(const char *s1, const char *s2, size_t n);

--- a/include/common/postgres_compat.h
+++ b/include/common/postgres_compat.h
@@ -7,6 +7,7 @@
 /* from c.h */
 
 #include <string.h>
+#include <usual/ctype.h>
 
 #define int8 int8_t
 #define uint8 uint8_t

--- a/include/hba.h
+++ b/include/hba.h
@@ -16,8 +16,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define NAME_ALL        1
-#define NAME_SAMEUSER   2
+#define NAME_ALL                1
+#define NAME_SAMEUSER           2
+#define NAME_REPLICATION        4
 
 enum RuleType {
 	RULE_LOCAL,
@@ -73,4 +74,4 @@ struct Ident *ident_load_map(const char *fn);
 void ident_free(struct Ident *ident);
 struct HBA *hba_load_rules(const char *fn, struct Ident *ident);
 void hba_free(struct HBA *hba);
-struct HBARule *hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username);
+struct HBARule *hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, ReplicationType replication, const char *dbname, const char *username);

--- a/include/objects.h
+++ b/include/objects.h
@@ -46,6 +46,7 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials);
 PgPool *get_peer_pool(PgDatabase *);
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs);
 bool evict_connection(PgDatabase *db)           _MUSTCHECK;
+bool evict_pool_connection(PgPool *pool)        _MUSTCHECK;
 bool evict_user_connection(PgCredentials *user_credentials)        _MUSTCHECK;
 bool find_server(PgSocket *client)              _MUSTCHECK;
 bool life_over(PgSocket *server);

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -97,9 +97,6 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 #define pktbuf_write_CancelRequest(buf, key) \
 	pktbuf_write_generic(buf, PKT_CANCEL, "b", key, 8)
 
-#define pktbuf_write_StartupMessage(buf, user, parms, parms_len) \
-	pktbuf_write_generic(buf, PKT_STARTUP_V3, "bsss", parms, parms_len, "user", user, "")
-
 #define pktbuf_write_NegotiateProtocolVersion( \
 		buf, \
 		unsupported_protocol_extensions_count, \

--- a/include/prepare.h
+++ b/include/prepare.h
@@ -31,8 +31,9 @@ typedef struct PgServerPreparedStatement {
 	PgPreparedStatement *ps;
 } PgServerPreparedStatement;
 
-#define is_prepared_statements_enabled(pool) \
-	(pool_pool_mode(pool) != POOL_SESSION && cf_max_prepared_statements != 0)
+#define is_prepared_statements_enabled(client_or_server) \
+	(connection_pool_mode(client_or_server) != POOL_SESSION && cf_max_prepared_statements != 0)
+
 
 bool handle_parse_command(PgSocket *client, PktHdr *pkt);
 bool handle_bind_command(PgSocket *client, PktHdr *pkt);

--- a/include/server.h
+++ b/include/server.h
@@ -18,7 +18,8 @@
 
 bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
 void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);
-int pool_pool_mode(PgPool *pool) _MUSTCHECK;
+int connection_pool_mode(PgSocket *server) _MUSTCHECK;
+int probably_wrong_pool_pool_mode(PgPool *pool) _MUSTCHECK;
 int pool_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_min_pool_size(PgPool *pool) _MUSTCHECK;
 usec_t pool_server_lifetime(PgPool *pool) _MUSTCHECK;

--- a/include/util.h
+++ b/include/util.h
@@ -70,3 +70,5 @@ bool cf_set_authdb(struct CfValue *cv, const char *value);
 
 /* reserved database name checking */
 bool check_reserved_database(const char *value);
+
+bool strings_equal(const char *str_left, const char *str_right) _MUSTCHECK;

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -19,6 +19,7 @@ void init_var_lookup(const char *cf_track_extra_parameters);
 int get_num_var_cached(void);
 bool varcache_set(VarCache *cache, const char *key, const char *value) /* _MUSTCHECK */;
 bool varcache_apply(PgSocket *server, PgSocket *client, bool *changes_p) _MUSTCHECK;
+void varcache_apply_startup(PktBuf *pkt, PgSocket *client);
 void varcache_fill_unset(VarCache *src, PgSocket *dst);
 void varcache_clean(VarCache *cache);
 void varcache_add_params(PktBuf *pkt, VarCache *vars);

--- a/src/common/bool.c
+++ b/src/common/bool.c
@@ -1,0 +1,112 @@
+/*-------------------------------------------------------------------------
+ *
+ * bool.c
+ *	  Functions for the built-in type "bool".
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/adt/bool.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "common/postgres_compat.h"
+
+#include "common/builtins.h"
+
+/*
+ * Try to interpret value as boolean value.  Valid values are: true,
+ * false, yes, no, on, off, 1, 0; as well as unique prefixes thereof.
+ * If the string parses okay, return true, else false.
+ * If okay and result is not NULL, return the value in *result.
+ */
+bool
+parse_bool(const char *value, bool *result)
+{
+	return parse_bool_with_len(value, strlen(value), result);
+}
+
+bool
+parse_bool_with_len(const char *value, size_t len, bool *result)
+{
+	switch (*value)
+	{
+		case 't':
+		case 'T':
+			if (pg_strncasecmp(value, "true", len) == 0)
+			{
+				if (result)
+					*result = true;
+				return true;
+			}
+			break;
+		case 'f':
+		case 'F':
+			if (pg_strncasecmp(value, "false", len) == 0)
+			{
+				if (result)
+					*result = false;
+				return true;
+			}
+			break;
+		case 'y':
+		case 'Y':
+			if (pg_strncasecmp(value, "yes", len) == 0)
+			{
+				if (result)
+					*result = true;
+				return true;
+			}
+			break;
+		case 'n':
+		case 'N':
+			if (pg_strncasecmp(value, "no", len) == 0)
+			{
+				if (result)
+					*result = false;
+				return true;
+			}
+			break;
+		case 'o':
+		case 'O':
+			/* 'o' is not unique enough */
+			if (pg_strncasecmp(value, "on", (len > 2 ? len : 2)) == 0)
+			{
+				if (result)
+					*result = true;
+				return true;
+			}
+			else if (pg_strncasecmp(value, "off", (len > 2 ? len : 2)) == 0)
+			{
+				if (result)
+					*result = false;
+				return true;
+			}
+			break;
+		case '1':
+			if (len == 1)
+			{
+				if (result)
+					*result = true;
+				return true;
+			}
+			break;
+		case '0':
+			if (len == 1)
+			{
+				if (result)
+					*result = false;
+				return true;
+			}
+			break;
+		default:
+			break;
+	}
+
+	if (result)
+		*result = false;		/* suppress compiler warning */
+	return false;
+}

--- a/src/common/pgstrcasecmp.c
+++ b/src/common/pgstrcasecmp.c
@@ -1,0 +1,64 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgstrcasecmp.c
+ *	   Portable SQL-like case-independent comparisons and conversions.
+ *
+ * SQL99 specifies Unicode-aware case normalization, which we don't yet
+ * have the infrastructure for.  Instead we use tolower() to provide a
+ * locale-aware translation.  However, there are some locales where this
+ * is not right either (eg, Turkish may do strange things with 'i' and
+ * 'I').  Our current compromise is to use tolower() for characters with
+ * the high bit set, and use an ASCII-only downcasing for 7-bit
+ * characters.
+ *
+ * NB: this code should match downcase_truncate_identifier() in scansup.c.
+ *
+ * We also provide strict ASCII-only case conversion functions, which can
+ * be used to implement C/POSIX case folding semantics no matter what the
+ * C library thinks the locale is.
+ *
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ *
+ * src/port/pgstrcasecmp.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "common/postgres_compat.h"
+
+#include "common/builtins.h"
+
+
+/*
+ * Case-independent comparison of two not-necessarily-null-terminated strings.
+ * At most n bytes will be examined from each string.
+ */
+int
+pg_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+	while (n-- > 0)
+	{
+		unsigned char ch1 = (unsigned char) *s1++;
+		unsigned char ch2 = (unsigned char) *s2++;
+
+		if (ch1 != ch2)
+		{
+			if (ch1 >= 'A' && ch1 <= 'Z')
+				ch1 += 'a' - 'A';
+			else if (IS_HIGHBIT_SET(ch1) && isupper(ch1))
+				ch1 = tolower(ch1);
+
+			if (ch2 >= 'A' && ch2 <= 'Z')
+				ch2 += 'a' - 'A';
+			else if (IS_HIGHBIT_SET(ch2) && isupper(ch2))
+				ch2 = tolower(ch2);
+
+			if (ch1 != ch2)
+				return (int) ch1 - (int) ch2;
+		}
+		if (ch1 == 0)
+			break;
+	}
+	return 0;
+}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -187,7 +187,14 @@ static void per_loop_activate(PgPool *pool)
 	sv_used = statlist_count(&pool->used_server_list);
 	statlist_for_each_safe(item, &pool->waiting_client_list, tmp) {
 		client = container_of(item, PgSocket, head);
-		if (!statlist_empty(&pool->idle_server_list)) {
+		if (client->replication) {
+			/*
+			 * For replication connections we always launch
+			 * a new connection, but we continue with the loop,
+			 * because there might be normal clients waiting too.
+			 */
+			launch_new_connection(pool, /* evict_if_needed= */ true);
+		} else if (!statlist_empty(&pool->idle_server_list)) {
 			/* db not fully initialized after reboot */
 			if (client->wait_for_welcome && !pool->welcome_msg_ready) {
 				launch_new_connection(pool, /* evict_if_needed= */ true);
@@ -535,14 +542,24 @@ static void pool_server_maint(PgPool *pool)
 	check_unused_servers(pool, &pool->tested_server_list, 0);
 	check_unused_servers(pool, &pool->idle_server_list, 1);
 
-	/* disconnect close_needed active servers if server_fast_close is set */
-	if (cf_server_fast_close) {
-		statlist_for_each_safe(item, &pool->active_server_list, tmp) {
-			server = container_of(item, PgSocket, head);
-			Assert(server->state == SV_ACTIVE);
-			if (server->ready && server->close_needed)
-				disconnect_server(server, true, "database configuration changed");
-		}
+	statlist_for_each_safe(item, &pool->active_server_list, tmp) {
+		server = container_of(item, PgSocket, head);
+		Assert(server->state == SV_ACTIVE);
+		/*
+		 * Disconnect active servers without outstanding requests if
+		 * server_fast_close is set. This only applies to session
+		 * pooling.
+		 */
+		if (cf_server_fast_close && server->ready && server->close_needed)
+			disconnect_server(server, true, "database configuration changed");
+		/*
+		 * Always disconnect close_needed replication servers. These
+		 * connections are expected to be very long lived (possibly
+		 * indefinitely), so waiting until the session/transaction is
+		 * over is not an option.
+		 */
+		if (server->replication && server->close_needed)
+			disconnect_server(server, true, "database configuration changed");
 	}
 
 	/* handle query_timeout and idle_transaction_timeout */

--- a/src/loader.c
+++ b/src/loader.c
@@ -122,20 +122,6 @@ static char * cstr_get_pair(char *p,
 }
 
 /*
- * Same as strcmp, but handles NULLs. If both sides are NULL, returns "true".
- */
-static bool strings_equal(const char *str_left, const char *str_right)
-{
-	if (str_left == NULL && str_right == NULL)
-		return true;
-
-	if (str_left == NULL || str_right == NULL)
-		return false;
-
-	return strcmp(str_left, str_right) == 0;
-}
-
-/*
  * Free the old value and set the new value
  */
 static bool set_param_value(char **old_value, const char *new_value)

--- a/src/util.c
+++ b/src/util.c
@@ -532,3 +532,18 @@ bool check_reserved_database(const char *value)
 	}
 	return true;
 }
+
+/*
+ * Same as strcmp, but handles NULLs. If both sides are NULL, returns "true".
+ */
+bool strings_equal(const char *str_left, const char *str_right)
+{
+	if (str_left == NULL && str_right == NULL)
+		return true;
+
+	if (str_left == NULL || str_right == NULL)
+		return false;
+
+	return strcmp(str_left, str_right) == 0;
+}
+

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -250,6 +250,21 @@ void varcache_set_canonical(PgSocket *server, PgSocket *client)
 	}
 }
 
+void varcache_apply_startup(PktBuf *pkt, PgSocket *client)
+{
+	const struct var_lookup *lk, *tmp;
+
+	HASH_ITER(hh, lookup_map, lk, tmp) {
+		struct PStr *val = get_value(&client->vars, lk);
+		if (!val)
+			continue;
+
+		slog_debug(client, "varcache_apply_startup: %s=%s", lk->name, val->str);
+		pktbuf_put_string(pkt, lk->name);
+		pktbuf_put_string(pkt, val->str);
+	}
+}
+
 void varcache_fill_unset(VarCache *src, PgSocket *dst)
 {
 	struct PStr *srcval, *dstval;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,6 +116,7 @@ def pg(tmp_path_factory, cert_dir):
             f.write(f"ssl_cert_file='{cert}'\n")
             f.write(f"ssl_key_file='{key}'\n")
 
+    pg.nossl_access("replication", "trust", user="postgres")
     pg.nossl_access("all", "trust")
     pg.nossl_access("p4", "password")
     pg.nossl_access("p5", "md5")

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -65,10 +65,12 @@ static char *get_token(char **ln_p)
 
 static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 {
-	const char *addr=NULL, *user=NULL, *db=NULL, *tls=NULL, *exp=NULL;
+	const char *addr=NULL, *user=NULL, *db=NULL, *modifier=NULL, *exp=NULL;
 	PgAddr pgaddr;
 	struct HBARule *rule;
 	int res = 0;
+	bool tls;
+	ReplicationType replication;
 
 	if (ln[0] == '#')
 		return 0;
@@ -76,7 +78,9 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	db = get_token(&ln);
 	user = get_token(&ln);
 	addr = get_token(&ln);
-	tls = get_token(&ln);
+	modifier = get_token(&ln);
+	tls = strings_equal(modifier, "tls");
+	replication = strings_equal(modifier, "replication") ?  REPLICATION_PHYSICAL : REPLICATION_NONE;
 	if (!exp)
 		return 0;
 	if (!db || !user)
@@ -85,7 +89,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	if (!pga_pton(&pgaddr, addr, 9999))
 		die("hbatest: invalid addr on line #%d", linenr);
 
-	rule = hba_eval(hba, &pgaddr, !!tls, db, user);
+	rule = hba_eval(hba, &pgaddr, !!tls, replication, db, user);
 
 	if (!rule) {
 	       if (strcmp("reject", exp) == 0) {

--- a/test/hba_test.eval
+++ b/test/hba_test.eval
@@ -79,3 +79,16 @@ md5		mdb	muser		ff11:2::1
 md5		mdb	muser		ff22:3::1
 trust		mdb	muser		::1
 reject		mdb	muser		::2
+
+# replication
+reject		mdb		muser		::1	replication
+reject		db		userp		unix	replication
+reject		replication	userp		unix	replication
+trust		db		admin		::1	replication
+trust		replication	admin		::1	replication
+reject		db		admin		::1
+reject		replication	admin		::1
+trust		db		admin2		::1	replication
+trust		replication	admin2		::1	replication
+trust		db2		admin2		::1
+reject		replication	admin2		::1

--- a/test/hba_test.rules
+++ b/test/hba_test.rules
@@ -5,6 +5,7 @@
 # hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
 # hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
 
+# The following lines test that weird whitespace does not break parsing
 # ws
  	 	 	
 			# z
@@ -52,3 +53,7 @@ host		mdb2	muser		128.0.0.0/1		cert
 host		mdb	muser		ff11::0/16		md5
 host		mdb	muser		ff20::/12		md5
 host		mdb	muser		::1/128			trust
+
+# replication
+host		replication	admin	::1/128			trust
+host		db2,replication	admin2	::1/128			trust

--- a/test/ssl/test.ini
+++ b/test/ssl/test.ini
@@ -1,6 +1,7 @@
 [databases]
 p0 = port=6666 host=localhost dbname=p0 user=bouncer pool_size=2
 p1 = port=6666 host=localhost dbname=p1 user=bouncer
+p7a= port=6666 host=localhost dbname=p7
 
 [pgbouncer]
 logfile = test.log

--- a/test/test.ini
+++ b/test/test.ini
@@ -29,6 +29,11 @@ p7c= port=6666 host=127.0.0.1 dbname=p7
 p8 = port=6666 host=127.0.0.1 dbname=p0 connect_query='set enable_seqscan=off; set enable_nestloop=off'
 p9 = port=6666 host=127.0.0.1 dbname=postgres server_lifetime=2 user=bouncer
 
+user_passthrough = port=6666 host=127.0.0.1 dbname=p0
+user_passthrough2 = port=6666 host=127.0.0.1 dbname=p2
+user_passthrough_pool_size2 = port=6666 host=127.0.0.1 dbname=p0 pool_size=2
+user_passthrough_pool_size5 = port=6666 host=127.0.0.1 dbname=p0 pool_size=2
+
 pauthz = port=6666 host=127.0.0.1 dbname=p7 auth_user=pswcheck auth_dbname=authdb
 authdb = port=6666 host=127.0.0.1 dbname=p1 auth_user=pswcheck
 
@@ -37,6 +42,11 @@ hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 
 varcache_change = port=6666 host=127.0.0.1 dbname=p0 client_encoding=SQL_ASCII
 non_existing_pg_db = port=6666 host=127.0.0.1 dbname=non_existing_pg_db
+
+; Needed for pg_receivewal and pg_basebackup tests until this patch is merged
+; in PostgreSQL (and we don't support PG16 anymore):
+; https://www.postgresql.org/message-id/flat/CAGECzQTw-dZkVT_RELRzfWRzY714-VaTjoBATYfZq93R8C-auA@mail.gmail.com
+replication = port=6666 host=127.0.0.1 dbname=replication
 
 ; commented out except for auto-database tests
 ;* = port=6666 host=127.0.0.1

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -98,7 +98,7 @@ def test_min_pool_size_with_lower_max_user_connections(bouncer):
 
     # Running a query for sufficient time for us to reach the final
     # connection count in the pool and detect any evictions.
-    with bouncer.log_contains("new connection to server", times=2):
+    with bouncer.log_contains(r"new connection to server \(from", times=2):
         with bouncer.log_contains("closing because: evicted", times=0):
             bouncer.sleep(2, dbname="p0x", user="maxedout2")
 
@@ -111,7 +111,7 @@ def test_min_pool_size_with_lower_max_db_connections(bouncer):
 
     # Running a query for sufficient time for us to reach the final
     # connection count in the pool and detect any evictions.
-    with bouncer.log_contains("new connection to server", times=2):
+    with bouncer.log_contains(r"new connection to server \(from", times=2):
         with bouncer.log_contains("closing because: evicted", times=0):
             bouncer.sleep(2, dbname="p0y", user="puser1")
 

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -1,0 +1,281 @@
+import asyncio
+import signal
+import subprocess
+import time
+
+import psycopg
+import psycopg.errors
+import pytest
+from psycopg import sql
+
+from .utils import PG_MAJOR_VERSION, WINDOWS, run
+
+
+def test_logical_rep(bouncer):
+    connect_args = {
+        "dbname": "user_passthrough",
+        "replication": "database",
+        "user": "postgres",
+        "application_name": "abc",
+        "options": "-c enable_seqscan=off",
+    }
+    # Starting in PG10 you can do other commands over logical rep connections
+    if PG_MAJOR_VERSION >= 10:
+        bouncer.test(**connect_args)
+        assert bouncer.sql_value("SHOW application_name", **connect_args) == "abc"
+        assert bouncer.sql_value("SHOW enable_seqscan", **connect_args) == "off"
+    bouncer.sql("IDENTIFY_SYSTEM", **connect_args)
+    # Do a normal connection to the same pool, to ensure that that doesn't
+    # break anything
+    bouncer.test(dbname="user_passthrough", user="postgres")
+    bouncer.sql("IDENTIFY_SYSTEM", **connect_args)
+
+
+def test_logical_rep_unprivileged(bouncer):
+    if PG_MAJOR_VERSION < 10:
+        expected_log = "no pg_hba.conf entry for replication connection"
+    elif PG_MAJOR_VERSION < 16:
+        expected_log = "must be superuser or replication role to start walsender"
+    else:
+        expected_log = "permission denied to start WAL sender"
+
+    with bouncer.log_contains(
+        expected_log,
+    ), bouncer.log_contains(
+        r"closing because: login failed \(age", times=2
+    ), pytest.raises(psycopg.OperationalError, match=r"login failed"):
+        bouncer.sql("IDENTIFY_SYSTEM", replication="database")
+
+
+@pytest.mark.skipif(
+    "PG_MAJOR_VERSION < 10", reason="logical replication was introduced in PG10"
+)
+def test_logical_rep_subscriber(bouncer):
+    bouncer.admin("set pool_mode=transaction")
+
+    # First write create a table and insert a row in the source database.
+    # Also create the replication slot and publication
+    bouncer.default_db = "user_passthrough"
+    bouncer.create_schema("test_logical_rep_subscriber")
+    bouncer.sql("CREATE TABLE test_logical_rep_subscriber.table(a int)")
+    bouncer.sql("INSERT INTO test_logical_rep_subscriber.table values (1)")
+    assert (
+        bouncer.sql_value("SELECT count(*) FROM test_logical_rep_subscriber.table") == 1
+    )
+
+    bouncer.create_publication(
+        "mypub", sql.SQL("FOR TABLE test_logical_rep_subscriber.table")
+    )
+
+    bouncer.create_logical_replication_slot("test_logical_rep_subscriber", "pgoutput")
+
+    # Create an equivalent, but empty schema in the target database.
+    # And setup the subscription
+    bouncer.default_db = "user_passthrough2"
+    bouncer.create_schema("test_logical_rep_subscriber")
+    bouncer.sql("CREATE TABLE test_logical_rep_subscriber.table(a int)")
+    conninfo = bouncer.make_conninfo(dbname="user_passthrough")
+    bouncer.create_subscription(
+        "mysub",
+        sql.SQL(
+            """
+            CONNECTION {}
+            PUBLICATION mypub
+            WITH (slot_name=test_logical_rep_subscriber, create_slot=false)
+        """
+        ).format(sql.Literal(conninfo)),
+    )
+
+    # The initial copy should now copy over the row
+    time.sleep(2)
+    assert (
+        bouncer.sql_value("SELECT count(*) FROM test_logical_rep_subscriber.table") >= 1
+    )
+
+    # Insert another row and logical replication should replicate it correctly
+    bouncer.sql(
+        "INSERT INTO test_logical_rep_subscriber.table values (2)",
+        dbname="user_passthrough",
+    )
+    time.sleep(2)
+    assert (
+        bouncer.sql_value("SELECT count(*) FROM test_logical_rep_subscriber.table") >= 2
+    )
+
+
+@pytest.mark.skipif(
+    "WINDOWS", reason="MINGW does not have contrib package containing test_decoding"
+)
+def test_logical_rep_pg_recvlogical(bouncer):
+    bouncer.default_db = "user_passthrough"
+    bouncer.create_schema("test_logical_rep_pg_recvlogical")
+    bouncer.sql("CREATE TABLE test_logical_rep_pg_recvlogical.table(a int)")
+    bouncer.create_logical_replication_slot(
+        "test_logical_rep_pg_recvlogical", "test_decoding"
+    )
+    process = subprocess.Popen(
+        [
+            "pg_recvlogical",
+            "--dbname",
+            bouncer.default_db,
+            "--host",
+            bouncer.host,
+            "--port",
+            str(bouncer.port),
+            "--user",
+            bouncer.default_user,
+            "--slot=test_logical_rep_pg_recvlogical",
+            "--file=-",
+            "--no-loop",
+            "--start",
+        ],
+        stdout=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    bouncer.sql("INSERT INTO test_logical_rep_pg_recvlogical.table values (1)")
+    try:
+        assert process.stdout.readline().startswith(b"BEGIN ")
+        assert (
+            process.stdout.readline()
+            == b'table test_logical_rep_pg_recvlogical."table": INSERT: a[integer]:1\n'
+        )
+        assert process.stdout.readline().startswith(b"COMMIT ")
+    finally:
+        process.kill()
+        process.communicate(timeout=5)
+
+
+def test_physical_rep(bouncer):
+    connect_args = {
+        "dbname": "user_passthrough",
+        "replication": "yes",
+        "user": "postgres",
+        "application_name": "abc",
+        "options": "-c enable_seqscan=off",
+    }
+    # Starting in PG10 you can do SHOW commands
+    if PG_MAJOR_VERSION >= 10:
+        with pytest.raises(
+            psycopg.errors.FeatureNotSupported,
+            match="cannot execute SQL commands in WAL sender for physical replication",
+        ):
+            bouncer.test(**connect_args)
+        assert bouncer.sql_value("SHOW application_name", **connect_args) == "abc"
+        assert bouncer.sql_value("SHOW enable_seqscan", **connect_args) == "off"
+    bouncer.sql("IDENTIFY_SYSTEM", **connect_args)
+    # Do a normal connection to the same pool, to ensure that that doesn't
+    # break anything
+    bouncer.test(dbname="user_passthrough", user="postgres")
+    bouncer.sql("IDENTIFY_SYSTEM", **connect_args)
+
+
+def test_physcal_rep_unprivileged(bouncer):
+    with bouncer.log_contains(
+        r"no pg_hba.conf entry for replication connection from host"
+    ), bouncer.log_contains(
+        r"closing because: login failed \(age", times=2
+    ), pytest.raises(
+        psycopg.OperationalError, match=r"login failed"
+    ):
+        bouncer.test(replication="yes")
+
+
+@pytest.mark.skipif("PG_MAJOR_VERSION < 10", reason="pg_receivewal was added in PG10")
+def test_physical_rep_pg_receivewal(bouncer, tmp_path):
+    bouncer.default_db = "user_passthrough"
+    bouncer.create_physical_replication_slot("test_physical_rep_pg_receivewal")
+    wal_dump_dir = tmp_path / "wal-dump"
+    wal_dump_dir.mkdir()
+
+    process = subprocess.Popen(
+        [
+            "pg_receivewal",
+            "--dbname",
+            bouncer.make_conninfo(),
+            "--slot=test_physical_rep_pg_receivewal",
+            "--directory",
+            str(wal_dump_dir),
+        ],
+    )
+    time.sleep(3)
+
+    if WINDOWS:
+        process.terminate()
+    else:
+        process.send_signal(signal.SIGINT)
+    process.communicate(timeout=5)
+
+    if WINDOWS:
+        assert process.returncode == 1
+    else:
+        assert process.returncode == 0
+
+    children = list(wal_dump_dir.iterdir())
+    assert len(children) > 0
+
+
+def test_physical_rep_pg_basebackup(bouncer, tmp_path):
+    bouncer.default_db = "user_passthrough"
+    dump_dir = tmp_path / "db-dump"
+    dump_dir.mkdir()
+
+    run(
+        [
+            "pg_basebackup",
+            "--dbname",
+            bouncer.make_conninfo(),
+            "--checkpoint=fast",
+            "--pgdata",
+            str(dump_dir),
+        ],
+        shell=False,
+    )
+    children = list(dump_dir.iterdir())
+    assert len(children) > 0
+    print(children)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    "PG_MAJOR_VERSION < 10",
+    reason="normal SQL commands are only supported in PG10+ on logical replication connections",
+)
+async def test_replication_pool_size(pg, bouncer):
+    connect_args = {
+        "dbname": "user_passthrough_pool_size2",
+        "replication": "database",
+        "user": "postgres",
+        "connect_timeout": 10,
+    }
+    start = time.time()
+    await bouncer.asleep(0.5, times=10, **connect_args)
+    assert time.time() - start > 2.5
+    # Replication connections always get closed right away
+    assert pg.connection_count("p0") == 0
+
+    connect_args["dbname"] = "user_passthrough_pool_size5"
+    start = time.time()
+    await bouncer.asleep(0.5, times=10, **connect_args)
+    assert time.time() - start > 1
+    # Replication connections always get closed right away
+    assert pg.connection_count("p0") == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    "PG_MAJOR_VERSION < 10",
+    reason="normal SQL commands are only supported in PG10+ on logical replication connections",
+)
+async def test_replication_pool_size_mixed_clients(bouncer):
+    connect_args = {
+        "dbname": "user_passthrough_pool_size2",
+        "user": "postgres",
+    }
+
+    # Fill the pool with normal connections
+    await bouncer.asleep(0.5, times=2, **connect_args)
+
+    # Then try to open a replication connection and ensure that it causes
+    # eviction of one of the normal connections
+    with bouncer.log_contains("closing because: evicted"):
+        bouncer.test(**connect_args, replication="database")


### PR DESCRIPTION
In session pooling mode PgBouncer is pretty much a transparent proxy,
i.e. the client does normally not even need to know that PgBouncer is in
the middle. This allows things like load balancing and failovers without
the client needing to know about this at all. But as soon as replication
connections are needed, this was not possible anymore, because PgBouncer
would reject those instead of proxying them to the right server.

This PR fixes that by also proxying replication connections. They are
handled pretty differently from normal connections though. A client and
server replication connection will form a strong pair, as soon as one is
closed the other is closed too. So, there's no caching of the server
replication connections, like is done for regular connections. Reusing
replication connections comes with a ton of gotchas. Postgres will
throw errors in many cases when trying to do so. So simply not
doing it seems like a good tradeoff for ease of implementation.
Especially because replication connections are pretty much always
very long lived. So re-using them gains pretty much no performance
benefits.

Fixes #382

Depends on #945
