### PR TITLE
Fix false positive reported by valgrind when using hba

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -446,10 +446,12 @@ void load_config(void)
 	if (cf_auth_type == AUTH_HBA) {
 		struct HBA *hba = hba_load_rules(cf_auth_hba_file);
 		if (hba) {
-			if (parsed_hba)
-				hba_free(parsed_hba);
+			hba_free(parsed_hba);
 			parsed_hba = hba;
 		}
+	} else {
+		hba_free(parsed_hba);
+		parsed_hba = NULL;
 	}
 
 	/* kill dbs */
@@ -852,6 +854,8 @@ static void cleanup(void)
 	}
 	adns_free_context(adns);
 	adns = NULL;
+	hba_free(parsed_hba);
+	parsed_hba = NULL;
 
 	admin_cleanup();
 	objects_cleanup();

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -475,3 +475,23 @@ def test_auth_dbname_works_fine(
         # The client connects to postgres DB that matches with autodb
         # pgbouncer must use postgres_authdb1, which is defined in [pgbouncer] section
         bouncer.test(user="stats", password="stats", dbname="postgres")
+
+
+def test_hba_leak(bouncer):
+    """
+    Don't actually check if HBA auth works, but check that it doesn't leak
+    memory when using the feature.
+    """
+    bouncer.write_ini(f"auth_type = hba")
+    bouncer.write_ini(f"auth_hba_file = hba_test.rules")
+
+    bouncer.admin("reload")
+
+    bouncer.write_ini(f"auth_type = trust")
+
+    bouncer.admin("reload")
+
+    bouncer.write_ini(f"auth_type = hba")
+
+    bouncer.admin("reload")
+    bouncer.admin("reload")


### PR DESCRIPTION
To make `valgrind` pass we have a cleanup function that we only use in
assert mode. In this function we free all globals before process exit.
However, we didn't free `parsed_hba`. This fixes that. In passing it
also slightly modifies how we free `parsed_hba` when reloading the
config.

Fixes #1000