### PR TITLE
Correct editorconfig rules for C files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,15 +10,12 @@ trim_trailing_whitespace = true
 
 [*.{c,h}]
 indent_style = tab
-# We specifically don't set indent_size and tab_with here so people can choose
-# what they prefer themselves
+indent_size = 8
 
 [*.py]
 indent_style = space
 indent_size = 4
-tab_width = 4
 
 [*.{yml,sh}]
 indent_style = space
 indent_size = 2
-tab_width = 2


### PR DESCRIPTION
Let's discuss the indentation rules for C files again. I disagree with the existing text in .editorconfig that basically everybody can do what they want, which seems kind of insane. ;-) The actual rules for pgbouncer source code has always been tab width 8 and indent by tab, so I suggest we put those in here. Note also that the whitespace rules in .gitattributes are set for this.
