### PR TITLE
[auth_dbname] introduce auto-registration option in case auto-database is configured

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -36,6 +36,7 @@ extern struct Slab *var_list_cache;
 
 PgDatabase *find_peer(int peer_id);
 PgDatabase *find_database(const char *name);
+PgDatabase *find_or_register_database(PgSocket *connection, const char *name);
 PgUser *find_user(const char *name);
 PgPool *get_pool(PgDatabase *, PgUser *);
 PgPool *get_peer_pool(PgDatabase *);

--- a/src/admin.c
+++ b/src/admin.c
@@ -407,19 +407,6 @@ static bool show_fds_from_list(PgSocket *admin, struct StatList *list)
 	return res;
 }
 
-static PgDatabase *find_or_register_database(PgSocket *admin, const char *name)
-{
-	PgDatabase *db = find_database(name);
-	if (db == NULL) {
-		db = register_auto_database(name);
-		if (db != NULL) {
-			slog_info(admin,
-				  "registered new auto-database: %s", name);
-		}
-	}
-	return db;
-}
-
 /*
  * Command: SHOW FDS
  *

--- a/src/client.c
+++ b/src/client.c
@@ -52,7 +52,7 @@ PgDatabase *prepare_auth_database(PgSocket *client)
 	if (!auth_dbname) {
 		auth_db = client->db;
 	} else {
-		auth_db = find_database(auth_dbname);
+		auth_db = find_or_register_database(client, auth_dbname);
 	}
 
 	if (!auth_db) {
@@ -334,12 +334,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	Assert((password && takeover) || (!password && !takeover));
 
 	/* find database */
-	client->db = find_database(dbname);
-	if (!client->db) {
-		client->db = register_auto_database(dbname);
-		if (client->db)
-			slog_info(client, "registered new auto-database: db=%s", dbname);
-	}
+	client->db = find_or_register_database(client, dbname);
 	if (!client->db) {
 		client->db = calloc(1, sizeof(*client->db));
 		client->db->fake = true;

--- a/src/objects.c
+++ b/src/objects.c
@@ -567,6 +567,23 @@ PgDatabase *find_database(const char *name)
 	return NULL;
 }
 
+/* 
+ * Similar to find_database. In case databse is not found, it will try to register
+ * it if auto-database ('*') is configured.
+ */
+PgDatabase *find_or_register_database(PgSocket *connection, const char *name)
+{
+	PgDatabase *db = find_database(name);
+	if (db == NULL) {
+		db = register_auto_database(name);
+		if (db != NULL) {
+			slog_info(connection,
+				  "registered new auto-database: %s", name);
+		}
+	}
+	return db;
+}
+
 /* find existing user */
 PgUser *find_user(const char *name)
 {

--- a/src/objects.c
+++ b/src/objects.c
@@ -567,7 +567,7 @@ PgDatabase *find_database(const char *name)
 	return NULL;
 }
 
-/* 
+/*
  * Similar to find_database. In case databse is not found, it will try to register
  * it if auto-database ('*') is configured.
  */

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,6 +74,7 @@ def pg(tmp_path_factory, cert_dir):
     for i in range(8):
         pg.sql(f"create database p{i}")
 
+    pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
     pg.sql("create user pswcheck with superuser createdb password 'pgbouncer-check';")
     pg.sql("create user someuser with password 'anypasswd';")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -77,9 +77,7 @@ def test_unregistered_auto_dbname_with_auto_database(bouncer):
         original = f.read()
     with bouncer.ini_path.open("w") as f:
         # uncomment the auto-database line
-        new = re.sub(
-            r"^;\* = ", "* = ", original, flags=re.MULTILINE
-        )
+        new = re.sub(r"^;\* = ", "* = ", original, flags=re.MULTILINE)
         print(new)
         f.write(new)
     # configure the auth_dbname to a database that is not configured
@@ -98,7 +96,8 @@ def test_unregistered_auto_dbname_with_auto_database(bouncer):
     # database. Hence, we can conclude that we were able to look up the password using
     # auth_dbname
     with pytest.raises(
-        psycopg.OperationalError, match="database \"this_database_doesnt_exist\" does not exist"
+        psycopg.OperationalError,
+        match='database "this_database_doesnt_exist" does not exist',
     ):
         bouncer.test(dbname="this_database_doesnt_exist", user="muser1", password="foo")
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -82,7 +82,8 @@ def test_unconfigured_auth_database_with_auto_database(bouncer):
     with bouncer.ini_path.open() as f:
         original = f.read()
         assert (
-            re.search(r"^unconfigured_auth_database", original, flags=re.MULTILINE) is None
+            re.search(r"^unconfigured_auth_database", original, flags=re.MULTILINE)
+            is None
         )
     with bouncer.ini_path.open("w") as f:
         # uncomment the auto-database line

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -82,8 +82,7 @@ def test_unconfigured_auth_database_with_auto_database(bouncer):
     with bouncer.ini_path.open() as f:
         original = f.read()
         assert (
-            re.search(r"^unconfigured_auth_database", original, flags=re.MULTILINE)
-            == None
+            re.search(r"^unconfigured_auth_database", original, flags=re.MULTILINE) is None
         )
     with bouncer.ini_path.open("w") as f:
         # uncomment the auto-database line

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -89,7 +89,7 @@ def test_unregistered_auto_dbname_with_auto_database(bouncer):
     bouncer.admin("set auth_user='pswcheck'")
     bouncer.admin(f"set auth_type='md5'")
     # postgres is not defined in test.ini
