### PR TITLE
Increase one more sleep in test_reserve_pool_size

### DIFF
--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -90,7 +90,7 @@ async def test_reserve_pool_size(pg, bouncer):
         # until the reserve_pool_timeout (2 seconds) is reached. At that point
         # 3 more connections should be allowed to continue.
         result = bouncer.asleep(10, dbname="p1", times=10)
-        await asyncio.sleep(1)
+        await asyncio.sleep(1.7)
         assert pg.connection_count("p1") == 5
         await asyncio.sleep(8)
         assert pg.connection_count("p1") == 8


### PR DESCRIPTION
In #923 I tried to make this test pass consistently on our now seemingly
slower Windows CI by increasing sleeps. This helped, but one sleep
was not increased and this sleep is still causing issues. Starting the
initial 5 connection sometimes takes slightly more than 1 second on the
Windows CI. The sleep of 1 second cannot be changed to 2, because then
faster operating systems might actually have started connections from
their reserve_pool already. So this changes it to 1.7 seconds.

Logs with timings from a failing test:
```
2023-08-16 17:43:25.724 Greenwich Standard Time [5900] LOG S-00c1b388: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49776)
2023-08-16 17:43:26.257 Greenwich Standard Time [5900] LOG S-00c1b520: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49818)
2023-08-16 17:43:26.607 Greenwich Standard Time [5900] LOG S-00c1b6b8: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49873)
2023-08-16 17:43:26.703 Greenwich Standard Time [5900] LOG S-00c1b850: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49878)
2023-08-16 17:43:26.852 Greenwich Standard Time [5900] LOG S-00c1b9e8: p1/bouncer@127.0.0.1:10202 new connection to server (from 127.0.0.1:49885)
```
