### PR TITLE
Fix handling of empty application_name

### DIFF
--- a/src/varcache.c
+++ b/src/varcache.c
@@ -156,7 +156,7 @@ static int apply_var(PktBuf *pkt, const char *key,
 	const char *tmp;
 
 	/* if unset, skip */
-	if (!cval || !sval || !*cval->str)
+	if (!cval || !sval)
 		return 0;
 
 	/* if equal, skip */

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -223,3 +223,15 @@ def test_options_startup_param(bouncer):
         )
         == "Portugal"
     )
+
+
+def test_empty_application_name(bouncer):
+    with bouncer.cur(dbname="p1", application_name="") as cur:
+        assert cur.execute("SHOW application_name").fetchone()[0] == ""
+        cur.execute("SET application_name = test")
+        assert cur.execute("SHOW application_name").fetchone()[0] == "test"
+
+    with bouncer.cur(dbname="p1", application_name="") as cur:
+        assert cur.execute("SHOW application_name").fetchone()[0] == ""
+        cur.execute("SET application_name = test")
+        assert cur.execute("SHOW application_name").fetchone()[0] == "test"


### PR DESCRIPTION
It was reported in #993 that using an empty `application_name` on
connection startup could result in the actual `application_name` that was
set later not being detected. The reason was that we were explicitely
not forwarding empty strings from clients as settings to Postgres. This
is fixed by simply removing this check. Why we were explicitely ignoring
empty strings is not clear to me. One possible reason is because when
this code was introduced, the empty string was an invalid value for
all of the supported startup parameters. But our handling of startup
parameters and GUCs has heavily changed over the years, and is
able to handle them fine like this and the empty string is a valid
value for `application_name`.

Fixes #993
