### PR TITLE
Introduce auth_ident_file setting and enhance cert and peer auth methods with user name maps

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -449,13 +449,15 @@ pam
 
 ### auth_hba_file
 
-HBA configuration file to use when `auth_type` is `hba`.
+HBA configuration file to use when `auth_type` is `hba`. See
+section [HBA file format](#hba-file-format) below about details.
 
 Default: not set
 
 ### auth_ident_file
 
-Identity map file to use when `auth_type` is `hba` and a user map will be defined.
+Identity map file to use when `auth_type` is `hba` and a user map will be defined.  See
+section [Ident map file format](#ident-map-file-format) below about details.
 
 Default: not set
 
@@ -1419,8 +1421,20 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 * Address field: Supports IPv4, IPv6.  Not supported: DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`
   are supported, plus `peer` and `reject`, but except `any` and `pam`, which only work globally.
-  User name map (`map=`) parameter is not supported.
+* User name map (`map = `) parameter is only supported for `auth_type` `cert`.
 
+## Ident map file format
+
+The location of the ident map file is specified by the setting
+`auth_ident_file`. It is only loaded if `auth_type` is set to `hba`.
+
+The file format is a simplified variation of the PostgreSQL ident map file
+(see <https://www.postgresql.org/docs/current/auth-username-maps.html>).
+
+* Supported lines are only of the form `map-name system-username database-username`.
+* There is no support for including file/directory.
+* System-username field: Not supported: regular expressions.
+* Database-username field: Supports `all` or a single postgres user name. Not supported: `+groupname`, multiple names.
 
 ## Examples
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1421,7 +1421,7 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 * Address field: Supports IPv4, IPv6.  Not supported: DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`
   are supported, plus `peer` and `reject`, but except `any` and `pam`, which only work globally.
-* User name map (`map = `) parameter is only supported for `auth_type` `cert`.
+* User name map (`map=`) parameter is only supported for `auth_type` `cert`.
 
 ## Ident map file format
 
@@ -1434,7 +1434,7 @@ The file format is a simplified variation of the PostgreSQL ident map file
 * Supported lines are only of the form `map-name system-username database-username`.
 * There is no support for including file/directory.
 * System-username field: Not supported: regular expressions.
-* Database-username field: Supports `all` or a single postgres user name. Not supported: `+groupname`, multiple names, regular expressions.
+* Database-username field: Supports `all` or a single postgres user name. Not supported: `+groupname`, regular expressions.
 
 ## Examples
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1434,7 +1434,7 @@ The file format is a simplified variation of the PostgreSQL ident map file
 * Supported lines are only of the form `map-name system-username database-username`.
 * There is no support for including file/directory.
 * System-username field: Not supported: regular expressions.
-* Database-username field: Supports `all` or a single postgres user name. Not supported: `+groupname`, multiple names.
+* Database-username field: Supports `all` or a single postgres user name. Not supported: `+groupname`, multiple names, regular expressions.
 
 ## Examples
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -453,7 +453,7 @@ HBA configuration file to use when `auth_type` is `hba`.
 
 Default: not set
 
-### auth_pgident_file
+### auth_ident_file
 
 Identity map file to use when `auth_type` is `hba` and a user map will be defined.
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1421,7 +1421,7 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 * Address field: Supports IPv4, IPv6.  Not supported: DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`
   are supported, plus `peer` and `reject`, but except `any` and `pam`, which only work globally.
-* User name map (`map=`) parameter is only supported for `auth_type` `cert`.
+* User name map (`map=`) parameter is supported when `auth_type` is `cert` or `peer`. 
 
 ## Ident map file format
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -453,6 +453,12 @@ HBA configuration file to use when `auth_type` is `hba`.
 
 Default: not set
 
+### auth_pgident_file
+
+Identity map file to use when `auth_type` is `hba` and a user map will be defined.
+
+Default: not set
+
 ### auth_file
 
 The name of the file to load user names and passwords from.  See

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -125,6 +125,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Path to HBA-style auth config
 ;auth_hba_file =
 
+;; Path to Pg-ident-style map file
+; auth_pgident_file =
+
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.
 ;auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -126,7 +126,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;auth_hba_file =
 
 ;; Path to Pg-ident-style map file
-; auth_pgident_file =
+; auth_ident_file =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/include/hba.h
+++ b/include/hba.h
@@ -15,6 +15,9 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+
+#define NAME_ALL        1
+
 enum RuleType {
 	RULE_LOCAL,
 	RULE_HOST,
@@ -52,6 +55,7 @@ struct IDENTMap {
 	char *map_name;
 	char *system_user_name;
 	char *postgres_user_name;
+	unsigned int name_flags;
 };
 
 struct IDENT {

--- a/include/hba.h
+++ b/include/hba.h
@@ -15,9 +15,51 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+enum RuleType {
+	RULE_LOCAL,
+	RULE_HOST,
+	RULE_HOSTSSL,
+	RULE_HOSTNOSSL,
+};
 
-struct HBA;
+struct NameSlot {
+	size_t strlen;
+	char str[];
+};
+struct HBAName {
+	unsigned int flags;
+	struct StrSet *name_set;
+};
 
-struct HBA *hba_load_rules(const char *fn);
+struct HBARule {
+	struct List node;
+	enum RuleType rule_type;
+	int rule_method;
+	int rule_af;
+	uint8_t rule_addr[16];
+	uint8_t rule_mask[16];
+	struct HBAName db_name;
+	struct HBAName user_name;
+	struct IDENTMap *identmap;
+};
+
+struct HBA {
+	struct List rules;
+};
+
+struct IDENTMap {
+	struct List node;
+	char *map_name;
+	char *system_user_name;
+	char *postgres_user_name;
+};
+
+struct IDENT {
+	struct List maps;
+};
+
+struct IDENT *ident_load_map(const char *fn);
+void ident_free(struct IDENT *ident);
+struct HBA *hba_load_rules(const char *fn, struct IDENT *ident);
 void hba_free(struct HBA *hba);
-int hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username);
+struct HBARule *hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username);

--- a/include/hba.h
+++ b/include/hba.h
@@ -17,6 +17,7 @@
  */
 
 #define NAME_ALL        1
+#define NAME_SAMEUSER   2
 
 enum RuleType {
 	RULE_LOCAL,

--- a/include/hba.h
+++ b/include/hba.h
@@ -44,27 +44,32 @@ struct HBARule {
 	uint8_t rule_mask[16];
 	struct HBAName db_name;
 	struct HBAName user_name;
-	struct IDENTMap *identmap;
+	struct IdentMap *identmap;
 };
 
 struct HBA {
 	struct List rules;
 };
 
-struct IDENTMap {
+struct Mapping {
 	struct List node;
-	char *map_name;
 	char *system_user_name;
 	char *postgres_user_name;
 	unsigned int name_flags;
 };
 
-struct IDENT {
+struct IdentMap {
+	struct List node;
+	char *map_name;
+	struct List mappings;
+};
+
+struct Ident {
 	struct List maps;
 };
 
-struct IDENT *ident_load_map(const char *fn);
-void ident_free(struct IDENT *ident);
-struct HBA *hba_load_rules(const char *fn, struct IDENT *ident);
+struct Ident *ident_load_map(const char *fn);
+void ident_free(struct Ident *ident);
+struct HBA *hba_load_rules(const char *fn, struct Ident *ident);
 void hba_free(struct HBA *hba);
 struct HBARule *hba_eval(struct HBA *hba, PgAddr *addr, bool is_tls, const char *dbname, const char *username);

--- a/include/hba.h
+++ b/include/hba.h
@@ -45,6 +45,7 @@ struct HBARule {
 	struct HBAName db_name;
 	struct HBAName user_name;
 	struct IdentMap *identmap;
+	int hba_linenr;
 };
 
 struct HBA {

--- a/src/client.c
+++ b/src/client.c
@@ -328,6 +328,8 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 			return false;
 		}
 
+		slog_noise(client, "HBA Line %d is matched", rule->hba_linenr);
+
 		auth = rule->rule_method;
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -306,8 +306,6 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		if (!rule)
 			return false;
 
-		log_warning("hba_eval returned Ident map %s %s %s", rule->identmap->map_name, rule->identmap->system_user_name, rule->identmap->postgres_user_name);
-
 		auth = rule->rule_method;
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -276,7 +276,10 @@ static bool login_as_unix_peer(PgSocket *client, struct HBARule *rule)
 			mapping = container_of(el, struct Mapping, node);
 
 			if (check_unix_peer_name(sbuf_socket(&client->sbuf), mapping->system_user_name)) {
-				if (!strcmp(mapping->postgres_user_name, client->login_user->name)) {
+				if ((mapping->name_flags & NAME_ALL) ||
+				    strcmp(mapping->postgres_user_name, client->login_user->name) == 0) {
+					slog_noise(client, "ident map '%s' is applied", rule->identmap->map_name);
+
 					mapped = true;
 					break;
 				}

--- a/src/hba.c
+++ b/src/hba.c
@@ -601,7 +601,8 @@ static bool parse_ident_line(struct Ident *ident, struct TokParser *tp, int line
 	next_token(tp);
 
 	if (!expect(tp, TOK_IDENT, &system_user_name)) {
-		goto failed;
+		if (!expect(tp, TOK_STRING, &system_user_name))
+			goto failed;
 	}
 
 	mapping->system_user_name = strdup(system_user_name);

--- a/src/hba.c
+++ b/src/hba.c
@@ -756,6 +756,7 @@ static bool parse_line(struct HBA *hba, struct Ident *ident, struct TokParser *t
 		goto failed;
 	}
 
+	rule->hba_linenr = linenr;
 	list_append(&hba->rules, &rule->node);
 	return true;
 failed:

--- a/src/hba.c
+++ b/src/hba.c
@@ -630,6 +630,7 @@ static bool parse_ident_line(struct Ident *ident, struct TokParser *tp, int line
 
 	if (find_ident_map(ident, map_name_copy, &ident_map)) {
 		list_append(&ident_map->mappings, &mapping->node);
+		free(map_name_copy);
 	} else {
 		ident_map = calloc(sizeof *ident_map, 1);
 

--- a/src/hba.c
+++ b/src/hba.c
@@ -509,8 +509,6 @@ static bool parse_map_definition(struct HBARule *rule, struct Ident *ident, stru
 	if (!expect(tp, TOK_IDENT, &str))
 		return true;
 
-	log_noise("hba line %d: map definition : %s", linenr, str);
-
 	val = strchr(str, '=');
 
 	if (val == NULL || strncmp(str, "map=", 4) != 0) {
@@ -519,8 +517,6 @@ static bool parse_map_definition(struct HBARule *rule, struct Ident *ident, stru
 	}
 
 	val++;
-
-	log_noise("hba line %d: map name : %s", linenr, val);
 
 	next_token(tp);
 

--- a/src/hba.c
+++ b/src/hba.c
@@ -24,8 +24,6 @@
 #include <usual/socket.h>
 #include <usual/string.h>
 
-#define NAME_SAMEUSER   2
-
 /*
  * StrSet
  */

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ int cf_tcp_user_timeout;
 int cf_auth_type = AUTH_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
-char *cf_auth_pgident_file;
+char *cf_auth_ident_file;
 char *cf_auth_user;
 char *cf_auth_query;
 char *cf_auth_dbname;
@@ -239,7 +239,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_dbname", CF_AUTHDB, cf_auth_dbname, 0, NULL),
 	CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
-	CF_ABS("auth_pgident_file", CF_STR, cf_auth_pgident_file, 0, NULL),
+	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
@@ -450,7 +450,7 @@ void load_config(void)
 		struct IDENT *ident;
 		struct HBA *hba;
 
-		ident = ident_load_map(cf_auth_pgident_file);
+		ident = ident_load_map(cf_auth_ident_file);
 
 		if (ident) {
 			if (parsed_ident)
@@ -890,7 +890,7 @@ static void cleanup(void)
 	xfree(&cf_unix_socket_dir);
 	xfree(&cf_unix_socket_group);
 	xfree(&cf_auth_file);
-	xfree(&cf_auth_pgident_file);
+	xfree(&cf_auth_ident_file);
 	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_hba_file);
 	xfree(&cf_auth_query);

--- a/src/main.c
+++ b/src/main.c
@@ -453,8 +453,7 @@ void load_config(void)
 		ident = ident_load_map(cf_auth_ident_file);
 
 		if (ident) {
-			if (parsed_ident)
-				ident_free(parsed_ident);
+			ident_free(parsed_ident);
 			parsed_ident = ident;
 		}
 
@@ -871,6 +870,8 @@ static void cleanup(void)
 	adns = NULL;
 	hba_free(parsed_hba);
 	parsed_hba = NULL;
+	ident_free(parsed_ident);
+	parsed_ident = NULL;
 
 	admin_cleanup();
 	objects_cleanup();

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,7 @@ struct event_base *pgb_event_base;
 struct DNSContext *adns;
 
 struct HBA *parsed_hba;
+struct IDENT *parsed_ident;
 
 /*
  * configuration storage
@@ -113,6 +114,7 @@ int cf_tcp_user_timeout;
 int cf_auth_type = AUTH_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
+char *cf_auth_pgident_file;
 char *cf_auth_user;
 char *cf_auth_query;
 char *cf_auth_dbname;
@@ -237,6 +239,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_dbname", CF_AUTHDB, cf_auth_dbname, 0, NULL),
 	CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
+	CF_ABS("auth_pgident_file", CF_STR, cf_auth_pgident_file, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
@@ -444,7 +447,19 @@ void load_config(void)
 	}
 
 	if (cf_auth_type == AUTH_HBA) {
-		struct HBA *hba = hba_load_rules(cf_auth_hba_file);
+		struct IDENT *ident;
+		struct HBA *hba;
+
+		ident = ident_load_map(cf_auth_pgident_file);
+
+		if (ident) {
+			if (parsed_ident)
+				ident_free(parsed_ident);
+			parsed_ident = ident;
+		}
+
+		hba = hba_load_rules(cf_auth_hba_file, parsed_ident);
+
 		if (hba) {
 			hba_free(parsed_hba);
 			parsed_hba = hba;
@@ -875,6 +890,7 @@ static void cleanup(void)
 	xfree(&cf_unix_socket_dir);
 	xfree(&cf_unix_socket_group);
 	xfree(&cf_auth_file);
+	xfree(&cf_auth_pgident_file);
 	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_hba_file);
 	xfree(&cf_auth_query);

--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,7 @@ struct event_base *pgb_event_base;
 struct DNSContext *adns;
 
 struct HBA *parsed_hba;
-struct IDENT *parsed_ident;
+struct Ident *parsed_ident;
 
 /*
  * configuration storage
@@ -447,7 +447,7 @@ void load_config(void)
 	}
 
 	if (cf_auth_type == AUTH_HBA) {
-		struct IDENT *ident;
+		struct Ident *ident;
 		struct HBA *hba;
 
 		ident = ident_load_map(cf_auth_ident_file);

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -68,7 +68,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	const char *addr=NULL, *user=NULL, *db=NULL, *tls=NULL, *exp=NULL;
 	PgAddr pgaddr;
 	struct HBARule *rule;
-	int res;
+	int res = 0;
 
 	if (ln[0] == '#')
 		return 0;

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -67,6 +67,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 {
 	const char *addr=NULL, *user=NULL, *db=NULL, *tls=NULL, *exp=NULL;
 	PgAddr pgaddr;
+	struct HBARule *rule;
 	int res;
 
 	if (ln[0] == '#')
@@ -84,14 +85,27 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	if (!pga_pton(&pgaddr, addr, 9999))
 		die("hbatest: invalid addr on line #%d", linenr);
 
-	res = hba_eval(hba, &pgaddr, !!tls, db, user);
-	if (strcmp(method2string(res), exp) == 0) {
-		res = 0;
+	rule = hba_eval(hba, &pgaddr, !!tls, db, user);
+
+	if (!rule) {
+	       if (strcmp("reject", exp) == 0) {
+		       	res = 0;
+	       } else {
+			log_warning("FAIL on line %d: No rule for user=%s db=%s addr=%s",
+                            linenr, user, db, addr);
+			res = 1;
+	       }
+
 	} else {
-		log_warning("FAIL on line %d: expected '%s' got '%s' - user=%s db=%s addr=%s",
+		if (strcmp(method2string(rule->rule_method), exp) == 0) {
+			res = 0;
+		} else {
+			log_warning("FAIL on line %d: expected '%s' got '%s' - user=%s db=%s addr=%s",
 			    linenr, exp, method2string(res), user, db, addr);
-		res = 1;
+			res = 1;
+		}
 	}
+
 	return res;
 }
 
@@ -105,7 +119,7 @@ static void hba_test(void)
 	int linenr;
 	int nfailed = 0;
 
-	hba = hba_load_rules("hba_test.rules");
+	hba = hba_load_rules("hba_test.rules", NULL);
 	if (!hba)
 		die("hbatest: did not find config");
 

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -7,8 +7,8 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl all             all             ::/0                    md5
 
 hostssl p0y             all             0.0.0.0/0               cert    map=test2
-hostssl p0x            	all	        0.0.0.0/0               cert    map=test
-hostssl p0           	bouncer         0.0.0.0/0               cert
+hostssl p0x             all             0.0.0.0/0               cert    map=test
+hostssl p0              bouncer         0.0.0.0/0               cert
 
 hostssl all             all		192.168.1.1/0		md5
 

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -5,7 +5,8 @@ hostssl all             postgres        ::/0                    reject
 hostssl all             postgres        0.0.0.0/0               reject
 #
 hostssl all             all             ::/0                    md5
-hostssl all             all             0.0.0.0/0               cert    map = test
+hostssl all             someuser        0.0.0.0/0               cert    map = test
+hostssl all             anotheruser     0.0.0.0/0               cert    map = test2
 
 hostssl all             all		192.168.1.1/0		md5
 

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -5,8 +5,8 @@ hostssl all             postgres        ::/0                    reject
 hostssl all             postgres        0.0.0.0/0               reject
 #
 hostssl all             all             ::/0                    md5
-hostssl all             someuser        0.0.0.0/0               cert    map = test
-hostssl all             anotheruser     0.0.0.0/0               cert    map = test2
+hostssl all             someuser        0.0.0.0/0               cert    map=test
+hostssl all             anotheruser     0.0.0.0/0               cert    map=test2
 
 hostssl all             all		192.168.1.1/0		md5
 

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -1,0 +1,11 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             postgres                                peer
+# do not let the "postgres" superuser login via a certificate
+hostssl all             postgres        ::/0                    reject
+hostssl all             postgres        0.0.0.0/0               reject
+#
+hostssl all             all             ::/0                    md5
+hostssl all             all             0.0.0.0/0               cert    map = test
+
+hostssl all             all		192.168.1.1/0		md5
+

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -5,9 +5,10 @@ hostssl all             postgres        ::/0                    reject
 hostssl all             postgres        0.0.0.0/0               reject
 #
 hostssl all             all             ::/0                    md5
-hostssl all             someuser        0.0.0.0/0               cert    map=test
-hostssl all             anotheruser     0.0.0.0/0               cert    map=test2
-hostssl all             bouncer		0.0.0.0/0               cert
+
+hostssl p0y             all             0.0.0.0/0               cert    map=test2
+hostssl p0x            	all	        0.0.0.0/0               cert    map=test
+hostssl p0           	bouncer         0.0.0.0/0               cert
 
 hostssl all             all		192.168.1.1/0		md5
 

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -7,6 +7,7 @@ hostssl all             postgres        0.0.0.0/0               reject
 hostssl all             all             ::/0                    md5
 hostssl all             someuser        0.0.0.0/0               cert    map=test
 hostssl all             anotheruser     0.0.0.0/0               cert    map=test2
+hostssl all             bouncer		0.0.0.0/0               cert
 
 hostssl all             all		192.168.1.1/0		md5
 

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -5,5 +5,5 @@
 test		pgbouncer.acme.org	someuser
 test		pgbouncer.acme.org	anotheruser
 test2		"bouncer"		all
-test2           pgbouncer.acme.org    "anotheruser"
+test2		pgbouncer.acme.org	"anotheruser"
 

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -3,3 +3,4 @@
 
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 test		pgbouncer.acme.org	someuser
+test2		bouncer			all

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -4,6 +4,6 @@
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 test		pgbouncer.acme.org	someuser
 test		pgbouncer.acme.org	anotheruser
-test2		bouncer			all
-test2           pgbouncer.acme.org      "anotheruser"
+test2		"bouncer"		all
+test2           pgbouncer.acme.org    "anotheruser"
 

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -3,4 +3,7 @@
 
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 test		pgbouncer.acme.org	someuser
+test		pgbouncer.acme.org	anotheruser
 test2		bouncer			all
+test2           pgbouncer.acme.org      "anotheruser"
+

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -1,0 +1,5 @@
+# PostgreSQL User Name Maps
+# =========================
+
+# MAPNAME       SYSTEM-USERNAME         PG-USERNAME
+test		pgbouncer.acme.org	someuser

--- a/test/ssl/create_certs.sh
+++ b/test/ssl/create_certs.sh
@@ -7,5 +7,6 @@ rm -rf TestCA1 TestCA2
 ./newsite.sh TestCA1 localhost C=QQ O=Org1 L=computer OU=db
 ./newsite.sh TestCA1 bouncer C=QQ O=Org1 L=computer OU=Dev
 ./newsite.sh TestCA1 random C=QQ O=Org1 L=computer OU=Dev
+./newsite.sh TestCA1 pgbouncer.acme.org C=QQ O=Org1 L=computer OU=Dev
 ./newca.sh TestCA2 C=QQ O=Org2 CN="TestCA2"
 ./newsite.sh TestCA2 localhost C=QQ O=Org1 L=computer OU=db

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -5,7 +5,7 @@ import time
 import psycopg
 import pytest
 
-from .utils import LONG_PASSWORD, PG_SUPPORTS_SCRAM, WINDOWS
+from .utils import LONG_PASSWORD, PG_SUPPORTS_SCRAM, TLS_SUPPORT, WINDOWS
 
 
 @pytest.mark.md5
@@ -578,6 +578,7 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
+@pytest.mark.skipif(not TLS_SUPPORT, reason="pgbouncer is built without TLS support")
 def test_client_hba_cert(bouncer, cert_dir):
     root = cert_dir / "TestCA1" / "ca.crt"
     key = cert_dir / "TestCA1" / "sites" / "01-localhost.key"

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -607,7 +607,7 @@ def test_client_hba_cert(bouncer, cert_dir):
 
     # The client connects to p0 DB using a client certificate with CN=pgbouncer.acme.org.
     # hba_eval returns the followign line:
-    #    hostssl all             someuser        0.0.0.0/0               cert    map = test
+    #    hostssl all             someuser        0.0.0.0/0               cert    map=test
     # where "test" map is defined in pgident.conf as
     #    test            pgbouncer.acme.org      someuser
     # hence the test succeeds.
@@ -624,7 +624,7 @@ def test_client_hba_cert(bouncer, cert_dir):
 
     # The client connects to p0 DB using a client certificate with CN="pgbouncer.acme.org".
     # hba_eval returns the followign line:
-    #    hostssl all             anotheruser     0.0.0.0/0               cert    map = test2
+    #    hostssl all             anotheruser     0.0.0.0/0               cert    map=test2
     # where "test2" map is defined in pgident.conf as
     #    test2           bouncer                 all
     # CN expected in map is "bouncer" which does not match the CN="pgbouncer.acme.org" in client cert
@@ -648,12 +648,12 @@ def test_client_hba_cert(bouncer, cert_dir):
 
     # The client connects to p0 DB using a client certificate with CN=bouncer.
     # hba_eval returns the followign line:
-    #    hostssl all             anotheruser     0.0.0.0/0               cert    map = test2
+    #    hostssl all             anotheruser     0.0.0.0/0               cert    map=test2
     # where "test2" map is defined in pgident.conf as
     #    test2           bouncer                 all
     # CN expected in map is "bouncer" which matches the CN in the client cert
     # hence the test succeeds.
-    with bouncer.log_contains("hba_eval returned Ident map test2 bouncer all"):
+    with bouncer.log_contains("hba_eval returned Ident map test2 bouncer "):
         bouncer.psql_test(
             host="localhost",
             user="anotheruser",

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -582,13 +582,14 @@ def test_client_hba_cert(bouncer, cert_dir):
     key = cert_dir / "TestCA1" / "sites" / "01-localhost.key"
     cert = cert_dir / "TestCA1" / "sites" / "01-localhost.crt"
 
-
     bouncer.write_ini(f"client_tls_key_file = {key}")
     bouncer.write_ini(f"client_tls_cert_file = {cert}")
     bouncer.write_ini(f"client_tls_ca_file = {root}")
     bouncer.write_ini(f"client_tls_sslmode = require")
     bouncer.write_ini(f"auth_type = hba")
-    bouncer.write_ini(f"auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1")
+    bouncer.write_ini(
+        f"auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1"
+    )
     bouncer.write_ini(f"auth_user = pswcheck")
     bouncer.write_ini(f"auth_file = {bouncer.auth_path}")
     bouncer.write_ini(f"auth_hba_file = pgbouncer_hba.conf")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -751,13 +751,13 @@ def test_client_hba_cert(bouncer, cert_dir):
 def test_peer_auth_ident_map(bouncer):
     cur_user = getpass.getuser()
 
-    with open("ident.conf", "w") as f:
+    with open(bouncer.config_dir / "ident.conf", "w") as f:
         f.write(f"mymap {cur_user} postgres\n")
         f.write(f"mymap {cur_user} someuser\n")
 
     bouncer.write_ini(f"auth_ident_file = ident.conf")
 
-    with open("hba.conf", "w") as f:
+    with open(bouncer.config_dir / "hba.conf", "w") as f:
         f.write(f"local   all  all peer map=mymap")
 
     bouncer.write_ini(f"auth_type = hba")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -497,6 +497,7 @@ def test_hba_leak(bouncer):
     bouncer.admin("reload")
     bouncer.admin("reload")
 
+<<<<<<< HEAD
 async def test_change_server_password_reconnect(bouncer, pg):
     bouncer.default_db = "p4"
     bouncer.admin(f"set default_pool_size=1")
@@ -576,6 +577,8 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
                 await result3
     finally:
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
+=======
+>>>>>>> 50f0051 (Doc and format)
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 @pytest.mark.skipif(not TLS_SUPPORT, reason="pgbouncer is built without TLS support")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -747,7 +747,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     )
 
 
-@pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
+@pytest.mark.skipif("WINDOWS", reason="Windows does not have peer authentication")
 def test_peer_auth_ident_map(bouncer):
     cur_user = getpass.getuser()
 
@@ -794,3 +794,14 @@ def test_peer_auth_ident_map(bouncer):
                 host=f"{bouncer.admin_host}",
                 user="bouncer",
             )
+
+    with open("ident.conf", "w") as f:
+        f.write(f"mymap {cur_user} all")
+
+    bouncer.admin("reload")
+
+    bouncer.psql_test(
+        dbname="p0",
+        host=f"{bouncer.admin_host}",
+        user="bouncer",
+    )

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -751,13 +751,13 @@ def test_client_hba_cert(bouncer, cert_dir):
 def test_peer_auth_ident_map(bouncer):
     cur_user = getpass.getuser()
 
-    with open(bouncer.config_dir / "ident.conf", "w") as f:
+    with open("ident.conf", "w") as f:
         f.write(f"mymap {cur_user} postgres\n")
         f.write(f"mymap {cur_user} someuser\n")
 
     bouncer.write_ini(f"auth_ident_file = ident.conf")
 
-    with open(bouncer.config_dir / "hba.conf", "w") as f:
+    with open("hba.conf", "w") as f:
         f.write(f"local   all  all peer map=mymap")
 
     bouncer.write_ini(f"auth_type = hba")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -497,7 +497,7 @@ def test_hba_leak(bouncer):
     bouncer.admin("reload")
     bouncer.admin("reload")
 
-<<<<<<< HEAD
+
 async def test_change_server_password_reconnect(bouncer, pg):
     bouncer.default_db = "p4"
     bouncer.admin(f"set default_pool_size=1")
@@ -577,8 +577,7 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
                 await result3
     finally:
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
-=======
->>>>>>> 50f0051 (Doc and format)
+
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 @pytest.mark.skipif(not TLS_SUPPORT, reason="pgbouncer is built without TLS support")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -6,7 +6,7 @@ import time
 import psycopg
 import pytest
 
-from .utils import LONG_PASSWORD, PG_SUPPORTS_SCRAM, TLS_SUPPORT, WINDOWS
+from .utils import LONG_PASSWORD, MACOS, PG_SUPPORTS_SCRAM, TLS_SUPPORT, WINDOWS
 
 
 @pytest.mark.md5
@@ -580,6 +580,7 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
 
 
+@pytest.mark.skipif("MACOS", reason="SSL tests are broken on OSX in CI #1031")
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 @pytest.mark.skipif(not TLS_SUPPORT, reason="pgbouncer is built without TLS support")
 def test_client_hba_cert(bouncer, cert_dir):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -593,7 +593,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     bouncer.write_ini(f"auth_user = pswcheck")
     bouncer.write_ini(f"auth_file = {bouncer.auth_path}")
     bouncer.write_ini(f"auth_hba_file = pgbouncer_hba.conf")
-    bouncer.write_ini(f"auth_pgident_file = pgident.conf")
+    bouncer.write_ini(f"auth_ident_file = pgident.conf")
 
     bouncer.admin("reload")
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -751,13 +751,14 @@ def test_client_hba_cert(bouncer, cert_dir):
 def test_peer_auth_ident_map(bouncer):
     cur_user = getpass.getuser()
 
-    with open("ident.conf", "w") as f:
+    ident_conf_file = bouncer.config_dir / "ident.conf"
+    hba_conf_file = bouncer.config_dir / "hba.conf"
+
+    with open(ident_conf_file, "w") as f:
         f.write(f"mymap {cur_user} postgres\n")
         f.write(f"mymap {cur_user} someuser\n")
 
-    bouncer.write_ini(f"auth_ident_file = ident.conf")
-
-    with open("hba.conf", "w") as f:
+    with open(hba_conf_file, "w") as f:
         f.write(f"local   all  all peer map=mymap")
 
     bouncer.write_ini(f"auth_type = hba")
@@ -766,8 +767,8 @@ def test_peer_auth_ident_map(bouncer):
     )
     bouncer.write_ini(f"auth_user = pswcheck")
     bouncer.write_ini(f"auth_file = {bouncer.auth_path}")
-
-    bouncer.write_ini(f"auth_hba_file = hba.conf")
+    bouncer.write_ini(f"auth_hba_file = {hba_conf_file}")
+    bouncer.write_ini(f"auth_ident_file = {ident_conf_file}")
 
     bouncer.admin("reload")
 
@@ -795,7 +796,7 @@ def test_peer_auth_ident_map(bouncer):
                 user="bouncer",
             )
 
-    with open("ident.conf", "w") as f:
+    with open(ident_conf_file, "w") as f:
         f.write(f"mymap {cur_user} all")
 
     bouncer.admin("reload")


### PR DESCRIPTION
Postgres supports user name maps[1] for `cert`  and `peer` authentication methods. This change provides the same functionality with some limitations for pgbouncer. The limitations are listed in "Ident map file format" section of the docs.

1. https://www.postgresql.org/docs/current/auth-username-maps.html

Fixes #767
Fixes #148
