### PR TITLE
Remove udns

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
     - container:
         image: ubuntu:20.04
       env:
-        configure_args: '--with-udns --without-openssl'
+        configure_args: '--without-openssl'
     - container:
         image: ubuntu:20.04
       env:
@@ -66,7 +66,7 @@ task:
     - curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
     - apt-get update
-    - pkgs="autoconf automake ca-certificates cpio libc-ares-dev libevent-dev libssl-dev libsystemd-dev libtool libudns-dev make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv sudo iptables"
+    - pkgs="autoconf automake ca-certificates cpio libc-ares-dev libevent-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv sudo iptables"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ their probing order:
 | backend                    | parallel | EDNS0 (1) | /etc/hosts | SOA lookup (2) | note                                  |
 |----------------------------|----------|-----------|------------|----------------|---------------------------------------|
 | c-ares                     | yes      | yes       | yes        | yes            | IPv6+CNAME buggy in <=1.10            |
-| udns                       | yes      | yes       | no         | yes            | IPv4 only                             |
 | evdns, libevent 2.x        | yes      | no        | yes        | no             | does not check /etc/hosts updates     |
 | getaddrinfo_a, glibc 2.9+  | yes      | yes (3)   | yes        | no             | N/A on non-glibc                      |
 | getaddrinfo, libc          | no       | yes (3)   | yes        | no             | requires pthreads                     |
@@ -62,10 +61,9 @@ options at this point and don't receive much testing anymore.
 
 By default, c-ares is used if it can be found.  Its use can be forced
 with `configure --with-cares` or disabled with `--without-cares`.  If
-c-ares is not used (not found or disabled), then specify `--with-udns`
-to pick udns, else Libevent is used.  Specify `--disable-evdns` to
-disable the use of Libevent's evdns and fall back to a libc-based
-implementation.
+c-ares is not used (not found or disabled), then Libevent is used.  Specify
+`--disable-evdns` to disable the use of Libevent's evdns and fall back to a
+libc-based implementation.
 
 PAM authentication
 ------------------

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,6 @@ fi
 
 # make sure all vars are set
 use_cares=no
-use_udns=no
 use_evdns=no
 
 dnl Find c-ares
@@ -142,41 +141,6 @@ if test "$use_cares" = "yes"; then
 
 else # !cares
 
-dnl Find libudns
-AC_MSG_CHECKING([whether to use libudns])
-AC_ARG_WITH(udns,
-  AS_HELP_STRING([--with-udns@<:@=PREFIX@:>@], [build with udns support]),
-  [ if test "$withval" = "no"; then
-      use_udns=no
-    elif test "$withval" = "yes"; then
-      use_udns=yes
-    else
-      use_udns=yes
-      CPPFLAGS="$CPPFLAGS -I$withval/include"
-      LDFLAGS="$LDFLAGS -L$withval/lib"
-    fi
-  ], [])
-AC_MSG_RESULT([$use_udns])
-
-if test "$use_udns" = "yes"; then
-  AC_DEFINE(USE_UDNS, 1, [Use UDNS for name resolution.])
-  LIBS="-ludns $LIBS"
-  AC_MSG_CHECKING([whether libudns is available])
-  AC_LINK_IFELSE([AC_LANG_SOURCE([
-    #include <sys/types.h>
-    #include <sys/time.h>
-    #include <stddef.h>
-    #include <udns.h>
-    int main(void) {
-      struct dns_ctx *ctx = NULL;
-      dns_init(ctx, 0);
-      dns_reset(ctx);
-    } ])],
-  [AC_MSG_RESULT([found])],
-  [AC_MSG_ERROR([not found, cannot proceed])])
-
-else # !udns
-
 dnl Allow user to override the decision
 AC_ARG_ENABLE(evdns, AS_HELP_STRING([--disable-evdns], [do not use libevent for DNS lookups]),
               [use_evdns=$enableval], [use_evdns=yes])
@@ -189,11 +153,9 @@ else
 fi
 
 dnl Check if need getaddinfo_a compat
-if test "$use_udns.$use_cares.$use_evdns" = "no.no.no"; then
+if test "$use_cares.$use_evdns" = "no.no"; then
   AC_USUAL_GETADDRINFO_A
 fi
-
-fi # !udns
 
 fi # !cares
 
