### PR TITLE
Improve connection fail fast logic

### DIFF
--- a/test/test.ini
+++ b/test/test.ini
@@ -34,6 +34,7 @@ hostlist1 = port=6666 host=127.0.0.1,::1 dbname=p0 user=bouncer
 hostlist2 = port=6666 host=127.0.0.1,127.0.0.1 dbname=p0 user=bouncer
 
 varcache_change = port=6666 host=127.0.0.1 dbname=p0 client_encoding=SQL_ASCII
+non_existing_pg_db = port=6666 host=127.0.0.1 dbname=non_existing_pg_db
 
 ; commented out except for auto-database tests
 ;* = port=6666 host=127.0.0.1

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -495,3 +495,84 @@ def test_hba_leak(bouncer):
 
     bouncer.admin("reload")
     bouncer.admin("reload")
+
+
+async def test_change_server_password_reconnect(bouncer, pg):
+    bouncer.default_db = "p4"
+    bouncer.admin(f"set default_pool_size=1")
+    bouncer.admin(f"set pool_mode=transaction")
+    try:
+        # good password, opens connection
+        bouncer.test()
+        pg.sql("ALTER USER puser1 PASSWORD 'bar'")
+        # works fine because server connection is still open
+        bouncer.test()
+        with bouncer.transaction() as cur1:
+            # Claim the connection
+            cur1.execute("select 1")
+            # Because of our fast client closure on server auth failures (see
+            # kill_pool_logins), we should only have one connection failing at
+            # the postgres side. But we should still have 3 failing at the
+            # pgbouncer side.
+            with pg.log_contains(
+                r"password authentication failed", times=1
+            ), bouncer.log_contains(
+                r"closing because: password authentication failed for user", times=3
+            ):
+                result1 = bouncer.atest()
+                result2 = bouncer.atest()
+                result3 = bouncer.atest()
+
+                # Mark the old connection as dirty
+                bouncer.admin("reconnect")
+                # Trigger new connection creation
+                bouncer.admin(f"set default_pool_size=2")
+                with pytest.raises(
+                    psycopg.OperationalError, match="password authentication failed"
+                ):
+                    await result1
+                with pytest.raises(
+                    psycopg.OperationalError, match="password authentication failed"
+                ):
+                    await result2
+                with pytest.raises(
+                    psycopg.OperationalError, match="password authentication failed"
+                ):
+                    await result3
+    finally:
+        pg.sql("ALTER USER puser1 PASSWORD 'foo'")
+
+
+async def test_change_server_password_server_lifetime(bouncer, pg):
+    bouncer.default_db = "p4"
+    bouncer.admin(f"set default_pool_size=1")
+    bouncer.admin(f"set pool_mode=transaction")
+    bouncer.admin(f"set server_lifetime=1")
+    try:
+        # good password, opens connection
+        bouncer.test()
+        pg.sql("ALTER USER puser1 PASSWORD 'bar'")
+        # wait until server disconnect
+        time.sleep(3)
+
+        # Because of our fast client closure on server auth failures (see
+        # kill_pool_logins), we should only have one connection failing at
+        # the postgres side. But we should still have 3 failing at the
+        # pgbouncer side.
+        with pg.log_contains(
+            r"password authentication failed", times=1
+        ), bouncer.log_contains(
+            r"closing because: password authentication failed for user", times=3
+        ):
+            result1 = bouncer.atest()
+            result2 = bouncer.atest()
+            result3 = bouncer.atest()
+
+            with pytest.raises(psycopg.OperationalError):
+                await result1
+            with pytest.raises(psycopg.OperationalError):
+                await result2
+            with pytest.raises(psycopg.OperationalError):
+                await result3
+    finally:
+        pg.sql("ALTER USER puser1 PASSWORD 'foo'")

--- a/test/utils.py
+++ b/test/utils.py
@@ -635,6 +635,26 @@ class Postgres(QueryRunner):
         """
         self.sql(f"alter system set {config}")
 
+    @contextmanager
+    def log_contains(self, re_string, times=None):
+        """Checks if during this with block the log matches re_string
+
+        re_string:
+            The regex to search for.
+        times:
+            If None, any number of matches is accepted. If a number, only that
+            specific number of matches is accepted.
+        """
+        with self.log_path.open() as f:
+            f.seek(0, os.SEEK_END)
+            yield
+            content = f.read()
+            if times is None:
+                assert re.search(re_string, content)
+            else:
+                match_count = len(re.findall(re_string, content))
+                assert match_count == times
+
 
 class Bouncer(QueryRunner):
     def __init__(


### PR DESCRIPTION
For a very long time, we've had logic to quickly close all clients when
the a server could not be connected to.

This wasn't working correctly in all cases, one of those was when an
`auth_user` was set (and no `auth_db`). This was reported in #989.

While looking closer into that issue I realized it also wouldn't handle
cases where first connecting worked but then after a while it doesn't
anymore, because it relied only on `wait_for_welcome`. It's not strictly
necessary to kill all waiting connections when creating new server
connections is not possible anymore, as long as there are still working
server connections. But if those don't exist either, then we're
effectively in the same state as complete refresh (except that we have
cached the welcome message).

Fixes #989
Fixes #985
