### PR TITLE
Add support for negotiating the protocol version with the client

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -229,6 +229,8 @@ extern int cf_sbuf_len;
 /* type codes for weird pkts */
 #define PKT_STARTUP_V2  0x20000
 #define PKT_STARTUP_V3  0x30000
+#define PKT_STARTUP_V3_UNSUPPORTED 0x30001
+#define PKT_STARTUP_V4  0x40000
 #define PKT_CANCEL      80877102
 #define PKT_SSLREQ      80877103
 #define PKT_GSSENCREQ   80877104

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -228,7 +228,7 @@ extern int cf_sbuf_len;
 
 /* type codes for weird pkts */
 #define PKT_STARTUP_V2  0x20000
-#define PKT_STARTUP     0x30000
+#define PKT_STARTUP_V3  0x30000
 #define PKT_CANCEL      80877102
 #define PKT_SSLREQ      80877103
 #define PKT_GSSENCREQ   80877104

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -100,6 +100,13 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 #define pktbuf_write_StartupMessage(buf, user, parms, parms_len) \
 	pktbuf_write_generic(buf, PKT_STARTUP_V3, "bsss", parms, parms_len, "user", user, "")
 
+#define pktbuf_write_NegotiateProtocolVersion( \
+		buf, \
+		unsupported_protocol_extensions_count, \
+		unsupported_protocol_extensions_bytes, \
+		unsupported_protocol_extensions_bytes_length) \
+	pktbuf_write_generic(buf, 'v', "iib", PKT_STARTUP_V3, unsupported_protocol_extensions_count, unsupported_protocol_extensions_bytes, unsupported_protocol_extensions_bytes_length)
+
 #define pktbuf_write_PasswordMessage(buf, psw) \
 	pktbuf_write_generic(buf, 'p', "s", psw)
 

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -98,7 +98,7 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 	pktbuf_write_generic(buf, PKT_CANCEL, "b", key, 8)
 
 #define pktbuf_write_StartupMessage(buf, user, parms, parms_len) \
-	pktbuf_write_generic(buf, PKT_STARTUP, "bsss", parms, parms_len, "user", user, "")
+	pktbuf_write_generic(buf, PKT_STARTUP_V3, "bsss", parms, parms_len, "user", user, "")
 
 #define pktbuf_write_PasswordMessage(buf, psw) \
 	pktbuf_write_generic(buf, 'p', "s", psw)

--- a/src/client.c
+++ b/src/client.c
@@ -752,6 +752,10 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 	const char *key, *val;
 	bool ok;
 	bool appname_found = false;
+	struct MBuf unsupported_protocol_extensions;
+	int unsupported_protocol_extensions_count = 0;
+
+	mbuf_init_dynamic(&unsupported_protocol_extensions);
 
 	while (1) {
 		ok = mbuf_get_string(&pkt->data, &key);
@@ -773,6 +777,11 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 		} else if (strcmp(key, "application_name") == 0) {
 			set_appname(client, val);
 			appname_found = true;
+		} else if (strncmp("_pq_.", key, 5) == 0) {
+			slog_debug(client, "ignoring protocol extension parameter: %s=%s", key, val);
+			unsupported_protocol_extensions_count++;
+			if (!mbuf_write(&unsupported_protocol_extensions, key, strlen(key) + 1))
+				return false;
 		} else if (varcache_set(&client->vars, key, val)) {
 			slog_debug(client, "got var: %s=%s", key, val);
 		} else if (strlist_contains(cf_ignore_startup_params, key)) {
@@ -804,6 +813,21 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			disconnect_client(client, true, "no more connections allowed (max_client_conn)");
 			return false;
 		}
+	}
+
+	if (pkt->type == PKT_STARTUP_V3_UNSUPPORTED || unsupported_protocol_extensions_count > 0) {
+		PktBuf *buf = pktbuf_dynamic(512);
+		int res;
+
+		pktbuf_write_NegotiateProtocolVersion(
+			buf,
+			unsupported_protocol_extensions_count,
+			unsupported_protocol_extensions.data,
+			unsupported_protocol_extensions.write_pos
+			);
+		res = pktbuf_send_immediate(buf, client);
+		if (!res)
+			disconnect_client(client, false, "unable to send protocol negotiation packet");
 	}
 
 	/* find pool */
