### PR TITLE
Fix confusing typo TLS/TCP typo in docs

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -711,7 +711,7 @@ TLS mode to use for connections to PostgreSQL servers.  The default mode is
 `prefer`.
 
 disable
-:   Plain TCP.  TCP is not even requested from the server.
+:   Plain TCP.  TLS is not even requested from the server.
 
 allow
 :   FIXME: if server rejects plain, try TLS?


### PR DESCRIPTION
This was originally reported by @ntse on the repo for the website. And
it was merged in https://github.com/pgbouncer/pgbouncer.github.io/pull/9

During the last release process I noticed that the change was
automatically overwritten, because for `config.md` this repo is the
canonical place. So this does the change again on the right repo.
