### PR TITLE
Reduce cancellation sending log level

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1848,11 +1848,11 @@ bool forward_cancel_request(PgSocket *server)
 		SEND_CancelRequest(res, server, req->canceled_server->cancel_key);
 	}
 	if (!res) {
-		log_warning("sending cancel request failed: %s", strerror(errno));
+		slog_warning(req, "sending cancel request failed: %s", strerror(errno));
 		disconnect_client(req, false, "failed to send cancel request");
 		return false;
 	}
-	log_info("started sending cancel request");
+	slog_debug(req, "started sending cancel request");
 	change_client_state(req, CL_ACTIVE_CANCEL);
 	return true;
 }


### PR DESCRIPTION
This log line was introduced in #666, because that significantly changed
our cancellation logic. But when a client sends many cancellations this
will flood the logs with many identical log lines. To avoid that this
lowers the log level to debug.

Also start using `slog_xxx` functions instead of `log_xxx` functions
for easier debugging in `forward_cancel_request`.

Fixes #901
