### PR TITLE
Handle DEALLOCATE ALL and DISCARD ALL for prepared statements

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -326,12 +326,11 @@ prepared on the server yet, it automatically prepares that statement before
 forwarding the command that the client sent.
 
 Note: This tracking and rewriting of prepared statement commands does not work
-for SQL-level prepared statement commands such as `PREPARE`, `EXECUTE`,
-`DEALLOCATE`, `DEALLOCATE ALL` and `DISCARD ALL`. Running `DEALLOCATE ALL` and
-`DISCARD ALL` is especially problematic, since those commands appear to run
-successfully, but they mess up with the state of the server connection
-significantly without PgBouncer noticing. Which in turn will very likely break
-the execution of any further prepared statements on that server connection.
+for SQL-level prepared statement commands, so `PREPARE`, `EXECUTE` and
+`DEALLOCATE` are forwarded straight to Postgres. The exception to this rule are
+the `DEALLOCATE ALL` and `DISCARD ALL` commands, these do work as expected and
+will clear the prepared statements that PgBouncer tracked for the client that
+sends this command.
 
 The actual value of this setting controls the number of prepared statements
 kept active on a single server connection. When the setting is set to 0

--- a/src/server.c
+++ b/src/server.c
@@ -365,6 +365,20 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (client)
 				client->expect_rfq_count = 0;
 		}
+		if (is_prepared_statements_enabled(server->pool)
+		    && (pkt->len == 1 + 4 + 15 || pkt->len == 1 + 4 + 12)) {	/* size of complete DEALLOCATE/DISCARD ALL */
+			const char *tag;
+			if (mbuf_get_string(&pkt->data, &tag)) {
+				if (strcmp(tag, "DEALLOCATE ALL") == 0 ||
+				    strcmp(tag, "DISCARD ALL") == 0) {
+					free_server_prepared_statements(server);
+					if (client)
+						free_client_prepared_statements(client);
+				}
+			} else {
+				return false;
+			}
+		}
 		pop_outstanding_request(server, "E", &ignore_packet);
 
 		break;

--- a/src/server.c
+++ b/src/server.c
@@ -365,6 +365,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (client)
 				client->expect_rfq_count = 0;
 		}
