### PR TITLE
Deprecate online restart

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -116,7 +116,9 @@ Basic setup and usage is as follows.
     Note: Does not work on Windows; **pgbouncer** need to run as service there.
 
 `-R`, `--reboot`
-:   Do an online restart. That means connecting to the running process,
+:   **DEPRECATED: Instead of this option use a rolling restart with multiple
+    pgbouncer processes listening on the same port using so_reuseport instead**
+    Do an online restart. That means connecting to the running process,
     loading the open sockets from it, and then using them.  If there
     is no active process, boot normally.
     Note: Works only if OS supports Unix sockets and the `unix_socket_dir`

--- a/src/main.c
+++ b/src/main.c
@@ -1001,6 +1001,7 @@ int main(int argc, char *argv[])
 	admin_setup();
 
 	if (cf_reboot) {
+		log_warning("Online restart is deprecated, use so_reuseport instead");
 		if (check_old_process_unix()) {
 			takeover_part1();
 			did_takeover = true;


### PR DESCRIPTION
We decided to deprecate online restarts. They have many known problems:
1. It does not work with TLS connections. Most production PgBouncer
   setups use TLS connections in some way.
2. `application_name` is not copied over (it's not part of SHOW FDS like
   the other tracked GUCs)
3. Any data that's in the `SBuf` its `iobuf` is lost during takeover
   (this seems quite bad)
4. It shows this warning during tests right after takover:
   ```
   `WARNING C-0x5620eb57bd90: p1/postgres@127.0.0.1:57066 FIXME: transaction end, but xact_start == 0
   ```
5. If the config file is different, but has not been loaded yet. Then
   many things will almost certainly break.
6. The parameters in `track_extra_parameters` are not copied over to the
   new process.
7. It does not work well with SystemD.

The new recommended way to do online restarts is by doing a rolling
restart of PgBouncer processes that listen on the same port using
`so_reuseport`.

This adds a warning to to the docs about this. And starts reporting a warning when the online restart feature is used.
