### PR TITLE
PgBouncer md5 FIPS compatibility changes

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -41,7 +41,7 @@ int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstl
  * password tools
  */
 #define MD5_PASSWD_LEN  35
-bool pg_md5_encrypt(const char *part1, const char *part2, size_t p2len, char *dest);
+bool pg_md5_encrypt(const char *part1, const char *part2, size_t p2len, char *dest) _MUSTCHECK;
 void get_random_bytes(uint8_t *dest, int len);
 
 const char *bin2hex(const uint8_t *src, unsigned srclen, char *dst, unsigned dstlen);

--- a/include/util.h
+++ b/include/util.h
@@ -41,7 +41,7 @@ int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstl
  * password tools
  */
 #define MD5_PASSWD_LEN  35
-void pg_md5_encrypt(const char *part1, const char *part2, size_t p2len, char *dest);
+bool pg_md5_encrypt(const char *part1, const char *part2, size_t p2len, char *dest);
 void get_random_bytes(uint8_t *dest, int len);
 
 const char *bin2hex(const uint8_t *src, unsigned srclen, char *dst, unsigned dstlen);

--- a/src/proto.c
+++ b/src/proto.c
@@ -348,7 +348,8 @@ static bool login_md5_psw(PgSocket *server, const uint8_t *salt)
 
 	switch (get_password_type(user->passwd)) {
 	case PASSWORD_TYPE_PLAINTEXT:
-		pg_md5_encrypt(user->passwd, user->name, strlen(user->name), txt);
+		if (!pg_md5_encrypt(user->passwd, user->name, strlen(user->name), txt))
+			return false;
 		src = txt + 3;
 		break;
 	case PASSWORD_TYPE_MD5:
@@ -360,7 +361,8 @@ static bool login_md5_psw(PgSocket *server, const uint8_t *salt)
 		return false;
 	}
 
-	pg_md5_encrypt(src, (char *)salt, 4, txt);
+	if (!pg_md5_encrypt(src, (char *)salt, 4, txt))
+		return false;
 
 	return send_password(server, txt);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -148,9 +148,8 @@ failed:
 
 	memcpy(dest, "md5", 3);
 	hash2hex(hash, dest + 3);
-	result = true;
+	return true;
 #endif
-	return result;
 }
 
 /* wrapped for getting random bytes */

--- a/src/util.c
+++ b/src/util.c
@@ -117,21 +117,15 @@ bool pg_md5_encrypt(const char *part1,
 	ERR_clear_error();
 	mdctx = EVP_MD_CTX_create();
 
-	if (EVP_DigestInit(mdctx, EVP_md5()) <= 0)
-	{
+	if (EVP_DigestInit(mdctx, EVP_md5()) <= 0) {
 		log_error("MD5 authentication: %s", ERR_reason_error_string(ERR_get_error()));
 		EVP_MD_CTX_free(mdctx);
-	}
-
-	else if (EVP_DigestUpdate(mdctx, part1, strlen(part1)) <= 0 ||
-		EVP_DigestUpdate(mdctx, part2, part2len) <= 0 ||
-		EVP_DigestFinal_ex(mdctx, hash, 0) <= 0 )
-	{
+	} else if (EVP_DigestUpdate(mdctx, part1, strlen(part1)) <= 0 ||
+		   EVP_DigestUpdate(mdctx, part2, part2len) <= 0 ||
+		   EVP_DigestFinal_ex(mdctx, hash, 0) <= 0) {
 		log_error("MD5 authentication: %s", ERR_reason_error_string(ERR_get_error()));
 		EVP_MD_CTX_destroy(mdctx);
-	}
-
-	else
+	} else
 	{
 		EVP_MD_CTX_destroy(mdctx);
 		memcpy(dest, "md5", 3);

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 
 noinst_PROGRAMS = hba_test
 hba_test_CPPFLAGS = -I../include $(LIBEVENT_CFLAGS)
-hba_test_LDADD = $(LIBEVENT_LIBS)
+hba_test_LDADD = $(LIBEVENT_LIBS) $(TLS_LIBS)
 hba_test_CFLAGS = -O0
 hba_test_SOURCES = hba_test.c ../src/hba.c ../src/util.c
 hba_test_EMBED_LIBUSUAL = 1


### PR DESCRIPTION
Root cause:

MD5 encryption functions are internally implemented in libusual (./lib/usual/crypto/md5.c). MD5 Authentication functions can not be used on FIPS compliant host. Due to internal implementation of MD5 algorithm, MD5 authentication is working without error on FIPS enabled host. Ideally it should throw error.

 Solution:

Due to internal implementation, we are not using openssl APIs for MD5. In this fix all internal MD5 calls are replaced to openssl APIs after which MD5 authentication throws expected error on FIPS compliant host.

Testing:

Pytest  testsuite ran successfully.
MD5 authentication scenario on non-FIPS compliant host runs successfully with and without compiling with “--without-openssl ” flag.
MD5 authentication scenario on FIPS compliant host errors out as expected when compiled with openssl flag.
MD5 authentication scenario on FIPS compliant host runs successfully when compiled with " “--without-openssl ” flag.