### PR TITLE
DOC: Prepared Statements: mention LRU Cache

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -333,10 +333,10 @@ will clear the prepared statements that PgBouncer tracked for the client that
 sends this command.
 
 The actual value of this setting controls the number of prepared statements
-kept active on a single server connection. When the setting is set to 0
-prepared statement support for transaction and statement pooling is disabled.
-To get the best performance you should try to make sure that this setting is
-larger than the amount of commonly used prepared statements in your
+kept active in a LRU cache on a single server connection. When the setting is 
+set to 0 prepared statement support for transaction and statement pooling is
+disabled. To get the best performance you should try to make sure that this 
+setting is larger than the amount of commonly used prepared statements in your
 application. Keep in mind that the higher this value, the larger the memory
 footprint of each PgBouncer connection will be on your PostgreSQL server,
 because it will keep more queries prepared on those connections. It also

--- a/doc/config.md
+++ b/doc/config.md
@@ -333,7 +333,7 @@ will clear the prepared statements that PgBouncer tracked for the client that
 sends this command.
 
 The actual value of this setting controls the number of prepared statements
-kept active in a LRU cache on a single server connection. When the setting is 
+kept active in an LRU cache on a single server connection. When the setting is 
 set to 0 prepared statement support for transaction and statement pooling is
 disabled. To get the best performance you should try to make sure that this 
 setting is larger than the amount of commonly used prepared statements in your


### PR DESCRIPTION
I was curious about this as a new user, and couldn't find any documentation on how prepared statements are cached. Looked into the source code (https://github.com/pgbouncer/pgbouncer/blob/6c7730e2e9f2a5710292a5535e17dbb8882679ff/src/prepare.c#L230) and it appears a Least Recently Used (LRU) cache is used. This is useful information for users.