### PR TITLE
Add support for options startup parameter

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -715,6 +715,19 @@ last_socket(struct StatList *slist)
 	return container_of(slist->head.prev, PgSocket, head);
 }
 
+
+/*
+ * cstr_skip_ws returns a pointer to the first non whitespace character
+ * in the given string.
+ */
+static inline char *cstr_skip_ws(char *p)
+{
+	while (*p && *p == ' ')
+		p++;
+	return p;
+}
+
+
 void load_config(void);
 
 

--- a/src/client.c
+++ b/src/client.c
@@ -610,7 +610,7 @@ static bool set_startup_options(PgSocket *client, const char *options)
 	struct MBuf arg;
 	const char *position = options;
 	mbuf_init_fixed_writer(&arg, arg_buf, sizeof(arg_buf));
-	slog_error(client, "received options: %s", options);
+	slog_debug(client, "received options: %s", options);
 	while (*position) {
 		const char *key_string, *value_string;
 		char *equals;
@@ -639,7 +639,8 @@ static bool set_startup_options(PgSocket *client, const char *options)
 			slog_debug(client, "ignoring startup parameter from options: %s=%s", key_string, value_string);
 		} else {
 			slog_warning(client, "unsupported startup parameter in options: %s=%s", key_string, value_string);
-			disconnect_client(client, true, "unsupported startup parameter: %s", key_string);
+			disconnect_client(client, true, "unsupported startup parameter in options: %s", key_string);
+			return false;
 		}
 	}
 	return true;

--- a/src/loader.c
+++ b/src/loader.c
@@ -29,14 +29,6 @@
  * ConnString parsing
  */
 
-/* just skip whitespace */
-static char *cstr_skip_ws(char *p)
-{
-	while (*p && *p == ' ')
-		p++;
-	return p;
-}
-
 /* parse parameter name before '=' */
 static char *cstr_get_key(char *p, char **dst_p)
 {

--- a/test/test.ini
+++ b/test/test.ini
@@ -63,3 +63,4 @@ tcp_keepalive = 0
 
 ;bgbouncer will only track the parameters with GUC_REPORT flag set in Postgres
 track_extra_parameters = search_path, intervalstyle
+ignore_startup_parameters = extra_float_digits

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -171,6 +171,13 @@ def test_options_startup_param(bouncer):
         == "Portugal"
     )
 
+    # extra_float_digits is in ignore_startup_parameters so setting it has no
+    # effect, and the default of 1 will still be used.
+    assert (
+        bouncer.sql_value("SHOW extra_float_digits", options="-c extra_float_digits=2")
+        == "1"
+    )
+
     with pytest.raises(
         psycopg.OperationalError,
         match="unsupported options startup parameter: only '-c config=val' is allowed",
@@ -190,3 +197,9 @@ def test_options_startup_param(bouncer):
         match="unsupported options startup parameter: parameter too long",
     ):
         bouncer.test(options="-c timezone=" + too_long_param)
+
+    with pytest.raises(
+        psycopg.OperationalError,
+        match="unsupported startup parameter in options: enable_seqscan",
+    ):
+        bouncer.test(options="-c enable_seqscan=true")

--- a/test/utils.py
+++ b/test/utils.py
@@ -477,6 +477,10 @@ class Postgres(QueryRunner):
             # of our test data.
             pgconf.write("fsync = false\n")
 
+            # Use a consistent value across postgres versions, so test results
+            # are the same.
+            pgconf.write("extra_float_digits = 1\n")
+
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)
 


### PR DESCRIPTION
It's allowed to specify any Postgres command line parameter in the `options`
startup packet #867. This is commonly used to specify GUC values on connection
startup, using the `-c key=value` command line flag. I believe the main reason
this is used instead of specifying the desired GUC as a startup parameter
directly is because libpq does not allow specifying arbitrary startup
parameters.

This PR adds support for configuring GUCs using the `-c` flag in the options
startup packet. While in theory people can specify any flag they want. In
practice the `-c` flag is the only one that I know is commonly used. Probably
because it is the only one that's documented in the Postgres docs for
`PGOPTIONS`. Any of the other command line flags are simply shorthands for
specific GUCs, and so even when those would be used they can be easily rewritten
using `-c`. So to keep parsing of the options startup parameter simple, this
only supports the `-c` flag.

Fixes #875
