### PR TITLE
Fix COPY FROM STDIN handling

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -603,7 +603,7 @@ struct PgSocket {
 	bool setting_vars : 1;		/* server: setting client vars */
 	bool exec_on_connect : 1;	/* server: executing connect_query */
 	bool resetting : 1;		/* server: executing reset query from auth login; don't release on flush */
-	bool copy_mode : 1;		/* server: in copy stream, ignores any Sync packets */
+	bool copy_mode : 1;		/* server: in copy stream, ignores any Sync packets until CopyDone or CopyFail */
 
 	bool wait_for_welcome : 1;	/* client: no server yet in pool, cannot send welcome msg */
 	bool wait_for_user_conn : 1;	/* client: waiting for auth_conn server connection */
@@ -620,8 +620,6 @@ struct PgSocket {
 	/* server: received an ErrorResponse, waiting for ReadyForQuery to clear
 	 * the outstanding requests until the next Sync */
 	bool query_failed : 1;
-
-	int expect_rfq_count;	/* client: count of ReadyForQuery packets client should see */
 
 	usec_t connect_time;	/* when connection was made */
 	usec_t request_time;	/* last activity time */

--- a/include/objects.h
+++ b/include/objects.h
@@ -65,7 +65,7 @@ PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUST
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
 bool add_outstanding_request(PgSocket *client, char type, ResponseAction action) _MUSTCHECK;
 bool pop_outstanding_request(PgSocket *client, char *types, bool *skip);
-bool clear_outstanding_requests_until_sync(PgSocket *server) _MUSTCHECK;
+bool clear_outstanding_requests_until(PgSocket *server, char *types) _MUSTCHECK;
 bool queue_fake_response(PgSocket *client, char request_type) _MUSTCHECK;
 
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;

--- a/src/objects.c
+++ b/src/objects.c
@@ -1014,7 +1014,7 @@ bool pop_outstanding_request(PgSocket *server, char *types, bool *skip)
 /*
  * Clear all outstanding requests until we reach response of any of the message
  * types in "types". Any Parse or Close statement requests that were still
- * outstanding will be unregistered or re-registered from the server its cache
+ * outstanding will be unregistered or re-registered from the server its cache.
  */
 bool clear_outstanding_requests_until(PgSocket *server, char *types)
 {
@@ -1371,7 +1371,7 @@ void disconnect_client_sqlstate(PgSocket *client, bool notify, const char *sqlst
 				 * we need to close the client connection
 				 * immediately.
 				 */
-				disconnect_server(server, true, "client disconnected with queries in progress");
+				disconnect_server(server, true, "client disconnected with query in progress");
 			} else if (!sbuf_is_empty(&server->sbuf)) {
 				/* ->ready may be set before all is sent */
 				server->link = NULL;

--- a/src/objects.c
+++ b/src/objects.c
@@ -1012,11 +1012,11 @@ bool pop_outstanding_request(PgSocket *server, char *types, bool *skip)
 }
 
 /*
- * clear all outstanding requests until we reach a Sync ('S') response, any
- * Parse or Close statement requests that were still outstanding will be
- * unregistered or re-registered from the server its cache
+ * Clear all outstanding requests until we reach response of any of the message
+ * types in "types". Any Parse or Close statement requests that were still
+ * outstanding will be unregistered or re-registered from the server its cache
  */
-bool clear_outstanding_requests_until_sync(PgSocket *server)
+bool clear_outstanding_requests_until(PgSocket *server, char *types)
 {
 	struct List *item, *tmp;
 	statlist_for_each_safe(item, &server->outstanding_requests, tmp) {
@@ -1043,7 +1043,7 @@ bool clear_outstanding_requests_until_sync(PgSocket *server)
 		statlist_remove(&server->outstanding_requests, item);
 		slab_free(outstanding_request_cache, request);
 
-		if (type == 'S')
+		if (strchr(types, type))
 			break;
 	}
 	slog_noise(server, "clear_outstanding_requests_until_sync: still outstanding %d", statlist_count(&server->outstanding_requests));

--- a/src/server.c
+++ b/src/server.c
@@ -348,6 +348,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			disconnect_server(server, true, "invalid server parameter");
 			return false;
 		}
+
 		/* ErrorResponse and CommandComplete show end of copy mode */
 		if (server->copy_mode) {
 			slog_debug(server, "COPY failed");
@@ -367,9 +368,9 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			 */
 			if (!clear_outstanding_requests_until(server, "cf"))
 				return false;
-		} else {
-			server->query_failed = true;
 		}
+
+		server->query_failed = true;
 		break;
 	case 'C':		/* CommandComplete */
 

--- a/src/server.c
+++ b/src/server.c
@@ -365,6 +365,13 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			 * be removed from the queue later when the server
 			 * sends a ReadyForQuery message and we clear the queue
 			 * until the next Sync.
+			 *
+			 * NOTE: CopyFail is the obvious error case, because
+			 * here the client triggers a failure of the COPY.
+			 * But CopyDone is also included in the search. The
+			 * reason for that being that the server might fail the
+			 * COPY for some reason unknown to the client (e.g. a
+			 * unique constraint violation).
 			 */
 			if (!clear_outstanding_requests_until(server, "cf"))
 				return false;

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 	     hba_test.eval hba_test.rules Makefile \
 	     test.ini stress.py userlist.txt \
 	     __init__.py conftest.py utils.py \
-	     test_admin.py test_auth.py test_cancel.py test_limits.py \
+	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
 	     test_misc.py test_no_database.py test_no_user.py test_operations.py \
 	     test_peering.py test_prepared.py test_ssl.py test_timeouts.py
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -136,8 +136,8 @@ def pg(tmp_path_factory, cert_dir):
     pg.sql(f"create user longpass with password '{LONG_PASSWORD}';")
     pg.sql("create user stats password 'stats';")
     pg.sql("grant all on schema public to public", dbname="p0")
-    pg.sql("create table t(i int)", dbname="p0")
-    pg.sql("grant all on table t to public", dbname="p0")
+    pg.sql("create table test_copy(i int)", dbname="p0")
+    pg.sql("grant all on table test_copy to public", dbname="p0")
 
     if PG_SUPPORTS_SCRAM:
         pg.sql("set password_encryption = 'md5'; create user muser1 password 'foo';")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -136,6 +136,9 @@ def pg(tmp_path_factory, cert_dir):
     pg.sql(f"create user longpass with password '{LONG_PASSWORD}';")
     pg.sql("create user stats password 'stats';")
     pg.sql("grant all on schema public to public", dbname="p0")
+    pg.sql("create table t(i int)", dbname="p0")
+    pg.sql("grant all on table t to public", dbname="p0")
+
     if PG_SUPPORTS_SCRAM:
         pg.sql("set password_encryption = 'md5'; create user muser1 password 'foo';")
         pg.sql("set password_encryption = 'md5'; create user muser2 password 'wrong';")

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -8,7 +8,7 @@ from .utils import LIBPQ_SUPPORTS_PIPELINING
 
 def test_copy_stdin_success_simple(bouncer):
     with bouncer.conn() as conn:
-        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query(f"COPY test_copy(i) FROM STDIN".encode())
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         conn.pgconn.put_copy_data(b"1\n")
         conn.pgconn.put_copy_end()
@@ -18,7 +18,7 @@ def test_copy_stdin_success_simple(bouncer):
 
 def test_copy_stdin_error_before_copy_done_simple(bouncer):
     with bouncer.conn() as conn:
-        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query(f"COPY test_copy(i) FROM STDIN".encode())
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         # Send bad row
         conn.pgconn.put_copy_data(b"\n")
@@ -33,7 +33,7 @@ def test_copy_stdin_error_before_copy_done_simple(bouncer):
 
 def test_copy_stdin_error_after_copy_done_simple(bouncer):
     with bouncer.conn() as conn:
-        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query(f"COPY test_copy(i) FROM STDIN".encode())
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         # Send bad row
         conn.pgconn.put_copy_data(b"\n")
@@ -63,7 +63,7 @@ def test_copy_stdout_simple(bouncer):
 def test_copy_stdin_success_extended(bouncer):
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.send_query_params(f"COPY test_copy(i) FROM STDIN".encode(), [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         conn.pgconn.put_copy_data(b"1\n")
@@ -80,7 +80,7 @@ def test_copy_stdin_success_extended(bouncer):
 def test_copy_stdin_error_before_copy_done_extended(bouncer):
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.send_query_params(f"COPY test_copy(i) FROM STDIN".encode(), [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         # Send bad row
@@ -102,7 +102,7 @@ def test_copy_stdin_error_before_copy_done_extended(bouncer):
 def test_copy_stdin_error_after_copy_done_extended(bouncer):
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.send_query_params(f"COPY test_copy(i) FROM STDIN".encode(), [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
         # Send bad row
@@ -144,7 +144,7 @@ def test_copy_stdin_success_prepared(bouncer):
 
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_prepare(b"p1", f"COPY test_copy(i) FROM STDIN".encode())
         conn.pgconn.send_query_prepared(b"p1", [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
@@ -166,7 +166,7 @@ def test_copy_stdin_error_before_copy_done_prepared(bouncer):
 
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_prepare(b"p1", f"COPY test_copy(i) FROM STDIN".encode())
         conn.pgconn.send_query_prepared(b"p1", [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
@@ -193,7 +193,7 @@ def test_copy_stdin_error_after_copy_done_prepared(bouncer):
 
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
-        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_prepare(b"p1", f"COPY test_copy(i) FROM STDIN".encode())
         conn.pgconn.send_query_prepared(b"p1", [])
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -43,12 +43,12 @@ def test_copy_stdin_error_after_copy_done_simple(bouncer):
 
 
 def test_copy_stdout_simple(bouncer):
-    bouncer.sql("TRUNCATE t")
-    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+    bouncer.sql("TRUNCATE test_copy")
+    bouncer.sql("INSERT INTO test_copy VALUES (1), (2)")
 
     with bouncer.conn() as conn:
         conn.pgconn.send_query(
-            f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode()
+            f"COPY (SELECT i FROM test_copy ORDER BY i) TO STDOUT (FORMAT TEXT)".encode()
         )
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_OUT
 
@@ -118,13 +118,14 @@ def test_copy_stdin_error_after_copy_done_extended(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_copy_stdout_extended(bouncer):
-    bouncer.sql("TRUNCATE t")
-    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+    bouncer.sql("TRUNCATE test_copy")
+    bouncer.sql("INSERT INTO test_copy VALUES (1), (2)")
 
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
         conn.pgconn.send_query_params(
-            f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode(), []
+            f"COPY (SELECT i FROM test_copy ORDER BY i) TO STDOUT (FORMAT TEXT)".encode(),
+            [],
         )
         conn.pgconn.pipeline_sync()
         assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_OUT
@@ -214,13 +215,14 @@ def test_copy_stdin_error_after_copy_done_prepared(bouncer):
 def test_copy_stdout_prepared(bouncer):
     bouncer.admin(f"set max_prepared_statements=100")
 
-    bouncer.sql("TRUNCATE t")
-    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+    bouncer.sql("TRUNCATE test_copy")
+    bouncer.sql("INSERT INTO test_copy VALUES (1), (2)")
 
     with bouncer.conn() as conn:
         conn.pgconn.enter_pipeline_mode()
         conn.pgconn.send_prepare(
-            b"p1", f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode()
+            b"p1",
+            f"COPY (SELECT i FROM test_copy ORDER BY i) TO STDOUT (FORMAT TEXT)".encode(),
         )
         conn.pgconn.send_query_prepared(b"p1", [])
         conn.pgconn.pipeline_sync()

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -1,0 +1,237 @@
+import time
+
+import pytest
+from psycopg import pq
+
+from .utils import LIBPQ_SUPPORTS_PIPELINING
+
+
+def test_copy_stdin_success_simple(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_data(b"1\n")
+        conn.pgconn.put_copy_end()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+
+
+def test_copy_stdin_error_before_copy_done_simple(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        # Flush and wait a bit so PgBouncer can receive the error
+        conn.pgconn.flush()
+        time.sleep(1)
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_end()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+
+
+def test_copy_stdin_error_after_copy_done_simple(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.send_query(f"COPY t(i) FROM STDIN".encode())
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        conn.pgconn.put_copy_end()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+
+
+def test_copy_stdout_simple(bouncer):
+    bouncer.sql("TRUNCATE t")
+    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.send_query(
+            f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode()
+        )
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_OUT
+
+        assert conn.pgconn.get_copy_data(0) == (2, b"1\n")
+        assert conn.pgconn.get_copy_data(0) == (2, b"2\n")
+        assert conn.pgconn.get_copy_data(0) == (-1, b"")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_success_extended(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_data(b"1\n")
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_error_before_copy_done_extended(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        # Flush and wait a bit so PgBouncer can receive the error
+        conn.pgconn.flush()
+        time.sleep(1)
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_error_after_copy_done_extended(bouncer):
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_query_params(f"COPY t(i) FROM STDIN".encode(), [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdout_extended(bouncer):
+    bouncer.sql("TRUNCATE t")
+    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_query_params(
+            f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode(), []
+        )
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_OUT
+
+        assert conn.pgconn.get_copy_data(0) == (2, b"1\n")
+        assert conn.pgconn.get_copy_data(0) == (2, b"2\n")
+        assert conn.pgconn.get_copy_data(0) == (-1, b"")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_success_prepared(bouncer):
+    bouncer.admin(f"set max_prepared_statements=100")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query_prepared(b"p1", [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_data(b"1\n")
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_error_before_copy_done_prepared(bouncer):
+    bouncer.admin(f"set max_prepared_statements=100")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query_prepared(b"p1", [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        # Flush and wait a bit so PgBouncer can receive the error
+        conn.pgconn.flush()
+        time.sleep(1)
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdin_error_after_copy_done_prepared(bouncer):
+    bouncer.admin(f"set max_prepared_statements=100")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_prepare(b"p1", f"COPY t(i) FROM STDIN".encode())
+        conn.pgconn.send_query_prepared(b"p1", [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        conn.pgconn.put_copy_end()
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()
+
+
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+def test_copy_stdout_prepared(bouncer):
+    bouncer.admin(f"set max_prepared_statements=100")
+
+    bouncer.sql("TRUNCATE t")
+    bouncer.sql("INSERT INTO t VALUES (1), (2)")
+
+    with bouncer.conn() as conn:
+        conn.pgconn.enter_pipeline_mode()
+        conn.pgconn.send_prepare(
+            b"p1", f"COPY (SELECT i FROM t ORDER BY i) TO STDOUT (FORMAT TEXT)".encode()
+        )
+        conn.pgconn.send_query_prepared(b"p1", [])
+        conn.pgconn.pipeline_sync()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_OUT
+
+        assert conn.pgconn.get_copy_data(0) == (2, b"1\n")
+        assert conn.pgconn.get_copy_data(0) == (2, b"2\n")
+        assert conn.pgconn.get_copy_data(0) == (-1, b"")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+        assert conn.pgconn.get_result().status == pq.ExecStatus.PIPELINE_SYNC
+        conn.pgconn.exit_pipeline_mode()

--- a/test/utils.py
+++ b/test/utils.py
@@ -856,10 +856,10 @@ class Bouncer(QueryRunner):
         # Most reliable way to detect Assert failures. Otherwise we might miss
         # Assert failures at the end of the test run.
         assert not re.search("FATAL.*Assert", log_contents)
-        # None of our tests should have queries in progress on the server when
+        # None of our tests should have a query in progress on the server when
         # the client disconnects. If this fails it almost certainly indicates a
         # bug in our outstanding request tracking.
-        assert "client disconnected with queries in progress" not in log_contents
+        assert "client disconnected with query in progress" not in log_contents
 
         if ENABLE_VALGRIND:
             failed_valgrind = False

--- a/test/utils.py
+++ b/test/utils.py
@@ -844,11 +844,22 @@ class Bouncer(QueryRunner):
 
     def print_logs(self):
         print(f"\n\nBOUNCER_LOG {self.config_dir}\n")
+
+        log_contents = ""
         try:
             with self.log_path.open() as f:
-                print(f.read())
+                log_contents = f.read()
+                print(log_contents)
         except Exception:
             pass
+
+        # Most reliable way to detect Assert failures. Otherwise we might miss
+        # Assert failures at the end of the test run.
+        assert not re.search("FATAL.*Assert", log_contents)
+        # None of our tests should have queries in progress on the server when
+        # the client disconnects. If this fails it almost certainly indicates a
+        # bug in our outstanding request tracking.
+        assert "client disconnected with queries in progress" not in log_contents
 
         if ENABLE_VALGRIND:
             failed_valgrind = False


### PR DESCRIPTION
In #845 full tracking of expected responses was implemented. This turned out to have bugs when sending `COPY FROM STDIN` queries using the extended protocol. [The protocol explicitly allows sending `Sync` messages after sending an `Execute` message for a `COPY FROM STDIN` command][1]. Such Sync messages are ignored by the server until a CopyDone or CopyFail message is received. The new command queue tracking did not take this into account, and was incorrectly expecting more ReadyForQuery messages from the server.

This could lead to two problems for the server connection on which the `COPY FROM STDIN` was sent:
1. The server connection would never be unassigned from the client.
2. Memory usage for this server connection would continue to increase until the client disconnects.
3. If `max_prepared_statements` was non-zero, then clients might receive ParseComplete and CloseComplete responses in the wrong order. This wouldn't result in wrong behaviour by the server, but the client might get confused and close the connection.

This PR fixes these issues. It also removes the rfq_count tracking, since it's now only keeping track of a strict subset of what the outstanding request queue was tracking.

[1]: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY

Fixes #1023
Fixes #1024