### PR TITLE
Tests: Add a capture helper

### DIFF
--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,6 +1,4 @@
-import subprocess
-
-from .utils import run
+from .utils import capture, run
 
 
 def test_show(bouncer):
@@ -37,13 +35,11 @@ def test_show(bouncer):
 
 def test_show_version(bouncer):
     admin_version = bouncer.admin_value(f"SHOW VERSION")
-    subprocess_result = run(
+    subprocess_result = capture(
         [*bouncer.base_command(), "--version"],
-        stdout=subprocess.PIPE,
         shell=False,
-        encoding="utf8",
     )
-    subprocess_version = subprocess_result.stdout.split("\n")[0]
+    subprocess_version = subprocess_result.split("\n")[0]
     assert admin_version == subprocess_version
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -107,10 +107,12 @@ def sudo(command, *args, shell=True, **kwargs):
         return run(["sudo", *command])
 
 
+def capture(command, *args, stdout=subprocess.PIPE, encoding="utf-8", **kwargs):
+    return run(command, *args, stdout=stdout, encoding=encoding, **kwargs).stdout
+
+
 def get_pg_major_version():
-    full_version_string = run(
-        "initdb --version", stdout=subprocess.PIPE, encoding="utf-8", silent=True
-    ).stdout
+    full_version_string = capture("initdb --version", silent=True)
     major_version_string = re.search("[0-9]+", full_version_string)
     assert major_version_string is not None
     return int(major_version_string.group(0))


### PR DESCRIPTION
It's a somewhat common operation to want to get the stdout output of a
command that you run. This adds a helper for that and uses it in the
two places that we currently need it.
