### PR TITLE
Stop supporting Ubuntu 18.04, since it is EOL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,10 +49,6 @@ task:
     - container:
         image: ubuntu:22.04
     - container:
-        image: ubuntu:18.04
-      env:
-        PGVERSION: 9.6
-    - container:
         image: debian:stable
       env:
         PGVERSION: 13


### PR DESCRIPTION
Ubuntu 18.04 has been causing build issues in PR #845, because we
started using a unicode symbol in the docs. This fails the docs build.
Since Ubuntu 18.04 has been EOL since April, it seems better to drop
support than to add code to work around this.

PG9.6 is also EOL, but continuing to support it hasn't been a big issue
yet. Also it seems useful for PgBouncer to still be able to talk to EOL
Postgres instances, but running the newest version of PgBouncer itself
on EOL operating systems seems much less useful.

We still remove the whole matrix task though, because there's already
another task with PG9.6.