@@ -999,6 +1023,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 	case PKT_STARTUP_V2:
 		disconnect_client(client, true, "old V2 protocol not supported");
 		return false;
+	case PKT_STARTUP_V3_UNSUPPORTED:
 	case PKT_STARTUP_V3:
 		/* require SSL except on unix socket */
 		if (client_accept_sslmode >= SSLMODE_REQUIRE && !client->sbuf.tls && !is_unix) {

--- a/src/client.c
+++ b/src/client.c
@@ -999,7 +999,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 	case PKT_STARTUP_V2:
 		disconnect_client(client, true, "old V2 protocol not supported");
 		return false;
-	case PKT_STARTUP:
+	case PKT_STARTUP_V3:
 		/* require SSL except on unix socket */
 		if (client_accept_sslmode >= SSLMODE_REQUIRE && !client->sbuf.tls && !is_unix) {
 			disconnect_client(client, true, "SSL required");

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -253,6 +253,9 @@ void pktbuf_put_uint64(PktBuf *buf, uint64_t val)
 
 void pktbuf_put_bytes(PktBuf *buf, const void *data, int len)
 {
+	if (len == 0)
+		return;
+
 	make_room(buf, len);
 	if (buf->failed)
 		return;

--- a/src/proto.c
+++ b/src/proto.c
@@ -103,7 +103,7 @@ bool get_header(struct MBuf *data, PktHdr *pkt)
 		} else if (code == PKT_GSSENCREQ) {
 			type = PKT_GSSENCREQ;
 		} else if ((code >> 16) == 3 && (code & 0xFFFF) < 2) {
-			type = PKT_STARTUP;
+			type = PKT_STARTUP_V3;
 		} else if (code == PKT_STARTUP_V2) {
 			type = PKT_STARTUP_V2;
 		} else {

--- a/src/proto.c
+++ b/src/proto.c
@@ -102,8 +102,10 @@ bool get_header(struct MBuf *data, PktHdr *pkt)
 			type = PKT_SSLREQ;
 		} else if (code == PKT_GSSENCREQ) {
 			type = PKT_GSSENCREQ;
-		} else if ((code >> 16) == 3 && (code & 0xFFFF) < 2) {
+		} else if (code >= PKT_STARTUP_V3 && code < PKT_STARTUP_V3_UNSUPPORTED) {
 			type = PKT_STARTUP_V3;
+		} else if (code >= PKT_STARTUP_V3_UNSUPPORTED && code < PKT_STARTUP_V4) {
+			type = PKT_STARTUP_V3_UNSUPPORTED;
 		} else if (code == PKT_STARTUP_V2) {
 			type = PKT_STARTUP_V2;
 		} else {


### PR DESCRIPTION
PgBouncer currently only supports protocol version 3.0. However, it was
still accepting connections if the client asked for the 3.1 protocol
version. This is obviously a bug, because PgBouncer likely won't
support the changes introduced in 3.1 of the protocol without
any code changes.

This starts sending the NegotiateProtocolVersion message when the client
asks for a minor version that PgBouncer does not support. Also, instead
of erroring when it receives unsupported protocol extensions parameters
it will include these in this NegotiateProtocolVersion message.

For reference this is the Postgres commit introducing NegotiateProtocolVersion: https://github.com/postgres/postgres/commit/ae65f6066dc3d19a55f4fdcd3b30003c5ad8dbed

I tested this manually using this patchset that bumps the protocol version. https://www.postgresql.org/message-id/flat/CAGECzQScQ3N-Ykv2j4NDyDtrPPc3FpRoa%3DLZ-2Uj2ocA4zr%3D4Q%40mail.gmail.com#cd9e8407820d492e8f677ee6a67c21ce

