### PR TITLE
Use server_tls_sslmode=disable in some flaky tests

### DIFF
--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -85,6 +85,10 @@ def test_min_pool_size_with_lower_max_db_connections(bouncer):
 async def test_reserve_pool_size(pg, bouncer):
     bouncer.admin("set reserve_pool_size = 3")
     bouncer.admin("set reserve_pool_timeout = 2")
+
+    # Disable tls to get more consistent timings
+    bouncer.admin("set server_tls_sslmode = disable")
+
     with bouncer.log_contains("taking connection from reserve_pool", times=3):
         # default_pool_size is 5, so half of the connections will need to wait
         # until the reserve_pool_timeout (2 seconds) is reached. At that point

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -78,6 +78,9 @@ async def test_server_login_retry(pg, bouncer):
     bouncer.admin(f"set query_timeout=10")
     bouncer.admin(f"set server_login_retry=3")
 
+    # Disable tls to get more consistent timings
+    bouncer.admin("set server_tls_sslmode = disable")
+
     pg.stop()
     if platform.system() == "FreeBSD":
         # XXX: For some reason FreeBSD logs don't contain connect failed


### PR DESCRIPTION
In 1.20.0 we started using `server_tls_sslmode=prefer` by default. This
sets it to `disable` for specific tests that depend heavily on specific
timings. These timings would be messed up on some OSes in CI, because
now PgBouncer would first try to connect using TLS and when that failed
it would try connect without. Especially on Windows CI a failed TLS
connection to localhost seems to sometimes take significant time.
