### PR TITLE
Support "options" in ignore_startup_parameters again

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -217,6 +217,13 @@ Postgres extensions can change this list though, they can add parameters themsel
 and they can start reporting already existing paremeters that Postgres does not report.
 Notably Citus 12.0+ causes Postgres to also report `search_path`.
 
+The postgres protocol allows specifying parameters settings, both direcly as a
+parameter in the startup packet, or inside the [`options` startup
+packet][options-startup]. Parameters specified using both of these methods are
+supported by `track_extra_parameters`. However, it's not possible to include
+`options` itself in `track_extra_parameters`, only the parameters contained in
+`options`.
+
 Default: IntervalStyle
 
 ### ignore_startup_parameters
@@ -228,6 +235,16 @@ specified here, so that PgBouncer knows that they are handled by the admin and i
 
 If you need to specify multiple values, use a comma-separated list (e.g.
 `options,extra_float_digits`)
+
+The postgres protocol allows specifying parameters settings, both direcly as a
+parameter in the startup packet, or inside the [`options` startup
+packet][options-startup]. Parameters specified using both of these methods are
+supported by `ignore_startup_parameters`. It's even possible to include
+`options` itself in `track_extra_parameters`, which results in any unkown
+parameters contained inside `options` to be ignored.
+
+
+[options-startup]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
 
 Default: empty
 

--- a/src/client.c
+++ b/src/client.c
@@ -589,7 +589,11 @@ static bool read_escaped_token(const char **escaped_string_ptr, struct MBuf *une
  * The reason that we don't support all arguments is to keep the parsing simple
  * an this is by far the argument that's most commonly used in practice in the
  * options startup parameter. Also all other postgres command line arguments
- * can be rewritten to this form:
+ * can be rewritten to this form.
+ *
+ * NOTE: it's possible to supply "options" in ignore_startup_parameters, which
+ * results in all unknown options being ignored. This is for historical reasons,
+ * because it was supported like that in the past.
  */
 static bool set_startup_options(PgSocket *client, const char *options)
 {

--- a/src/client.c
+++ b/src/client.c
@@ -623,7 +623,7 @@ static bool set_startup_options(PgSocket *client, const char *options)
 		value_string = (const char *) equals + 1;
 		if (varcache_set(&client->vars, key_string, value_string)) {
 			slog_debug(client, "got var from options: %s=%s", key_string, value_string);
-		} else if (strlist_contains(cf_ignore_startup_params, key_string)) {
+		} else if (strlist_contains(cf_ignore_startup_params, key_string) || strlist_contains(cf_ignore_startup_params, "options")) {
 			slog_debug(client, "ignoring startup parameter from options: %s=%s", key_string, value_string);
 		} else {
 			slog_warning(client, "unsupported startup parameter in options: %s=%s", key_string, value_string);

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -202,4 +202,24 @@ def test_options_startup_param(bouncer):
         psycopg.OperationalError,
         match="unsupported startup parameter in options: enable_seqscan",
     ):
-        bouncer.test(options="-c enable_seqscan=true")
+        bouncer.test(options="-c enable_seqscan=false")
+
+    bouncer.admin("set ignore_startup_parameters = options")
+    # Unsupported values should be ignored, so it shouldn't error but it should
+    # have its default value instead.
+    assert (
+        bouncer.sql_value(
+            "SHOW enable_seqscan",
+            options="-c enable_seqscan=false",
+        )
+        == "on"
+    )
+
+    # Even though we have options in ignore_startup_parameters, we still parse
+    # and configure any values in it that we support
+    assert (
+        bouncer.sql_value(
+            "SHOW timezone", options="-ctimezone=Portugal  -cdatestyle=German,\\ YMD"
+        )
+        == "Portugal"
+    )


### PR DESCRIPTION
By supporting parsing the `options` startup parameter, we accidentally
stopped supporting using it in `ignore_startup_parameters`.

Users have put `options` in `ignore_startup_parameters` and so upgrading
to 1.20.0 might break their existing connection strings, if the actual
options that are contained in the `options` startup parameter are
unsupported.

This changes the parsing of `options` to allow any unsupported parameter
if `options` itself is in `ignore_startup_parameters`.

NOTE: There's other failure paths in the `options` startup parameter
parsing that could still trigger now even though `options` is in
`ignore_startup_parameters`:

- too long parameter
- non `-c` parameter
- options would have been unparsable by PostgreSQL too

But honestly those seem unlikely enough that I think it's better to
error for them than to ignore those errors.

Fixes #907
