### PR TITLE
Limit concurrency in CI for Windows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -246,7 +246,7 @@ task:
     - sh -l -c "./configure --prefix=$HOME/install --enable-werror PANDOC=/c/programdata/chocolatey/bin/pandoc LDFLAGS=-static LIBS=-liphlpapi PKG_CONFIG='pkg-config --static'"
     - sh -l -c "make -j4"
   test_script:
-    - sh -l -c "make -j4 check CONCURRENCY=4"
+    - sh -l -c "make -j4 check CONCURRENCY=3"
     - sh -l -c "windres pgbouncer.exe"
   install_script:
     - sh -l -c "make -j4 install"


### PR DESCRIPTION
Windows CI has been running out of memory frequently recently. This
changes the test concurrency from 4 to 3 to hopefully reduce memory
pressure a bit.
