### PR TITLE
Add editorconfig rules for our hba_test files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,16 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 8
 
+[hba_test.{eval,rules}]
+indent_style = tab
+indent_size = 8
+
+[hba_test.rules]
+# Disable automatic trailing whitespace trimming for hba_test.rules, because
+# one of the tests in that file is that parsing doesn't break in case of
+# trailing whitespace.
+trim_trailing_whitespace = false
+
 [*.py]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Our hba_test.eval and hba_test.rules file only look well aligned with 8
size tabs. This configures editors (and GitHub) to display them as such.
