### PR TITLE
Fix src/dst confusion in log

### DIFF
--- a/src/pooler.c
+++ b/src/pooler.c
@@ -312,7 +312,7 @@ static const char *addrpair(const PgAddr *src, const PgAddr *dst)
 		return "unix->unix";
 
 	ip1 = pga_ntop(src, ip1buf, sizeof(ip1buf));
-	ip2 = pga_ntop(src, ip2buf, sizeof(ip2buf));
+	ip2 = pga_ntop(dst, ip2buf, sizeof(ip2buf));
 	snprintf(buf, sizeof(buf), "%s:%d -> %s:%d",
 		 ip1, pga_port(src), ip2, pga_port(dst));
 	return buf;


### PR DESCRIPTION
I found an odd debug log where it looked like the `src` was trying to contact itself (at a different port); and traced it back with teammates to this location where it looks like the `src` IP is being used twice (though the port is being logged correctly).