### PR TITLE
Change SHOW USERS to list connections

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -506,6 +506,13 @@ name
 pool_mode
 :   The user's override pool_mode, or NULL if the default will be used instead.
 
+max_user_connections
+:   The user's max_user_connections setting. If this setting is not set
+    for this specific user, then the default value will be displayed.
+
+current_connections
+:   Current number of connections that this user has open to all servers.
+
 #### SHOW DATABASES
 
 name

--- a/src/admin.c
+++ b/src/admin.c
@@ -595,7 +595,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	}
 	cv.extra = pool_mode_map;
 
-	pktbuf_write_RowDescription(buf, "ss", "name", "pool_mode");
+	pktbuf_write_RowDescription(buf, "ssii", "name", "pool_mode", "max_user_connections", "current_connections");
 	statlist_for_each(item, &user_list) {
 		user = container_of(item, PgUser, head);
 		pool_mode_str = NULL;
@@ -603,7 +603,11 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		if (user->pool_mode != POOL_INHERIT)
 			pool_mode_str = cf_get_lookup(&cv);
 
-		pktbuf_write_DataRow(buf, "ss", user->name, pool_mode_str);
+		pktbuf_write_DataRow(buf, "ssii", user->name,
+				     pool_mode_str,
+				     user_max_connections(user),
+				     user->connection_count
+				     );
 	}
 	admin_flush(admin, buf, "SHOW");
 	return true;


### PR DESCRIPTION
While reviewing #1039 I had a hard time seeing if
max_user_connections was applied correctly because `SHOW USERS` didn't
list it. This addresses that by adding a `max_user_connections` and
`current_connections` column to the output of `SHOW USERS`.
