### PR TITLE
Support configuring auth_query per database

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1170,7 +1170,7 @@ Override of the global `auth_user` setting, if specified.
 
 ### auth_query
 
-Override of the global `auth_query` setting, if specified. The entire SQL statement needs to be enclosed in double quotes.
+Override of the global `auth_query` setting, if specified. The entire SQL statement needs to be enclosed in single quotes.
 
 ### pool_size
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1169,6 +1169,10 @@ If no password is specified here, the password from the `auth_file` or
 
 Override of the global `auth_user` setting, if specified.
 
+### auth_query
+
+Override of the global `auth_auery` setting, if specified. The entire SQL statement needs to be enclosed in quotes.
+
 ### pool_size
 
 Set the maximum size of pools for this database.  If not set,

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -528,6 +528,7 @@ struct PgDatabase {
 	char *auth_dbname;	/* if not NULL, auth_query will be run on the specified database */
 	PgUser *forced_user;	/* if not NULL, the user/psw is forced */
 	PgUser *auth_user;	/* if not NULL, users not in userlist.txt will be looked up on the server */
+	char *auth_query; /* if not NULL, will be used to fetch password from database. */
 
 	/*
 	 * run-time state

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -528,7 +528,7 @@ struct PgDatabase {
 	char *auth_dbname;	/* if not NULL, auth_query will be run on the specified database */
 	PgUser *forced_user;	/* if not NULL, the user/psw is forced */
 	PgUser *auth_user;	/* if not NULL, users not in userlist.txt will be looked up on the server */
-	char *auth_query; /* if not NULL, will be used to fetch password from database. */
+	char *auth_query;	/* if not NULL, will be used to fetch password from database. */
 
 	/*
 	 * run-time state

--- a/src/client.c
+++ b/src/client.c
@@ -167,7 +167,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 {
 	int res;
 	PktBuf *buf;
-	const char *auth_query = client->db->auth_query ? client->db->auth_query : cf_auth_query; 
+	const char *auth_query = client->db->auth_query ? client->db->auth_query : cf_auth_query;
 
 	/* have to fetch user info from db */
 	PgDatabase *auth_db = prepare_auth_database(client);

--- a/src/client.c
+++ b/src/client.c
@@ -178,7 +178,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 		client->wait_for_user_conn = true;
 		return;
 	}
