### PR TITLE
Increase sleeps in test_reserve_pool_size to avoid flakyness

### DIFF
--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -86,10 +86,13 @@ async def test_reserve_pool_size(pg, bouncer):
     bouncer.admin("set reserve_pool_size = 3")
     bouncer.admin("set reserve_pool_timeout = 2")
     with bouncer.log_contains("taking connection from reserve_pool", times=3):
-        result = bouncer.asleep(6, dbname="p1", times=10)
+        # default_pool_size is 5, so half of the connections will need to wait
+        # until the reserve_pool_timeout (2 seconds) is reached. At that point
+        # 3 more connections should be allowed to continue.
+        result = bouncer.asleep(10, dbname="p1", times=10)
         await asyncio.sleep(1)
         assert pg.connection_count("p1") == 5
-        await asyncio.sleep(4)
+        await asyncio.sleep(8)
         assert pg.connection_count("p1") == 8
         await result
 


### PR DESCRIPTION
On windows CI the test_reserve_pool_size test has started failing pretty
regularly. This increases the sleeps some more to hopefully make it less
flaky. One test I investigated shows that it took ~5 seconds to open the
last of the three reserved pool connections.

```
2023-08-16 09:04:12.876 Greenwich Standard Time [5912] LOG S-00000161ad72a0f0: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49750)
2023-08-16 09:04:12.963 Greenwich Standard Time [5912] LOG S-00000161ad72a330: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49751)
2023-08-16 09:04:13.006 Greenwich Standard Time [5912] LOG S-00000161ad72a570: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49752)
2023-08-16 09:04:13.060 Greenwich Standard Time [5912] LOG S-00000161ad72a7b0: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49753)
2023-08-16 09:04:13.116 Greenwich Standard Time [5912] LOG S-00000161ad72a9f0: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49754)
2023-08-16 09:04:15.009 Greenwich Standard Time [5912] WARNING C-00000161ad6f14d0: p1/postgres@127.0.0.1:49744 taking connection from reserve_pool
2023-08-16 09:04:15.010 Greenwich Standard Time [5912] LOG S-00000161ad72ac30: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49904)
2023-08-16 09:04:16.391 Greenwich Standard Time [5912] WARNING C-00000161ad6f2010: p1/postgres@127.0.0.1:49749 taking connection from reserve_pool
2023-08-16 09:04:16.392 Greenwich Standard Time [5912] LOG S-00000161ad72ae70: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49968)
2023-08-16 09:04:17.984 Greenwich Standard Time [5912] WARNING C-00000161ad6f1050: p1/postgres@127.0.0.1:49742 taking connection from reserve_pool
2023-08-16 09:04:17.986 Greenwich Standard Time [5912] LOG S-00000161ad72b0b0: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49972)