+		/*
+		 * Clean up prepared statements if needed if the client sent a
+		 * DEALLOCATE ALL or a DISCARD ALL query. Not doing so would
+		 * confuse our prepared statement handling, because we would
+		 * expect certain queries to be prepared at the server that are
+		 * not.
+		 */
 		if (is_prepared_statements_enabled(server->pool)
 		    && (pkt->len == 1 + 4 + 15 || pkt->len == 1 + 4 + 12)) {	/* size of complete DEALLOCATE/DISCARD ALL */
 			const char *tag;

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -79,7 +79,8 @@ def test_deallocate_all(bouncer):
             # client 1
             with bouncer.log_contains("prepared statement did not exist"):
                 with pytest.raises(
-                    psycopg.OperationalError, match="prepared statement did not exist|server closed the connection unexpectedly"
+                    psycopg.OperationalError,
+                    match="prepared statement did not exist|server closed the connection unexpectedly",
                 ):
                     cur1.execute(prepared_query)
 
@@ -108,7 +109,8 @@ def test_discard_all(bouncer):
             # client 1
             with bouncer.log_contains("prepared statement did not exist"):
                 with pytest.raises(
-                    psycopg.OperationalError, match="prepared statement did not exist|server closed the connection unexpectedly"
+                    psycopg.OperationalError,
+                    match="prepared statement did not exist|server closed the connection unexpectedly",
                 ):
                     cur1.execute(prepared_query)
 

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -75,14 +75,40 @@ def test_deallocate_all(bouncer):
             # Run the prepared query again on server 2 and client 2
             cur2.execute(prepared_query)
 
+            # Confirm that the prepared query is not available anymore on
+            # client 1
+            with pytest.raises(
+                psycopg.OperationalError, match="prepared statement did not exist"
+            ):
+                cur1.execute(prepared_query)
+
+
+def test_discard_all(bouncer):
+    bouncer.admin(f"set pool_mode=transaction")
+    bouncer.admin(f"set max_prepared_statements=100")
+    prepared_query = "SELECT 1"
+    with bouncer.cur() as cur1:
+        with bouncer.cur() as cur2:
             # prepare query on client 1
-            cur1.execute(prepared_query2, prepare=True)
+            cur1.execute(prepared_query, prepare=True)
+            # Run the prepared query again on same server and client
+            cur1.execute(prepared_query)
+
+            # prepared query for client 2
+            cur2.execute(prepared_query, prepare=True)
 
             # execute DISCARD ALL on client 1
-            cur2.execute("DISCARD ALL")
+            cur1.execute("DISCARD ALL")
 
-            # Run the prepared query again on client 2
-            cur2.execute(prepared_query2)
+            # Run the prepared query again on server 2 and client 2
+            cur2.execute(prepared_query)
+
+            # Confirm that the prepared query is not available anymore on
+            # client 1
+            with pytest.raises(
+                psycopg.OperationalError, match="prepared statement did not exist"
+            ):
+                cur1.execute(prepared_query)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -57,28 +57,32 @@ def test_prepared_statement_params(bouncer):
 def test_deallocate_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     bouncer.admin(f"set max_prepared_statements=100")
-    prepared_query = "SELECT %s"
+    prepared_query = "SELECT 1"
+    prepared_query2 = "SELECT 2"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
-            # prepare query on server 1 and client 1
-            cur1.execute(prepared_query, params=(1,), prepare=True)
-            # prepare query on server 2 and client 2
-            cur2.execute(prepared_query, params=(1,), prepare=True)
+            # prepare query on client 1
+            cur1.execute(prepared_query, prepare=True)
+            # Run the prepared query again on same server and client
+            cur1.execute(prepared_query)
 
-            # execute DEALLOCATE ALL on server 1
+            # prepared query for client 2
+            cur2.execute(prepared_query, prepare=True)
+
+            # execute DEALLOCATE ALL on client 1
             cur1.execute("DEALLOCATE ALL")
 
             # Run the prepared query again on server 2 and client 2
-            cur2.execute(prepared_query, params=(1,))
+            cur2.execute(prepared_query)
 
-            # prepare query on server 1 and client 1
-            cur1.execute(prepared_query, params=(2,), prepare=True)
+            # prepare query on client 1
+            cur1.execute(prepared_query2, prepare=True)
 
-            # execute DISCARD ALL on server 2
+            # execute DISCARD ALL on client 1
             cur2.execute("DISCARD ALL")
 
-            # Run the prepared query again on server 1 and client 1
-            cur1.execute(prepared_query, params=(2,))
+            # Run the prepared query again on client 2
+            cur2.execute(prepared_query2)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -53,6 +53,7 @@ def test_prepared_statement_params(bouncer):
                 # prepared query for this different client.
                 cur2.execute(prepared_query, params=(1,), prepare=True)
 
+
 def test_deallocate_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     bouncer.admin(f"set max_prepared_statements=100")
@@ -64,7 +65,7 @@ def test_deallocate_all(bouncer):
             # prepare query on server 2 and client 2
             cur2.execute(prepared_query, params=(1,), prepare=True)
 
-            #execute DEALLOCATE ALL on server 1
+            # execute DEALLOCATE ALL on server 1
             cur1.execute("DEALLOCATE ALL")
 
             # Run the prepared query again on server 2 and client 2
@@ -73,11 +74,12 @@ def test_deallocate_all(bouncer):
             # prepare query on server 1 and client 1
             cur1.execute(prepared_query, params=(2,), prepare=True)
 
-            #execute DISCARD ALL on server 2
+            # execute DISCARD ALL on server 2
             cur2.execute("DISCARD ALL")
 
             # Run the prepared query again on server 1 and client 1
             cur1.execute(prepared_query, params=(2,))
+
 
 def test_parse_larger_than_pkt_buf(bouncer):
     bouncer.admin(f"set max_prepared_statements=100")

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -77,10 +77,11 @@ def test_deallocate_all(bouncer):
 
             # Confirm that the prepared query is not available anymore on
             # client 1
-            with pytest.raises(
-                psycopg.OperationalError, match="prepared statement did not exist"
-            ):
-                cur1.execute(prepared_query)
+            with bouncer.log_contains("prepared statement did not exist"):
+                with pytest.raises(
+                    psycopg.OperationalError, match="prepared statement did not exist|server closed the connection unexpectedly"
+                ):
+                    cur1.execute(prepared_query)
 
 
 def test_discard_all(bouncer):
@@ -105,10 +106,11 @@ def test_discard_all(bouncer):
 
             # Confirm that the prepared query is not available anymore on
             # client 1
-            with pytest.raises(
-                psycopg.OperationalError, match="prepared statement did not exist"
-            ):
-                cur1.execute(prepared_query)
+            with bouncer.log_contains("prepared statement did not exist"):
+                with pytest.raises(
+                    psycopg.OperationalError, match="prepared statement did not exist|server closed the connection unexpectedly"
+                ):
+                    cur1.execute(prepared_query)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -58,7 +58,6 @@ def test_deallocate_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     bouncer.admin(f"set max_prepared_statements=100")
     prepared_query = "SELECT 1"
-    prepared_query2 = "SELECT 2"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
             # prepare query on client 1

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -53,6 +53,31 @@ def test_prepared_statement_params(bouncer):
                 # prepared query for this different client.
                 cur2.execute(prepared_query, params=(1,), prepare=True)
 
+def test_deallocate_all(bouncer):
+    bouncer.admin(f"set pool_mode=transaction")
+    bouncer.admin(f"set max_prepared_statements=100")
+    prepared_query = "SELECT %s"
+    with bouncer.cur() as cur1:
+        with bouncer.cur() as cur2:
+            # prepare query on server 1 and client 1
+            cur1.execute(prepared_query, params=(1,), prepare=True)
+            # prepare query on server 2 and client 2
+            cur2.execute(prepared_query, params=(1,), prepare=True)
+
+            #execute DEALLOCATE ALL on server 1
+            cur1.execute("DEALLOCATE ALL")
+
+            # Run the prepared query again on server 2 and client 2
+            cur2.execute(prepared_query, params=(1,))
+
+            # prepare query on server 1 and client 1
+            cur1.execute(prepared_query, params=(2,), prepare=True)
+
+            #execute DISCARD ALL on server 2
+            cur2.execute("DISCARD ALL")
+
+            # Run the prepared query again on server 1 and client 1
+            cur1.execute(prepared_query, params=(2,))
 
 def test_parse_larger_than_pkt_buf(bouncer):
     bouncer.admin(f"set max_prepared_statements=100")


### PR DESCRIPTION
This implements a hacky/clever approach of handling the `DEALLOCATE ALL` and `DISCARD ALL` SQL statements. Instead of parsing the queries themselves, which PgBouncer avoids doing completely, this parses the CommandComplete packet returned by the server.

Fixes https://github.com/prisma/prisma/issues/21635
Fixes #974 