@@ -224,8 +186,6 @@ echo "Results:"
 dnl Note: Report here should match selection in src/dnslookup.c
 if test "$use_cares" = "yes"; then
   echo "  adns    = c-ares"
-elif test "$use_udns" = "yes"; then
-  echo "  adns    = udns"
 elif test "$use_evdns" = "yes"; then
   echo "  adns    = evdns2"
 elif test "$ac_cv_usual_glibc_gaia" = "yes"; then

--- a/doc/config.md
+++ b/doc/config.md
@@ -621,7 +621,7 @@ If it notices changes, all host names under that zone
 are looked up again.  If any host IP changes, its connections
 are invalidated.
 
-Works only with UDNS and c-ares backends (`configure` option `--with-udns` or `--with-cares`).
+Works only with UDNS and c-ares backends (`configure` option `--with-cares`).
 
 Default: 0.0 (disabled)
 

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -21,7 +21,7 @@
 #include <usual/netdb.h>
 #include <usual/socket.h>
 
-#if !defined(USE_EVDNS) && !defined(USE_UDNS) && !defined(USE_CARES)
+#if !defined(USE_EVDNS) && !defined(USE_CARES)
 #define USE_GETADDRINFO_A
 #endif
 
@@ -43,11 +43,6 @@
 #else
 /* only c-ares requires this */
 #define impl_per_loop(ctx)
-#endif
-
-#ifdef USE_UDNS
-#include <udns.h>
-#define ZONE_RECHECK 1
 #endif
 
 #ifndef ZONE_RECHECK
@@ -132,7 +127,7 @@ static void got_zone_serial(struct DNSContext *ctx, uint32_t *serial);
  * Custom addrinfo generation
  */
 
-#if defined(USE_UDNS) || defined(USE_CARES)
+#if defined(USE_CARES)
 
 static struct addrinfo *mk_addrinfo(const void *adr, int af)
 {
@@ -182,32 +177,6 @@ static void freeaddrinfo(struct addrinfo *ai)
 		free(cur);
 	}
 }
-
-#if defined(USE_UDNS)
-
-static inline struct addrinfo *convert_ipv4_result(const struct in_addr *adrs, int count)
-{
-	struct addrinfo *ai, *first = NULL, *last = NULL;
-	int i;
-
-	for (i = 0; i < count; i++) {
-		ai = mk_addrinfo(&adrs[i], AF_INET);
-		if (!ai)
-			goto failed;
-
-		if (!first)
-			first = ai;
-		else
-			last->ai_next = ai;
-		last = ai;
-	}
-	return first;
-failed:
-	freeaddrinfo(first);
-	return NULL;
-}
-
-#endif /* USE_UDNS */
 
 #ifdef USE_CARES
 
@@ -442,286 +411,6 @@ static void impl_release(struct DNSContext *ctx)
 }
 
 #endif /* USE_EVDNS */
