### PR TITLE
Fix FATAL in function server_proto(): server in bad state: 11

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -587,6 +587,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		case SV_USED:
 		case SV_ACTIVE:
 		case SV_ACTIVE_CANCEL:
+		case SV_BEING_CANCELED:
 		case SV_IDLE:
 			res = handle_server_work(server, &pkt);
 			break;
@@ -635,6 +636,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 				break;
 			default:
 				slog_warning(server, "EV_FLUSH with state=%d", server->state);
+			case SV_BEING_CANCELED:
 			case SV_IDLE:
 				break;
 			}


### PR DESCRIPTION
Fixes #822
Related to #904 and #717

In #904 @tnt-dev reported to still get the issue in #822 on 1.19.1 (on
which it was expected to be fixed).

```
2023-08-12T16:34:07+00:00 pgbouncer[4920]: @src/server.c:591 in function server_proto(): server_proto: server in bad state: 11
2023-08-12T16:34:07+00:00 systemd[1]: pgbouncer.service: Main process exited, code=exited, status=1/FAILURE
2023-08-12T16:34:07+00:00 systemd[1]: pgbouncer.service: Failed with result 'exit-code'.
2023-08-12T16:34:07+00:00 systemd[1]: pgbouncer.service: Consumed 1h 51min 3.308s CPU time.
2023-08-12T16:34:07+00:00 pgbouncer[4920]: @src/server.c:591 in function server_proto(): server_proto: server in bad state: 11
2023-08-12T16:34:07+00:00 pgbouncer[4920]: started sending cancel request
```

Looking again, I now understand that the switch in question was missing
the SV_BEING_CANCELED case. I now added it to the same case list
that SV_IDLE was part of. Since SV_BEING_CANCELED is effectively the
same state as SV_IDLE (except we don't allow reuse of the server yet).

I did the same in a second switch case, for that one only warnings would
have been shown instead of causing a fatal error. But still it seems
good to avoid unnecessary warnings.

One example where this fatal error might occur is when PgBouncer is
still waiting for a response from the cancel request it sent to the server.
But the query that's being canceled completes before that happens.
This puts the server in SV_BEING_CANCELED. Then for whatever
reason the server sends a NOTICE or ERROR message (still before
the cancel request receives a response from postgres).

I was able to reproduce (and confirm that the patch resolves it), by adding
some fake latency between pgbouncer and postgres. And stopping postgres
while the server was in the SV_BEING_CANCELED state.