### PR TITLE
Add support for waiting clients count

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -249,6 +249,7 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
 struct PgStats {
 	uint64_t xact_count;
 	uint64_t query_count;
+	uint64_t wait_count;	/*total amount of clients that had to wait*/
 	uint64_t server_bytes;
 	uint64_t client_bytes;
 	usec_t xact_time;	/* total transaction time in us */

--- a/src/objects.c
+++ b/src/objects.c
@@ -206,6 +206,8 @@ void change_client_state(PgSocket *client, SocketState newstate)
 		break;
 	case CL_WAITING:
 	case CL_WAITING_LOGIN:
+		/*increase number of clients that had to wait*/
+		client->pool->stats.wait_count++;
 		client->wait_start = get_cached_time();
 		statlist_append(&pool->waiting_client_list, &client->head);
 		break;


### PR DESCRIPTION
Hello 👋🏽 

In this PR, I'm trying to add support to a new logging variable that would track how many clients have had to wait in order to connect to the server.

I feel like this makes sense when taking into account that there already exist `{query,xact}_{count,time}` / `wait_time` variables.

I tried looking into how these were calculated and follow the same approach for this one, but I'm of course open to feedback.