### PR TITLE
Add cf_dns_close_previous option

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -628,6 +628,7 @@ extern int cf_disable_pqexec;
 extern usec_t cf_dns_max_ttl;
 extern usec_t cf_dns_nxdomain_ttl;
 extern usec_t cf_dns_zone_check_period;
+extern int cf_dns_close_previous;
 extern char *cf_resolv_conf;
 
 extern int cf_auth_type;

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -1401,7 +1401,7 @@ static void got_result_gai(int result, struct addrinfo *res, void *arg)
 		req->result = res;
 		req->current = res;
 
-		if (req->oldres)
+		if (req->oldres && cf_dns_close_previous)
 			check_req_result_changes(req);
 
 		/* show all results */

--- a/src/main.c
+++ b/src/main.c
@@ -136,6 +136,7 @@ int cf_disable_pqexec;
 usec_t cf_dns_max_ttl;
 usec_t cf_dns_nxdomain_ttl;
 usec_t cf_dns_zone_check_period;
+int cf_dns_close_previous;
 char *cf_resolv_conf;
 unsigned int cf_max_packet_size;
 
@@ -255,6 +256,7 @@ CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),
 CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
 CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
+CF_ABS("dns_close_previous", CF_INT, cf_dns_close_previous, 0, "1"),
 CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 CF_ABS("job_name", CF_STR, cf_jobname, CF_NO_RELOAD, "pgbouncer"),


### PR DESCRIPTION
_**This is just a proposal, needs full implementation**_

## What
Currently, when a host is resolved, pgbouncer checks all server connections for this host and tags connections using IPs not found in the new resolved list as dirty (`close_needed`). I'm proposing to add a configuration option that would disable this behavior. This would be helpful in avoiding connection churn in scenarios where, for example, the host might return a list of different IP addresses (think weighted routing in Route53) every time. 