-
-
-/*
- * ADNS with <udns.h>
- */
-
-#ifdef USE_UDNS
-
-struct UdnsMeta {
-	struct dns_ctx *ctx;
-	struct event ev_io;
-	struct event ev_timer;
-	bool timer_active;
-};
-
-const char *adns_get_backend(void)
-{
-	return "udns " UDNS_VERSION;
-}
-
-static void udns_timer_setter(struct dns_ctx *uctx, int timeout, void *arg)
-{
-	struct DNSContext *ctx = arg;
-	struct UdnsMeta *udns = ctx->edns;
-
-	log_noise("udns_timer_setter: ctx=%p timeout=%d", uctx, timeout);
-
-	if (udns->timer_active) {
-		event_del(&udns->ev_timer);
-		udns->timer_active = false;
-	}
-
-	if (uctx && timeout >= 0) {
-		struct timeval tv = { .tv_sec = timeout, .tv_usec = 0 };
-		evtimer_add(&udns->ev_timer, &tv);
-		udns->timer_active = true;
-	}
-}
-
-static void udns_timer_cb(int d, short fl, void *arg)
-{
-	struct DNSContext *ctx = arg;
-	struct UdnsMeta *udns = ctx->edns;
-	time_t now = get_cached_time() / USEC;
-
-	log_noise("udns_timer_cb");
-
-	dns_timeouts(udns->ctx, 10, now);
-}
-
-static void udns_io_cb(int fd, short fl, void *arg)
-{
-	struct DNSContext *ctx = arg;
-	struct UdnsMeta *udns = ctx->edns;
-	time_t now = get_cached_time() / USEC;
-
-	log_noise("udns_io_cb");
-
-	dns_ioevent(udns->ctx, now);
-}
-
-static void udns_result_a4(struct dns_ctx *ctx, struct dns_rr_a4 *a4, void *data)
-{
-	struct DNSRequest *req = data;
-	struct addrinfo *res = NULL;
-	int err;
-
-	err = dns_status(ctx);
-	if (err < 0) {
-		log_warning("udns_result_a4: %s: query failed [%d]", req->name, err);
-	} else if (a4) {
-		log_noise("udns_result_a4: %s: %d ips", req->name, a4->dnsa4_nrr);
-		res = convert_ipv4_result(a4->dnsa4_addr, a4->dnsa4_nrr);
-		free(a4);
-	} else {
-		log_warning("udns_result_a4: %s: missing result", req->name);
-	}
-	got_result_gai(0, res, req);
-}
-
-static void impl_launch_query(struct DNSRequest *req)
-{
-	struct UdnsMeta *udns = req->ctx->edns;
-	struct dns_query *q;
-	int flags = 0;
-
-	q = dns_submit_a4(udns->ctx, req->name, flags, udns_result_a4, req);
-	if (q) {
-		log_noise("dns: udns_launch_query(%s)=%p", req->name, q);
-	} else {
-		log_warning("dns: udns_launch_query(%s)=NULL", req->name);
-	}
-}
-
-static bool impl_init(struct DNSContext *ctx)
-{
-	int fd;
-	struct dns_ctx *dctx;
-	struct UdnsMeta *udns;
-	int err;
-
-	if (cf_resolv_conf && cf_resolv_conf[0]) {
-		log_error("resolv_conf setting is not supported by udns");
-		return false;
-	}
-
-	dns_init(NULL, 0);
-
-	dctx = dns_new(NULL);
-	if (!dctx)
-		return false;
-
-	udns = calloc(1, sizeof(*udns));
-	if (!udns)
-		return false;
-	ctx->edns = udns;
-	udns->ctx = dctx;
-
-	/* i/o callback setup */
-	fd = dns_open(dctx);
-	if (fd <= 0) {
-		log_error("dns_open failed: fd=%d", fd);
-		return false;
-	}
-	event_assign(&udns->ev_io, pgb_event_base, fd, EV_READ | EV_PERSIST, udns_io_cb, ctx);
-	err = event_add(&udns->ev_io, NULL);
-	if (err < 0)
-		log_warning("impl_init: event_add failed: %s", strerror(errno));
-
-	/* timer setup */
-	evtimer_assign(&udns->ev_timer, pgb_event_base, udns_timer_cb, ctx);
-	dns_set_tmcbck(udns->ctx, udns_timer_setter, ctx);
-
-	return true;
-}
-
-static void impl_release(struct DNSContext *ctx)
-{
-	struct UdnsMeta *udns = ctx->edns;
-
-	event_del(&udns->ev_io);
-	dns_free(udns->ctx);
-	if (udns->timer_active) {
-		event_del(&udns->ev_timer);
-		udns->timer_active = false;
-	}
-}
-
-/*
- * generic SOA query for UDNS
- */
-
-struct SOA {
-	dns_rr_common(dnssoa);
-
-	char *dnssoa_nsname;
-	char *dnssoa_hostmaster;
-	uint32_t dnssoa_serial;
-	uint32_t dnssoa_refresh;
-	uint32_t dnssoa_retry;
-	uint32_t dnssoa_expire;
-	uint32_t dnssoa_minttl;
-};
-
-typedef void query_soa_fn(struct dns_ctx *ctx, struct SOA *result, void *data);
-
-static int parse_soa(dnscc_t *qdn, dnscc_t *pkt, dnscc_t *cur, dnscc_t *end, void **result)
-{
-	struct SOA *soa = NULL;
-	int res, len;
-	struct dns_parse p;
-	struct dns_rr rr;
-	dnsc_t buf[DNS_MAXDN];
-	char *s;
-
-	/* calc size */
-	len = 0;
-	dns_initparse(&p, qdn, pkt, cur, end);
-	while ((res = dns_nextrr(&p, &rr)) > 0) {
-		cur = rr.dnsrr_dptr;
-
-		res = dns_getdn(pkt, &cur, end, buf, sizeof(buf));
-		if (res <= 0)
-			goto failed;
-		len += dns_dntop_size(buf);
-
-		res = dns_getdn(pkt, &cur, end, buf, sizeof(buf));
-		if (res <= 0)
-			goto failed;
-		len += dns_dntop_size(buf);
-
-		if (cur + 5*4 != rr.dnsrr_dend)
-			goto failed;
-	}
-	if (res < 0 || p.dnsp_nrr != 1)
-		goto failed;
-	len += dns_stdrr_size(&p);
-
-	/* allocate */
-	soa = malloc(sizeof(*soa) + len);
-	if (!soa)
-		return DNS_E_NOMEM;
-
-	/* fill with data */
-	soa->dnssoa_nrr = 1;
-	dns_rewind(&p, qdn);
-	dns_nextrr(&p, &rr);
-	s = (char *)(soa + 1);
-	cur = rr.dnsrr_dptr;
-
-	soa->dnssoa_nsname = s;
-	dns_getdn(pkt, &cur, end, buf, sizeof(buf));
-	s += dns_dntop(buf, s, DNS_MAXNAME);
-
-	soa->dnssoa_hostmaster = s;
-	dns_getdn(pkt, &cur, end, buf, sizeof(buf));
-	s += dns_dntop(buf, s, DNS_MAXNAME);
-
-	soa->dnssoa_serial = dns_get32(cur + 0*4);
-	soa->dnssoa_refresh = dns_get32(cur + 1*4);
-	soa->dnssoa_retry = dns_get32(cur + 2*4);
-	soa->dnssoa_expire = dns_get32(cur + 3*4);
-	soa->dnssoa_minttl = dns_get32(cur + 4*4);
-
-	dns_stdrr_finish((struct dns_rr_null *)soa, s, &p);
-
-	*result = soa;
-	return 0;
-failed:
-	free(soa);
-	return DNS_E_PROTOCOL;
-}
-
-static struct dns_query *submit_soa(struct dns_ctx *ctx, const char *name, int flags, query_soa_fn *cb, void *data)
-{
-	return dns_submit_p(ctx, name, DNS_C_IN, DNS_T_SOA, flags,
-			    parse_soa, (dns_query_fn *)cb, data);
-}
-
-/*
- * actual "get serial" part
- */
-
-static void udns_result_soa(struct dns_ctx *uctx, struct SOA *soa, void *data)
-{
-	struct DNSContext *ctx = data;
-
-	if (!soa) {
-		log_noise("SOA query failed");
-		got_zone_serial(ctx, NULL);
-		return;
-	}
-
-	log_noise("SOA1: cname=%s qname=%s ttl=%u nrr=%u",
-		  soa->dnssoa_cname, soa->dnssoa_qname,
-		  soa->dnssoa_ttl, soa->dnssoa_nrr);
-	log_noise("SOA2: nsname=%s hostmaster=%s serial=%u refresh=%u retry=%u expire=%u minttl=%u",
-		  soa->dnssoa_nsname, soa->dnssoa_hostmaster, soa->dnssoa_serial, soa->dnssoa_refresh,
-		  soa->dnssoa_retry, soa->dnssoa_expire, soa->dnssoa_minttl);
-
-	got_zone_serial(ctx, &soa->dnssoa_serial);
-
-	free(soa);
-}
-
-static int impl_query_soa_serial(struct DNSContext *ctx, const char *zonename)
-{
-	struct UdnsMeta *udns = ctx->edns;
-	struct dns_query *q;
-	int flags = 0;
-
-	log_debug("udns: impl_query_soa_serial: name=%s", zonename);
-	q = submit_soa(udns->ctx, zonename, flags, udns_result_soa, ctx);
-	if (!q) {
-		log_error("impl_query_soa_serial failed: %s", zonename);
-	}
-	return 0;
-}
-
-#endif /* USE_UDNS */
 
 
 /*


### PR DESCRIPTION
libudns is not maintained for a long time (+9 years) [1]. Since there are other DNS resolvers that have been maintained and there isn't a modern operating system that enables it, remove libudns support.

[1] https://www.corpit.ru/mjt/udns.html