### PR TITLE
Fix errors pointed out by static analyzer

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -240,6 +240,9 @@ static bool admin_set(PgSocket *admin, const char *key, const char *val)
 		ok = set_config_param(key, val);
 		if (ok) {
 			PktBuf *buf = pktbuf_dynamic(256);
+			if (!buf) {
+				return admin_error(admin, "no mem");
+			}
 			if (strstr(key, "_tls_") != NULL) {
 				if (!sbuf_tls_setup())
 					pktbuf_write_Notice(buf, "TLS settings could not be applied, still using old configuration");

--- a/src/proto.c
+++ b/src/proto.c
@@ -485,7 +485,7 @@ static bool login_scram_sha_256_final(PgSocket *server, unsigned datalen, const 
 	if (!verify_server_signature(&server->scram_state, user, ServerSignature)) {
 		slog_error(server, "invalid server signature");
 		kill_pool_logins(server->pool, NULL, "server login failed: invalid server signature");
-		return false;
+		goto failed;
 	}
 
 	free(ibuf);
@@ -683,14 +683,17 @@ int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...)
 				int newlen;
 				if (strncmp(val, "\\x", 2) != 0) {
 					log_warning("invalid bytea value");
+					va_end(ap);
 					return -1;
 				}
 
 				newlen = (len - 2) / 2;
 				*len_p = newlen;
 				*bytes_p = malloc(newlen);
-				if (!(*bytes_p))
+				if (!(*bytes_p)) {
+					va_end(ap);
 					return -1;
+				}
 				for (int j = 0; j < newlen; j++) {
 					unsigned int b;
 					sscanf(val + 2 + 2 * j, "%2x", &b);

--- a/src/proto.c
+++ b/src/proto.c
@@ -628,15 +628,13 @@ int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...)
 
 		if (i < ncol) {
 			if (!mbuf_get_uint32be(pkt, &len)) {
-				va_end(ap);
-				return -1;
+				goto failed;
 			}
 			if ((int32_t)len < 0) {
 				val = NULL;
 			} else {
 				if (!mbuf_get_chars(pkt, len, &val)) {
-					va_end(ap);
-					return -1;
+					goto failed;
 				}
 			}
 
@@ -683,16 +681,14 @@ int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...)
 				int newlen;
 				if (strncmp(val, "\\x", 2) != 0) {
 					log_warning("invalid bytea value");
-					va_end(ap);
-					return -1;
+					goto failed;
 				}
 
 				newlen = (len - 2) / 2;
 				*len_p = newlen;
 				*bytes_p = malloc(newlen);
 				if (!(*bytes_p)) {
-					va_end(ap);
-					return -1;
+					goto failed;
 				}
 				for (int j = 0; j < newlen; j++) {
 					unsigned int b;
@@ -712,4 +708,7 @@ int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...)
 	va_end(ap);
 
 	return ncol;
+failed:
+	va_end(ap);
+	return -1;
 }

--- a/src/scram.c
+++ b/src/scram.c
@@ -934,8 +934,10 @@ static char *compute_server_signature(ScramState *state)
 		return NULL;
 	siglen = pg_b64_encode((const char *) ServerSignature,
 			       SCRAM_KEY_LEN, server_signature_base64, siglen);
-	if (siglen < 0)
+	if (siglen < 0) {
+		free(server_signature_base64);
 		return NULL;
+	}
 	server_signature_base64[siglen] = '\0';
 
 	return server_signature_base64;


### PR DESCRIPTION
A static analyzer found some errors -

1) Deref of Null - admin.c
>Return value of a function 'pktbuf_dynamic' is dereferenced at admin.c:245 without checking for NULL, but it is usually checked for this function (25/26).

2) Memory Leak - proto.c
>Dynamic memory, referenced by 'ibuf', is allocated at proto.c:474 by calling function 'malloc' and lost at proto.c:488.

3) Memory Leak - scram.c
>Dynamic memory, referenced by 'server_signature_base64', is allocated at scram.c:932 by calling function 'malloc' and lost at scram.c:938.

4) No VA End - proto.c : 686; 
>Function 'va_end' was not called before proto.c:686 inside function 'scan_text_result'. (Function 'va_start' was called at proto.c:624.)

5) No VA End - proto.c : 693
>Function 'va_end' was not called before proto.c:693 inside function 'scan_text_result'. (Function 'va_start' was called at proto.c:624.)

So here's proposed fixes