### PR TITLE
Install contextlib2 for Python 3.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,7 +73,6 @@ task:
     - apt-get -y install $pkgs
     - python3 -m venv /venv
     - /venv/bin/pip install -r requirements.txt
-    - if [ "$(lsb_release -cs)" = "bionic" ]; then /venv/bin/pip install contextlib2; fi
     - useradd user
     - chown -R user .
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
@@ -114,7 +113,6 @@ task:
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
 # XXX: python too old
     - if cat /etc/centos-release | grep -q ' 7'; then true; else pip3 install -r requirements.txt; fi
-    - if cat /etc/centos-release | grep -q ' 7'; then true; else pip3 install contextlib2; fi
     - useradd user
     - chown -R user .
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest-timeout
 pytest-xdist
 psycopg
 filelock
+contextlib2; python_version < "3.7"


### PR DESCRIPTION
We were doing this manually in CI already, but that doesn't help anyone
that wants to run tests themselves on an old python version. This PR
adds contextlib2 to requirements.txt, in a conditional way so that it's
only installed for versions below 3.7.

Fixes #914
