### PR TITLE
CI: Update FreeBSD image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -162,7 +162,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-13-1
+    image_family: freebsd-13-2
   env:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true


### PR DESCRIPTION
FreeBSD 13.1 will EOL in ~2 weeks. This updates CI to use 13.2 instead.
