### PR TITLE
Allow tests to pass in FIPS mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ addopts = [
     "--showlocals",
     "--tb=short",
 ]
+markers = [
+    "md5: uses MD5, will fail in FIPS mode",
+]
 timeout = 30
 
 # The asyncio_mode setting doesn't work on outdated versions of pytest-asyncio.

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -7,6 +7,7 @@ import pytest
 from .utils import LONG_PASSWORD, PG_SUPPORTS_SCRAM, WINDOWS
 
 
+@pytest.mark.md5
 def test_auth_user(bouncer):
     bouncer.default_db = "authdb"
     bouncer.admin(f"set auth_type='md5'")
@@ -21,6 +22,7 @@ def test_auth_user(bouncer):
         bouncer.test(user="someuser", password="badpasswd")
 
 
+@pytest.mark.md5
 def test_auth_dbname_global(bouncer):
     bouncer.admin(f"set auth_dbname='authdb'")
     bouncer.admin(f"set auth_user='pswcheck'")
@@ -29,6 +31,7 @@ def test_auth_dbname_global(bouncer):
     bouncer.test(dbname="p7a", user="someuser", password="anypasswd")
 
 
+@pytest.mark.md5
 def test_auth_dbname_global_invalid(bouncer):
     bouncer.admin(f"set auth_dbname='p_unconfigured_auth_dbname'")
     bouncer.admin(f"set auth_type='md5'")
@@ -54,6 +57,7 @@ def test_auth_dbname_disabled(bouncer):
         bouncer.test(dbname="pauthz", user="someuser", password="anypasswd")
 
 
+@pytest.mark.md5
 def test_auth_dbname_with_auto_database(bouncer):
     with bouncer.ini_path.open() as f:
         original = f.read()
@@ -72,6 +76,7 @@ def test_auth_dbname_with_auto_database(bouncer):
     bouncer.test(dbname="postgres", user="someuser", password="anypasswd")
 
 
+@pytest.mark.md5
 def test_unconfigured_auth_database_with_auto_database(bouncer):
     """
     Tests the scenario where the authentication database does not
@@ -139,6 +144,7 @@ def test_password_server(bouncer):
     bouncer.test(dbname="p4l")
 
 
+@pytest.mark.md5
 def test_md5_server(bouncer):
     run_server_auth_test(bouncer, "p5")
 
@@ -160,6 +166,7 @@ def test_scram_server(bouncer):
         bouncer.test(dbname="p6z")
 
 
+@pytest.mark.md5
 def connect_with_password_client_users(bouncer):
     # good password
     bouncer.test(user="puser1", password="foo")
@@ -191,6 +198,7 @@ def connect_with_scram_client_users(bouncer):
 
 
 # Test plain-text password authentication from client to PgBouncer
+@pytest.mark.md5
 def test_password_client(bouncer):
     bouncer.admin(f"set auth_type='plain'")
     connect_with_password_client_users(bouncer)
@@ -206,6 +214,7 @@ def test_password_client(bouncer):
         bouncer.test(user="longpass", password="X" + LONG_PASSWORD)
 
 
+@pytest.mark.md5
 def test_md5_client(bouncer):
     bouncer.admin(f"set auth_type='md5'")
     connect_with_password_client_users(bouncer)
@@ -332,6 +341,7 @@ def test_auth_dbname_usage_global_setting(
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
+@pytest.mark.md5
 def test_auth_dbname_works_fine(
     bouncer,
 ):

--- a/test/test_no_database.py
+++ b/test/test_no_database.py
@@ -55,6 +55,7 @@ def test_no_database_scram_auth_scram_pw_success(bouncer):
             bouncer.test(dbname="nosuchdb", user="scramuser1", password="foo")
 
 
+@pytest.mark.md5
 def test_no_database_md5_auth_md5_pw_success(bouncer):
     # Testing what happens on successful MD5 auth with a MD5 pw connection to
     # non-existent DB Segfaults have been seen after mock authentication was


### PR DESCRIPTION
After c74d1cd, the test suite will not pass if OpenSSL is in FIPS mode.  To allow the test suite to pass anyway, mark affected tests with the "md5" pytest marker.  That way, these tests can be skipped, e.g., with `pytest -m 'not md5'`.

---

Further thoughts:
* [Here](https://www.postgresql.org/message-id/c8f11f3c-c267-1f62-f90c-619b8fae9013%40enterprisedb.com) is an analogous discussion for core PostgreSQL. There, the proposed patch checks first if the `md5()` function works. We don't have such an option for PgBouncer, I think, hence the manual toggle.
* We could also do an environment-variable based skip, like for sudo, but I think the marker approach is more native to pytest.
* Some of these tests could probably be rewritten to not use md5 (use scram instead), since they are not really testing md5 but just some other aspect of authentication. (Similar changes are being made to the core PostgreSQL test suites.)