### PR TITLE
Redesign shutdown logic to support rolling restarts using so_reuseport

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -90,9 +90,26 @@ enum PauseMode {
 };
 
 enum ShutDownMode {
+	/* just stay running */
 	SHUTDOWN_NONE = 0,
-	/* wait for all servers to become idle before stopping the process */
+	/*
+	 * Wait for all servers to become idle before stopping the process. New
+	 * client connection attempts are denied while waiting for the servers
+	 * to be released. Already connected clients that go to CL_WAITING
+	 * state are disconnected eagerly.
+	 */
 	SHUTDOWN_WAIT_FOR_SERVERS,
+	/*
+	 * Wait for all clients to disconnect before stopping the process.
+	 * While waiting for this we stop listening on the socket so no new
+	 * clients can connect. Still connected clients will continue to be
+	 * handed connections from the pool until they disconnect.
+	 *
+	 * This allows for a rolling restart in combination with so_reuseport.
+	 *
+	 * This is an even more graceful shutdown than SHUTDOWN_WAIT_FOR_SERVERS.
+	 */
+	SHUTDOWN_WAIT_FOR_CLIENTS,
 	/* close all connections immediately and stop the process */
 	SHUTDOWN_IMMEDIATE,
 };

--- a/include/pooler.h
+++ b/include/pooler.h
@@ -22,6 +22,7 @@ void resume_pooler(void);
 void suspend_pooler(void);
 void per_loop_pooler_maint(void);
 void pooler_tune_accept(bool on);
+void cleanup_sockets(void);
 
 typedef bool (*pooler_cb)(void *arg, int fd, const PgAddr *addr);
 bool for_each_pooler_fd(pooler_cb cb, void *arg);

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -58,7 +58,7 @@ static struct timeval err_timeout = {5, 0};
 static void tune_accept(int sock, bool on);
 
 /* atexit() cleanup func */
-static void cleanup_sockets(void)
+void cleanup_sockets(void)
 {
 	struct ListenSocket *ls;
 	struct List *el;


### PR DESCRIPTION
In 1.20 we announced deprecation of online restarts using the `-R` flag and recommended for people to use `so_reuseport` instead. But the safe shutdown logic that we executed when receiving a `SIGINT` signal didn't actually allow for zero-downtime rolling restarts.

This PR changes the behaviour of our shutdown signals to allow for rolling restarts. The changes that this PR makes are:

1. SIGTERM does not do "immediate shutdown" anymore, but instead triggers a newly introduced "super safe shutdown". This "super safe shutdown" waits for all clients to disconnect before shutting down the server. This can be used for rolling restarts as described in the newly added documentation. A second SIGTERM will cause an "immediate shutdown".
2. SIGINT mostly keeps doing what it was doing previously: waiting until all servers are released before shutting down PgBouncer. But it incorporates a few improvements from the new SIGTERM logic:
     1. It also stops listening for new connections while PgBouncer is waiting for servers to be released. This does have the downside that SIGUSR2 cannot be used to cancel a safe shutdown anymore, but that was quite a weird/niche feature anyway.
     2. Clients that have released their server and then do another query will be disconnected, instead of putting them in pause mode until either `query_wait_timeout` triggers or PgBouncer shuts down. This way they can reconnect quicker to another PgBouncer, because they were never going to get a new server anyway.
     3.  A that a second SIGINT will trigger an "immediate shutdown"
3. SIGQUIT handling is introduced and now causes an immediate shutdown.

Since this changes the existing behaviour of SIGTERM and SIGINT, this can be considered a breaking change. But the amount of breakage should be minimal since most of the time people would not want an immediate shutdown, and the new SIGINT behaviour is closer to the behaviour most people would expect.

Related to #894
Related to #900

Since this changes SIGTERM to not do a fast shutdown anymore this also indirectly addresses #806 and #770.

Fixes #806 
Fixes #770