### PR TITLE
tests: Don't use pytest-xdist if no concurrency is requested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,11 @@ CONCURRENCY = auto
 
 check: all
 	etc/optscan.sh
-	PYTHONIOENCODING=utf8 $(PYTEST) -n $(CONCURRENCY)
+	if [ $(CONCURRENCY) = 1 ]; then \
+		PYTHONIOENCODING=utf8 $(PYTEST); \
+	else \
+		PYTHONIOENCODING=utf8 $(PYTEST) -n $(CONCURRENCY); \
+	fi
 	$(MAKE) -C test check
 
 w32zip = $(PACKAGE_TARNAME)-$(PACKAGE_VERSION)-windows-$(host_cpu).zip


### PR DESCRIPTION
This makes stacktraces triggered by pytest-timeout easier to read,
because there's only a single process running instead of two. This
especially impacts Windows.
