### PR TITLE
Improve recommended systemd unit file

### DIFF
--- a/etc/pgbouncer.service
+++ b/etc/pgbouncer.service
@@ -25,7 +25,8 @@
 Description=connection pooler for PostgreSQL
 Documentation=man:pgbouncer(1)
 Documentation=https://www.pgbouncer.org/
-After=network.target
+After=network-online.target
+Wants=network-online.target
 #Requires=pgbouncer.socket
 
 [Service]


### PR DESCRIPTION
Replace network.target with network-online.target. Postgres already did it [1]. Issue #980 suggests that if you are using DNS and, for some reason, the PgBouncer starts before the network finishes the initialization, it is unable to resolve names; the solution is to restart the service if it occurs (which is a unfortunate workaround).

According to man 7 systemd.special [2]:

Note the distinction between this unit and network.target. This unit is an active unit (i.e.  pulled in by the consumer rather than the provider of this functionality) and pulls in a service which possibly adds substantial delays to further execution. In contrast, network.target is a passive unit (i.e. pulled in by the provider of the functionality, rather than the consumer) that usually does not delay execution much.

It could delay the service start up to $timeout (default is 90 seconds). Hence, PgBouncer won't accept connections until the network is ready and it is time to start the service. It seems a good tradeoff to wait until the network is ready then to fail a setup that uses DNS. (If you don't use DNS and cannot afford waiting the network to be ready and wants to accept client connections ASAP, then edit the systemd unit file and revert this change.)

Fixes #980

[1] https://github.com/postgres/postgres/commit/2d27e13b35
[2] https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/