### PR TITLE
Exclude lib and uthash directory for python tooling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,8 @@
 [flake8]
 extend-ignore = E203, E265, F401, F541
 max-line-length = 150
+exclude =
+    .git,
+    __pycache__,
+    lib,
+    uthash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,20 @@ timeout = 30
 # versions is a small price to pay to not have to worry about that.
 asyncio_mode = 'auto'
 
+# Make test discovery quicker
+norecursedirs = [
+    '*.egg',
+    '.*',
+    '__pycache__',
+    'venv',
+    'src',
+    'lib',
+    'uthash',
+]
+
 [tool.isort]
 profile = 'black'
-skip = 'lib'
+skip = 'lib,uthash'
 
 [tool.black]
-extend-exclude = 'lib'
+extend-exclude = 'lib|uthash'


### PR DESCRIPTION
Discovering tests and running linters takes longer than necessary,
because they traversed the submodules. This excludes them everywhere.
