### PR TITLE
Only use positive numbers in the PID part of the cancel key

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1184,7 +1184,7 @@ different).  Example:
     1 = host=host1.example.com
     2 = host=/tmp/pgbouncer-2  port=5555
 
-Note: For peering to work, the `peer_id` of each PgBouncer process in the group
+Note 1: For peering to work, the `peer_id` of each PgBouncer process in the group
 must be unique within the peered group.  And the `[peers]` section should
 contain entries for each of those peer ids.  An example can be found in the
 examples section of these docs.  It **is** allowed, but not necessary, for the
@@ -1192,6 +1192,11 @@ examples section of these docs.  It **is** allowed, but not necessary, for the
 for. Such an entry will be ignored, but it is allowed to config management easy.
 Because it allows using the exact same `[peers]` section for multiple
 configs.
+
+Note 2: Cross-version peering is supported as long as all peers are on the same
+side of the v1.21.0 version boundary. In v1.21.0 some breaking changes were
+made in how we encode the cancellation tokens that made them incompatible with
+the ones created by earlier versions.
 
 ### host
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -1758,9 +1758,10 @@ void accept_cancel_request(PgSocket *req)
 	peering_enabled = cf_peer_id > 0;
 	if (peering_enabled) {
 		/*
-		 * Extract the peer id from the cancel key
+		 * Extract the peer id from the cancel key. The peer id is
+		 * stored in the 2nd and 3rd byte.
 		 */
-		int peer_id = req->cancel_key[0] + (req->cancel_key[1] << 8);
+		int peer_id = req->cancel_key[1] + (req->cancel_key[2] << 8);
 		bool needs_forwarding_to_peer = cf_peer_id != peer_id;
 		if (needs_forwarding_to_peer) {
 			accept_cancel_request_for_peer(peer_id, req);


### PR DESCRIPTION
We were using the full 64 bits of the BackendKeyData message as random
bytes. This turned out to be arguably incorrect, because the first 32
bits are used by PostgreSQL as a Process ID (and this is part of the
[protocol documentation too][1]). Actual PIDs are always positive, but
we also put a random bit in the sign bit so were setting it to negative
numbers half of the time. For most cases this does not matter, but it
turned out that [`pg_basebackup` relied on the PID part to actually be
positive][2].

While `pg_basebackup` is now fixed to support negative Process IDs, it
still seems good to adhere to this implicit requirement on positive
numbers in case other clients also depend on it.

Since this change requires changing the bytes of the cancel key in which
we encode the `peer_id`, this change breaks cancelations in peered
clusters of different PgBouncer versions. This seems like a minor
enough problem that we should not care about this. In practice this
should only happen during a rolling upgrade, which we currently don't
support well anyway (see #902 for improvements on that). And even if we
did, breaking cancellations for a few minutes in this transitional stage
doesn't seem like a huge deal.

[1]: https://www.postgresql.org/docs/current/protocol-message-formats.html
[2]: https://www.postgresql.org/message-id/flat/CAGECzQQOGvYfp8ziF4fWQ_o8s2K7ppaoWBQnTmdakn3s-4Z%3D5g%40mail.gmail.com
