### PR TITLE
Update psycopg to an actual release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ pytest
 pytest-asyncio
 pytest-timeout
 pytest-xdist
-psycopg; python_version < "3.7"
-https://github.com/psycopg/psycopg/archive/master.zip#egg=psycopg&subdirectory=psycopg; python_version >= "3.7"
+psycopg>=3.1.18
 filelock
 contextlib2; python_version < "3.7"

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -238,7 +238,7 @@ def test_empty_application_name(bouncer):
 
 
 def test_equivalent_startup_param(bouncer):
-    bouncer.admin("set verbose=2")
+    bouncer.admin("set verbose=1")
 
     canonical_expected_times = 1 if PG_MAJOR_VERSION >= 14 else 0
     with bouncer.cur(options="-c DateStyle=ISO") as cur:

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -350,7 +350,7 @@ def test_statement_name_longer_than_pkt_buf(bouncer):
         assert result.status == pq.ExecStatus.COMMAND_OK
         result = conn.pgconn.describe_prepared(name)
         assert result.status == pq.ExecStatus.COMMAND_OK
-        result = conn.pgconn.exec_prepared(name, (b"abc",))
+        result = conn.pgconn.exec_prepared(name, [b"abc"])
         assert result.status == pq.ExecStatus.TUPLES_OK
         assert result.get_value(0, 0) == b"abc"
 
@@ -408,7 +408,7 @@ def test_prepared_statement_pipeline_error_delayed_sync(bouncer):
             ):
                 cur.execute("SELECT 123")
 
-            with pytest.raises(psycopg.errors.PipelineAborted):
+            with pytest.raises(psycopg.errors.DatabaseError):
                 cur.fetchall()
 
             p.sync()

--- a/test/utils.py
+++ b/test/utils.py
@@ -516,6 +516,9 @@ class Postgres(QueryRunner):
             # are the same.
             pgconf.write("extra_float_digits = 1\n")
 
+            # Make sure this is consistent across platforms
+            pgconf.write("datestyle = 'iso, mdy'\n")
+
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)
 


### PR DESCRIPTION
This starts pulling in a released version of psycopg instead of the version
from GitHub. The support for Close packet has been released, so it's not
necessary to pull from GitHub anymore. 

This fixes a bunch of issues on these official psycopg releases. It also fixes
an issue that I ran into where `test_equivalent_startup_param` failed on my new
laptop because initdb would use 'iso, dmy' as datestyle instead of 'iso, mdy'.
