### PR TITLE
Update `pgbouncer access from unix socket` to respect `log_connections` config option

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1635,7 +1635,8 @@ bool admin_pre_login(PgSocket *client, const char *username)
 			client->login_user = admin_pool->db->forced_user;
 			client->own_user = true;
 			client->admin_user = true;
-			slog_info(client, "pgbouncer access from unix socket");
+			if (cf_log_connections)
+				slog_info(client, "pgbouncer access from unix socket");
 			return true;
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/pgbouncer/pgbouncer/issues/883