### PR TITLE
Don't kill all waiting clients on temporary FATAL errors during login

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -22,6 +22,8 @@
 
 #include "bouncer.h"
 
+#define ERRCODE_CANNOT_CONNECT_NOW "57P03"
+
 static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
 {
 	const char *key, *val;
@@ -83,8 +85,15 @@ static void kill_pool_logins_server_error(PgPool *pool, PktHdr *errpkt)
 
 	parse_server_error(errpkt, &level, &msg, &sqlstate);
 	log_warning("server login failed: %s %s", level, msg);
-	log_noise("kill_pool_logins_server_error: sqlstate: %s", sqlstate);
-	kill_pool_logins(pool, sqlstate, msg);
+
+	/*
+	 * Kill all waiting clients unless it's a temporary error, such as
+	 * "database system is starting up".
+	 */
+	if (strcmp(sqlstate, ERRCODE_CANNOT_CONNECT_NOW) != 0) {
+		log_noise("kill_pool_logins_server_error: sqlstate: %s", sqlstate);
+		kill_pool_logins(pool, sqlstate, msg);
+	}
 }
 
 /* process packets on server auth phase */


### PR DESCRIPTION
If the server connection returns a FATAL error in the login phase we
kill all the waiting clients and show this error to the user. The reason
is that when this happens it's usually because of some configuration
error (e.g. pg_hba.conf on Postgres not being configured correctly).

But there are common cases where the error is temporary too, most
importantly: "the database system is starting up"

Postgres returns a specific error code for these types of errors. This
PR starts checking for that error code, and won't disconnect the clients
when it received a FATAL error from the server with that specific error
code.

The primary reason I spent time to fix this is because it was making
our tests flaky:
https://cirrus-ci.com/task/5607330616705024