-    bouncer.test(dbname="postgres", user="someuser", password="anypasswd")
+    bouncer.test(dbname="authdb", user="someuser", password="anypasswd")
     # test already configured database, should still work.
     bouncer.test(user="muser1", password="foo")
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -72,6 +72,36 @@ def test_auth_dbname_with_auto_database(bouncer):
     bouncer.test(dbname="postgres", user="someuser", password="anypasswd")
 
 
+def test_unregistered_auto_dbname_with_auto_database(bouncer):
+    with bouncer.ini_path.open() as f:
+            original = f.read()
+    with bouncer.ini_path.open("w") as f:
+        # uncomment the auto-database line
+        new = re.sub(
+            r"^;\* = ", "* = ", original, flags=re.MULTILINE
+        )
+        print(new)
+        f.write(new)
+    # configure the auth_dbname to a database that is not configured
+    # expected behavior is to fallback to auto-database and auto-register.
+    bouncer.admin("set auth_dbname=postgres")
+    bouncer.admin("reload")
+    bouncer.admin("set auth_user='pswcheck'")
+    bouncer.admin(f"set auth_type='md5'")
+    # postgres is not defined in test.ini
+    bouncer.test(dbname="postgres", user="someuser", password="anypasswd")
+    # test already configured database, should still work.
+    bouncer.test(user="muser1", password="foo")
+
+    # test a database that does not exist in the server, it should fail.
+    # but this error will only surface when we attempt to make the connection to client's
+    # database. Hence, we can conclude that we were able to look up the password using
+    # auth_dbname
+    with pytest.raises(
+        psycopg.OperationalError, match="database \"this_database_doesnt_exist\" does not exist"
+    ):
+        bouncer.test(dbname="this_database_doesnt_exist", user="muser1", password="foo")
+
 def run_server_auth_test(bouncer, dbname):
     bouncer.admin(f"set auth_type='trust'")
     # good password from ini

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -74,7 +74,7 @@ def test_auth_dbname_with_auto_database(bouncer):
 
 def test_unregistered_auto_dbname_with_auto_database(bouncer):
     with bouncer.ini_path.open() as f:
-            original = f.read()
+        original = f.read()
     with bouncer.ini_path.open("w") as f:
         # uncomment the auto-database line
         new = re.sub(
@@ -101,6 +101,7 @@ def test_unregistered_auto_dbname_with_auto_database(bouncer):
         psycopg.OperationalError, match="database \"this_database_doesnt_exist\" does not exist"
     ):
         bouncer.test(dbname="this_database_doesnt_exist", user="muser1", password="foo")
+
 
 def run_server_auth_test(bouncer, dbname):
     bouncer.admin(f"set auth_type='trust'")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -96,12 +96,8 @@ def test_unconfigured_auth_database_with_auto_database(bouncer):
     bouncer.admin("reload")
     bouncer.admin("set auth_user='pswcheck'")
     bouncer.admin(f"set auth_type='md5'")
-    # postgres is not defined in test.ini
-    bouncer.test(dbname="authdb", user="someuser", password="anypasswd")
-    # test already configured database, should still work.
-    bouncer.test(user="muser1", password="foo")
 
-    # test a database that does not exist in the server, it should fail.
+    # test a database that does not exist on the server, it should fail.
     # but this error will only surface when we attempt to make the connection to client's
     # database. Hence, we can conclude that we were able to look up the password using
     # auth_dbname
@@ -110,6 +106,8 @@ def test_unconfigured_auth_database_with_auto_database(bouncer):
         match='database "this_database_doesnt_exist" does not exist',
     ):
         bouncer.test(dbname="this_database_doesnt_exist", user="muser1", password="foo")
+    # do a final sanity check that we can connect.
+    bouncer.test(user="muser1", password="foo")
 
 
 def run_server_auth_test(bouncer, dbname):


### PR DESCRIPTION
When the database section has an auto-database, '*', the expected behavior for login experience to have client's database registered when not found. However, this experience would be blocked if we configure `auth_dbname` to fall to auto-database. Hence, the main goal of this PR is to ensure that `auth_dbname` can still function on cases where it is not configured, but auto-database is provided.

To achieve that, this PR makes already existing function, find_or_register_database, public and uses it from various places to simplify code.

Edit:

Quoting the targeted use case of this change from @JelteF 's comment, which makes the change more presentable:

```ini
[databases]
* = host=localhost

[pgbouncer]
auth_dbname=postgres
```

Where, we will use `auth_dbname=postgres` with auto-registered database's connection string.