### PR TITLE
Fix FATAL in function client_proto(): bad client state: 6/7

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1190,6 +1190,9 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 			break;
 		case CL_WAITING:
 			fatal("why waiting client in client_proto()");
+		case CL_WAITING_CANCEL:
+		case CL_ACTIVE_CANCEL:
+			fatal("why canceling client in client_proto()");
 		default:
 			fatal("bad client state: %d", client->state);
 		}


### PR DESCRIPTION
The cancel request protocol is very simple:
1. Clients send a cancel key
2. Server cancels the query running on the matching backend
3. The server closes the socket to indicate the cancel request was
   handled

At no point after sending the cancel key the client is required to send
any data, and if it does it won't get a response anyway because the
server would close the connection. So most clients don't, specifically
all libpq based client don't.

The Go client however, sends a Terminate ('X') packet before closing the
cancel socket from its own side (usually due to a 10 second timeout).
This would cause a crash in PgBouncer, because PgBouncer would still
listen on the client socket, but on receiving any data we wouldreport a
fatal error. This PR fixes that fatal error by stopping to listen on the
client socket once we've received the cancel key (i.e. when we change
the client state to CL_WAITING_CANCEL).

I was able to reproduce both of the errors reported by @raymasson and
confirmed that after this change the errors would not occur again.

Reproducing this with libpq based clients is not possible, except when
manually attaching to the client using `gdb` and manually running `send`
on the cancel request its socket. So no test is added, since our test
suite uses psycopg which uses libpq under the hood.

Fixes #904

Related to #717
