### PR TITLE
Add outstanding request for auth_query

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -188,6 +188,15 @@ static void start_auth_query(PgSocket *client, const char *username)
 	}
 	client->link->ready = false;
 
+	/*
+	 * Add outstanding request, so that the server is closed if the client
+	 * disconnects before the auth_query completes.
+	 */
+	if (!add_outstanding_request(client, 'S', RA_SKIP)) {
+		disconnect_server(client->link, true, "out of memory");
+		return;
+	}
+
 	res = 0;
 	buf = pktbuf_dynamic(512);
 	if (buf) {


### PR DESCRIPTION
I realized I was a bit too trigger-happy when removing all references to
`expected_rfq_count` in #1025. One occurrence should have been replaced
with adding an outstanding request. Normally this isn't an issue, but it
could cause the server connection not to be closed if the client
disconnects before the auth_query is finished running.

To be clear, #1025 did not introduce a regression in this respect.
Because `expect_rfq_count` being non-zero on would not cause
a server connection closure when the server was released.