### PR TITLE
Reduce CI builds because of lowered Cirrus credits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,8 @@ env:
 task:
   name: Linux (Debian/Ubuntu)
   matrix:
-    - container:
-        image: ubuntu:20.04
+    # - container:
+    #     image: ubuntu:20.04
     - container:
         image: ubuntu:20.04
       env:
@@ -17,45 +17,45 @@ task:
         image: ubuntu:20.04
       env:
         configure_args: '--without-openssl'
-    - container:
-        image: ubuntu:20.04
-      env:
-        configure_args: '--disable-evdns'
-    - container:
-        image: ubuntu:20.04
-      env:
-        CC: clang
-    - container:
-        image: ubuntu:20.04
-      env:
-        CFLAGS: -fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift
-    - container:
-        image: ubuntu:20.04
-      env:
-        ENABLE_VALGRIND: yes
-        CFLAGS: -O0 -g
+    # - container:
+    #     image: ubuntu:20.04
+    #   env:
+    #     configure_args: '--disable-evdns'
+    # - container:
+    #     image: ubuntu:20.04
+    #   env:
+    #     CC: clang
+    # - container:
+    #     image: ubuntu:20.04
+    #   env:
+    #     CFLAGS: -fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift
     - container:
         image: ubuntu:20.04
       env:
         ENABLE_VALGRIND: yes
         CFLAGS: -O0 -g
-        PGVERSION: 9.6
-    - container:
-        image: ubuntu:20.04
-      env:
-        use_scan_build: yes
-    - arm_container:
-        image: ubuntu:20.04
-    - container:
-        image: ubuntu:22.04
-    - container:
-        image: debian:stable
-      env:
-        PGVERSION: 13
-    - container:
-        image: debian:oldstable
-      env:
-        PGVERSION: 11
+    # - container:
+    #     image: ubuntu:20.04
+    #   env:
+    #     ENABLE_VALGRIND: yes
+    #     CFLAGS: -O0 -g
+    #     PGVERSION: 9.6
+    # - container:
+    #     image: ubuntu:20.04
+    #   env:
+    #     use_scan_build: yes
+    # - arm_container:
+    #     image: ubuntu:20.04
+    # - container:
+    #     image: ubuntu:22.04
+    # - container:
+    #     image: debian:stable
+    #   env:
+    #     PGVERSION: 13
+    # - container:
+    #     image: debian:oldstable
+    #   env:
+    #     PGVERSION: 11
   setup_script:
     - apt-get update
     - apt-get -y install curl gnupg lsb-release
@@ -95,63 +95,63 @@ task:
       path: "config.log"
       type: text/plain
 
-task:
-  name: Linux (Red Hat)
-  container:
-    matrix:
-      - image: rockylinux:9
-      - image: rockylinux:8
-      - image: centos:centos7
-  setup_script:
-    - yum -y install autoconf automake diffutils file libevent-devel libtool make openssl-devel pkg-config postgresql-server systemd-devel wget
-    - if cat /etc/centos-release | grep -q ' 7'; then yum -y install python python-pip; else yum -y install python3 python3-pip sudo iptables; fi
-    - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
-    - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
-# XXX: python too old
-    - if cat /etc/centos-release | grep -q ' 7'; then true; else pip3 install -r requirements.txt; fi
-    - useradd user
-    - chown -R user .
-    - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-  build_script:
-    - su user -c "./autogen.sh"
-    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-systemd"
-    - su user -c "make -j4"
-  test_script:
-# XXX: postgresql too old on centos7
-    - if cat /etc/centos-release | grep -q ' 7'; then true; else su user -c "make -j4 check CONCURRENCY=4"; fi
-  install_script:
-    - make -j4 install
-  always:
-    configure_artifacts:
-      path: "config.log"
-      type: text/plain
+# task:
+#   name: Linux (Red Hat)
+#   container:
+#     matrix:
+#       - image: rockylinux:9
+#       - image: rockylinux:8
+#       - image: centos:centos7
+#   setup_script:
+#     - yum -y install autoconf automake diffutils file libevent-devel libtool make openssl-devel pkg-config postgresql-server systemd-devel wget
+#     - if cat /etc/centos-release | grep -q ' 7'; then yum -y install python python-pip; else yum -y install python3 python3-pip sudo iptables; fi
+#     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
+#     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
+# # XXX: python too old
+#     - if cat /etc/centos-release | grep -q ' 7'; then true; else pip3 install -r requirements.txt; fi
+#     - useradd user
+#     - chown -R user .
+#     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+#   build_script:
+#     - su user -c "./autogen.sh"
+#     - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-systemd"
+#     - su user -c "make -j4"
+#   test_script:
+# # XXX: postgresql too old on centos7
+#     - if cat /etc/centos-release | grep -q ' 7'; then true; else su user -c "make -j4 check CONCURRENCY=4"; fi
+#   install_script:
+#     - make -j4 install
+#   always:
+#     configure_artifacts:
+#       path: "config.log"
+#       type: text/plain
 
-task:
-  name: Linux (Alpine)
-  container:
-    matrix:
-      - image: alpine:latest
-  setup_script:
-    - apk update
-    - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 py3-pip wget sudo iptables
-    - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
-    - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
-    - python3 -m pip install -r requirements.txt
-    - adduser --disabled-password user
-    - chown -R user .
-    - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-  build_script:
-    - su user -c "./autogen.sh"
-    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror"
-    - su user -c "make -j4"
-  test_script:
-    - su user -c "make -j4 check CONCURRENCY=4"
-  install_script:
-    - make -j4 install
-  always:
-    configure_artifacts:
-      path: "config.log"
-      type: text/plain
+# task:
+#   name: Linux (Alpine)
+#   container:
+#     matrix:
+#       - image: alpine:latest
+#   setup_script:
+#     - apk update
+#     - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql python3 py3-pip wget sudo iptables
+#     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
+#     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
+#     - python3 -m pip install -r requirements.txt
+#     - adduser --disabled-password user
+#     - chown -R user .
+#     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+#   build_script:
+#     - su user -c "./autogen.sh"
+#     - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror"
+#     - su user -c "make -j4"
+#   test_script:
+#     - su user -c "make -j4 check CONCURRENCY=4"
+#   install_script:
+#     - make -j4 install
+#   always:
+#     configure_artifacts:
+#       path: "config.log"
+#       type: text/plain
 
 task:
   name: FreeBSD
@@ -226,8 +226,8 @@ task:
   matrix:
     - env:
         MSYSTEM: MINGW64
-    - env:
-        MSYSTEM: MINGW32
+    # - env:
+    #     MSYSTEM: MINGW32
   setup_script:
     - choco install -y --no-progress msys2
     - sh -l -c "pacman --noconfirm -S --needed base-devel ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-libevent ${MINGW_PACKAGE_PREFIX}-openssl ${MINGW_PACKAGE_PREFIX}-postgresql autoconf automake libtool ${MINGW_PACKAGE_PREFIX}-python ${MINGW_PACKAGE_PREFIX}-python-pip zip"


### PR DESCRIPTION
Cirrus is limiting free usage of its CI more to combat misuse for crypto
mining: https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/

This reduces the amount of jobs that we run to hopefully get CI to run
reasonably fast again.