-	slog_noise(client, "doing auth_conn query");
+	slog_noise(client, "doing auth_conn query: %s", auth_query);
 	client->wait_for_user_conn = false;
 	client->wait_for_user = true;
 	if (!sbuf_pause(&client->sbuf)) {

--- a/src/client.c
+++ b/src/client.c
@@ -167,12 +167,12 @@ static void start_auth_query(PgSocket *client, const char *username)
 {
 	int res;
 	PktBuf *buf;
+	const char *auth_query = client->db->auth_query ? client->db->auth_query : cf_auth_query; 
 
 	/* have to fetch user info from db */
 	PgDatabase *auth_db = prepare_auth_database(client);
 	if (!auth_db)
 		return;
-
 	client->pool = get_pool(auth_db, client->db->auth_user);
 	if (!find_server(client)) {
 		client->wait_for_user_conn = true;
@@ -191,7 +191,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 	res = 0;
 	buf = pktbuf_dynamic(512);
 	if (buf) {
-		pktbuf_write_ExtQuery(buf, cf_auth_query, 1, username);
+		pktbuf_write_ExtQuery(buf, auth_query, 1, username);
 		res = pktbuf_send_immediate(buf, client->link);
 		pktbuf_free(buf);
 		/*

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -827,6 +827,9 @@ void kill_database(PgDatabase *db)
 	if (db->auth_dbname)
 		free((void *)db->auth_dbname);
 
+	if (db->auth_query)
+		free((void *)db->auth_query);
+
 	aatree_destroy(&db->user_tree);
 	slab_free(db_cache, db);
 }

--- a/src/loader.c
+++ b/src/loader.c
@@ -134,22 +134,22 @@ static bool strings_equal(const char *str_left, const char *str_right)
 	return strcmp(str_left, str_right) == 0;
 }
 
-static bool set_auth_dbname(PgDatabase *db, const char *new_auth_dbname)
+static bool set_value(char **old_value, const char *new_value)
 {
-	if (strings_equal(db->auth_dbname, new_auth_dbname))
+	if (strings_equal(*old_value, new_value))
 		return true;
 
-	if (db->auth_dbname)
-		free(db->auth_dbname);
+	if (*old_value)
+		free(*old_value);
 
-	if (new_auth_dbname) {
-		db->auth_dbname = strdup(new_auth_dbname);
-		if (!db->auth_dbname) {
-			log_error("auth_dbname %s could not be set for database %s, out of memory", new_auth_dbname, db->name);
+	if (new_value) {
+		*old_value = strdup(new_value);
+		if (!(*old_value)) {
+			log_error("out of memory");
 			return false;
 		}
 	} else {
-		db->auth_dbname = NULL;
+		*old_value = NULL;
 	}
 
 	return true;
@@ -279,6 +279,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	char *timezone = NULL;
 	char *connect_query = NULL;
 	char *appname = NULL;
+	char *auth_query = NULL;
 
 	cv.value_p = &pool_mode;
 	cv.extra = (const void *)pool_mode_map;
@@ -357,6 +358,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			}
 		} else if (strcmp("application_name", key) == 0) {
 			appname = val;
+		} else if (strcmp("auth_query", key) == 0){
+			auth_query = val;
 		} else {
 			log_error("unrecognized connection parameter: %s", key);
 			goto fail;
@@ -394,6 +397,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			changed = true;
 		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
 			changed = true;
+		} else if (!strings_equal(db->auth_query, auth_query)){
+			changed = true;
 		}
 		if (changed)
 			tag_database_dirty(db);
@@ -410,7 +415,10 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	free(db->connect_query);
 	db->connect_query = connect_query;
 
-	if (!set_auth_dbname(db, auth_dbname))
+	if (!set_value(&db->auth_dbname, auth_dbname))
+		goto fail;
+	
+	if (!set_value(&(db->auth_query), auth_query))
 		goto fail;
 
 	if (db->startup_params) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -421,7 +421,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	if (!set_value(&db->auth_dbname, auth_dbname))
 		goto fail;
 	
-	if (!set_value(&(db->auth_query), auth_query))
+	if (!set_value(&db->auth_query, auth_query))
 		goto fail;
 
 	if (db->startup_params) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -361,7 +361,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			}
 		} else if (strcmp("application_name", key) == 0) {
 			appname = val;
-		} else if (strcmp("auth_query", key) == 0){
+		} else if (strcmp("auth_query", key) == 0) {
 			auth_query = val;
 		} else {
 			log_error("unrecognized connection parameter: %s", key);
@@ -400,7 +400,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			changed = true;
 		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
 			changed = true;
-		} else if (!strings_equal(db->auth_query, auth_query)){
+		} else if (!strings_equal(db->auth_query, auth_query)) {
 			changed = true;
 		}
 		if (changed)
@@ -420,7 +420,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 
 	if (!set_value(&db->auth_dbname, auth_dbname))
 		goto fail;
-	
+
 	if (!set_value(&db->auth_query, auth_query))
 		goto fail;
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -137,7 +137,7 @@ static bool strings_equal(const char *str_left, const char *str_right)
 /*
  * Free the old value and set the new value
  */
-static bool set_value(char **old_value, const char *new_value)
+static bool set_param_value(char **old_value, const char *new_value)
 {
 	if (strings_equal(*old_value, new_value))
 		return true;
@@ -418,10 +418,10 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	free(db->connect_query);
 	db->connect_query = connect_query;
 
-	if (!set_value(&db->auth_dbname, auth_dbname))
+	if (!set_param_value(&db->auth_dbname, auth_dbname))
 		goto fail;
 
-	if (!set_value(&db->auth_query, auth_query))
+	if (!set_param_value(&db->auth_query, auth_query))
 		goto fail;
 
 	if (db->startup_params) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -134,6 +134,9 @@ static bool strings_equal(const char *str_left, const char *str_right)
 	return strcmp(str_left, str_right) == 0;
 }
 
+/*
+ * Free the old value and set the new value
+ */
 static bool set_value(char **old_value, const char *new_value)
 {
 	if (strings_equal(*old_value, new_value))

--- a/test/README.md
+++ b/test/README.md
@@ -4,21 +4,21 @@ Tests
 ## Setting up Python dependencies for testing
 
 To be able to run most of the tests you need to install a few python tools.  To
-do so, you should run the following from of the root of the repository:
+do so, you should run the following from the root of the repository:
 
 ```bash
 pip3 install --user -r requirements.txt
 ```
 
 This will install the packages globally on your system, if you don't want to do
-that (or if tests are still not working after the above command) you can use a
+that (or if tests are still not working after executing the above command) you can use a
 [virtual environment][1] instead:
 ```bash
 # create a virtual environment (only needed once)
 python3 -m venv env
 
 # activate the environment. You will need to activate this environment in
-# your shell every time you want to run the tests. (so needed once per
+# your shell every time you want to run the tests. (so it's needed once per
 # shell).
 source env/bin/activate
 
@@ -47,7 +47,7 @@ Optionally, this test suite can use `iptables`/`pfctl` to simulate various
 network conditions.  To include these tests, set the environment variable
 USE_SUDO to a nonempty value, for example `make check USE_SUDO=1`.  This will
 ask for sudo access, so it might convenient to run `sudo -v` before the test, or
-set up `/etc/sudoers` appropriately at your peril.  Check the source if there
+set up `/etc/sudoers` appropriately, at your peril.  Check the source if there
 are any doubts.
 
 This test is run by `make check`.
@@ -89,4 +89,4 @@ to build, then see `run-conntest.sh` how to run the different pieces.
 
 ### `stress.py`
 
-Stress test, see source for details.  Requires Python and `psycopg2` module.
+Stress test, see source code for details.  Requires Python and `psycopg2` module.

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -368,7 +368,10 @@ def test_auth_query_database_setting(
     with bouncer.run_with_config(config):
         with bouncer.run_with_config(config):
             bouncer.sql(
-                query="select version()", user="stats", password="stats", dbname="postgres"
+                query="select version()",
+                user="stats",
+                password="stats",
+                dbname="postgres",
             )
 
     config = f"""
@@ -394,7 +397,10 @@ def test_auth_query_database_setting(
         ):
             with bouncer.run_with_config(config):
                 bouncer.sql(
-                    query="select version()", user="stats", password="stats", dbname="postgres"
+                    query="select version()",
+                    user="stats",
+                    password="stats",
+                    dbname="postgres",
                 )
 
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -353,7 +353,7 @@ def test_auth_query_database_setting(
         postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
             host={bouncer.pg.host} port={bouncer.pg.port}
         [pgbouncer]
-        auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+        auth_query = SELECT 1
         auth_user = pswcheck
         stats_users = stats
         listen_addr = {bouncer.host}

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -341,6 +341,62 @@ def test_auth_dbname_usage_global_setting(
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
+def test_auth_query_database_setting(
+    bouncer,
+):
+    # """
+    # Check that pgbouncer can use auth_query in database section to get password
+    # """
+
+    config = f"""
+        [databases]
+        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'
+        [pgbouncer]
+        auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+    """
+
+    with bouncer.run_with_config(config):
+        with bouncer.run_with_config(config):
+            bouncer.sql(
+                query="select version()", user="stats", password="stats", dbname="postgres"
+            )
+
+    config = f"""
+        [databases]
+        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1'
+        [pgbouncer]
+        auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+    """
+
+    with bouncer.run_with_config(config):
+        with pytest.raises(
+            psycopg.OperationalError, match="password authentication failed"
+            ): 
+            with bouncer.run_with_config(config):
+                bouncer.sql(
+                    query="select version()", user="stats", password="stats", dbname="postgres"
+                )
+
+
+@pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 @pytest.mark.md5
 def test_auth_dbname_works_fine(
     bouncer,

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -350,7 +350,8 @@ def test_auth_query_database_setting(
 
     config = f"""
         [databases]
-        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port}
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck
@@ -372,7 +373,8 @@ def test_auth_query_database_setting(
 
     config = f"""
         [databases]
-        postgres = auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port}
+        postgres = auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -344,13 +344,13 @@ def test_auth_dbname_usage_global_setting(
 def test_auth_query_database_setting(
     bouncer,
 ):
-    # """
-    # Check the pgbouncer can use auth_query in database section to get password
-    # """
+    """
+    Check the pgbouncer can use auth_query in database section to get password
+    """
 
     config = f"""
         [databases]
-        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port} 
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port}
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck
@@ -372,7 +372,7 @@ def test_auth_query_database_setting(
 
     config = f"""
         [databases]
-        postgres = auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port} 
+        postgres = auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port}
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck
@@ -389,7 +389,7 @@ def test_auth_query_database_setting(
     with bouncer.run_with_config(config):
         with pytest.raises(
             psycopg.OperationalError, match="password authentication failed"
-            ): 
+        ):
             with bouncer.run_with_config(config):
                 bouncer.sql(
                     query="select version()", user="stats", password="stats", dbname="postgres"

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -345,12 +345,12 @@ def test_auth_query_database_setting(
     bouncer,
 ):
     # """
-    # Check that pgbouncer can use auth_query in database section to get password
+    # Check the pgbouncer can use auth_query in database section to get password
     # """
 
     config = f"""
         [databases]
-        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port} 
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck
@@ -372,7 +372,7 @@ def test_auth_query_database_setting(
 
     config = f"""
         [databases]
-        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1'
+        postgres = auth_query='SELECT usename, substring(passwd,1,3) FROM pg_shadow where usename = $1' host={bouncer.pg.host} port={bouncer.pg.port} 
         [pgbouncer]
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = pswcheck


### PR DESCRIPTION
This adds support for allowing specifing a different auth_query for different databases. This is useful if the auth_query needs to contain an encryption key that can differ per database.

Fixes #910