### PR TITLE
Update client varcache with canonical values from server

### DIFF
--- a/include/varcache.h
+++ b/include/varcache.h
@@ -23,3 +23,4 @@ void varcache_fill_unset(VarCache *src, PgSocket *dst);
 void varcache_clean(VarCache *cache);
 void varcache_add_params(PktBuf *pkt, VarCache *vars);
 void varcache_deinit(void);
+void varcache_set_canonical(PgSocket *server, PgSocket *client);

--- a/src/server.c
+++ b/src/server.c
@@ -613,6 +613,18 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 			PgSocket *client = server->link;
 			Assert(client);
 
+			/*
+			 * It's possible that the client vars and server vars have
+			 * different string representations, but still Postgres did not
+			 * send a ParamaterStatus packet. This happens when the server
+			 * variable is the canonical version of the client variable, i.e.
+			 * they mean the same just written slightly different. To make sure
+			 * that the canonical version is also stored in the client, we now
+			 * copy the server variables over to the client variables.
+			 * See issue #776 for an example of this.
+			 */
+			varcache_set_canonical(server, client);
+
 			server->setting_vars = false;
 			sbuf_continue(&client->sbuf);
 			break;

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -233,6 +233,24 @@ bool varcache_apply(PgSocket *server, PgSocket *client, bool *changes_p)
 	return pktbuf_send_immediate(pkt, server);
 }
 
+void varcache_set_canonical(PgSocket *server, PgSocket *client)
+{
+	struct PStr *server_val, *client_val;
+	const struct var_lookup *lk, *tmp;
+
+	HASH_ITER(hh, lookup_map, lk, tmp) {
+		server_val = server->vars.var_list[lk->idx];
+		client_val = client->vars.var_list[lk->idx];
+		if (client_val && server_val && client_val != server_val) {
+			slog_debug(client, "varcache_set_canonical: setting %s to its canonical version %s -> %s",
+				   lk->name, client_val->str, server_val->str);
+			strpool_incref(server_val);
+			strpool_decref(client_val);
+			client->vars.var_list[lk->idx] = server_val;
+		}
+	}
+}
+
 void varcache_fill_unset(VarCache *src, PgSocket *dst)
 {
 	struct PStr *srcval, *dstval;


### PR DESCRIPTION
Since PG14, Postgres doesn't send ParameterStatus packets anymore when a
setting has not actually changed. This could cause the client varcache
and server varcache to become out of sync. Which then in turn resulted
in unnecessary `SET` commands to be sent to the server.

Fixes #776
