### PR TITLE
Remove final mention of UDNS

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -718,7 +718,7 @@ If it notices changes, all host names under that zone
 are looked up again.  If any host IP changes, its connections
 are invalidated.
 
-Works only with UDNS and c-ares backends (`configure` option `--with-cares`).
+Works only with c-ares backend (`configure` option `--with-cares`).
 
 Default: 0.0 (disabled)
 


### PR DESCRIPTION
We removed support for UDNS, but it was still referenced in one part of
the docs.
