### PR TITLE
Fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -279,7 +279,7 @@ PgBouncer 1.18.x
     ([#648](https://github.com/pgbouncer/pgbouncer/pull/648))
   * Fix `SHOW HELP` with PostgreSQL 15
     ([#769](https://github.com/pgbouncer/pgbouncer/issues/769))
-  * Fix race condition in query cancelation handling.  It was possible
+  * Fix race condition in query cancellation handling.  It was possible
     that a query cancellation for one client canceled a query for
     another one.  This could happen when a cancel request was received
     by PgBouncer when the query it was meant to cancel already
@@ -825,7 +825,7 @@ PgBouncer 1.6.x
 
     [CVE-2015-6817](https://access.redhat.com/security/cve/cve-2015-6817)
 
-  * Skip NoticeResponce in handle_auth_response.  Otherwise verbose
+  * Skip NoticeResponse in handle_auth_response.  Otherwise verbose
     log levels on server cause login failures.
 
   * console: Fill `auth_user` when auth_type=any.  Otherwise
@@ -966,12 +966,12 @@ PgBouncer 1.5.x
   * max_packet_size - config parameter to tune maximum packet size
     that is allowed through.  Default is kept same: (2G-1), but now
     it can be made smaller.
-  * In case of unparseable packet header, show it in hex in log and
+  * In case of unparsable packet header, show it in hex in log and
     error message.
 
 - Fixes
 
-  * AntiMake: it used $(relpath) and $(abspath) to manupulate pathnames,
+  * AntiMake: it used $(relpath) and $(abspath) to manipulate pathnames,
     but the result was build failure when source tree path contained
     symlinks.  The code is now changed to work on plain strings only.
   * console: now SET can be used to set empty string values.
@@ -1011,7 +1011,7 @@ PgBouncer 1.5.x
     earlier versions anymore.
   * Stop trying to retry on EINTR from close().
 
-**2012-01-05  -  PgBouncer 1.5  -  "Bouncing Satisified Clients Since 2007"**
+**2012-01-05  -  PgBouncer 1.5  -  "Bouncing Satisfied Clients Since 2007"**
 
 If you use more than 8 IPs behind one DNS name, you now need to
 use EDNS0 protocol to query.  Only getaddrinfo_a()/getaddrinfo()
@@ -1050,7 +1050,7 @@ GNU Make 3.81+ is required for building.
     (Dan McGee)
   * Console: Support ident quoting with "".  Originally we did not
     have any commands that took database names, so no quoting was needed.
-  * Console: allow numbers at the stard of word regex.  Trying
+  * Console: allow numbers at the start of word regex.  Trying
     to use strict parser makes things too complex here.
   * Don't expire auto DBs that are paused.
     (Michael Tharp)
@@ -1363,7 +1363,7 @@ PgBouncer 1.3.x
 
   * In case event_del() reports failure, just proceed with cleanup.
     Previously pgbouncer retried it, in case the failure was due ENOMEM.
-    But this has caused log floods with inifinite repeats, so it seems
+    But this has caused log floods with infinite repeats, so it seems
     libevent does not like it.
 
     Why event_del() report failure first time is still mystery.
@@ -1545,7 +1545,7 @@ PgBouncer 1.1.x
     - Accept custom unix socket location in host=
     - Accept quoted values: password=' asd''foo'
 
-  * New config var: server_reset_query, to be sent immidiately after release
+  * New config var: server_reset_query, to be sent immediately after release
   * New config var: server_round_robin, to switch between LIFO and RR.
   * Cancel pkt sent for idle connection does not drop it anymore.
   * Cancel with ^C from psql works for SUSPEND / PAUSE.
@@ -1634,13 +1634,13 @@ PgBouncer 1.0.x
 - Fixes
   * libevent may report a deleted event inside same loop.
     Avoid socket reuse for one loop.
-  * release_server() from disconnect_client() didnt look
+  * release_server() from disconnect_client() didn't look
     it the packet was actually sent.
 
 **2007-03-15  -  PgBouncer 1.0.1  -  "Alien technology"**
 
 - Fixes
-  * Mixed usage of cached and non-cached time, plus unsiged usec_t typedef
+  * Mixed usage of cached and non-cached time, plus unsigned usec_t typedef
     created spurious query_timeout errors.
   * Fix rare case when socket woken up from send-wait could stay stalling.
   * More fair queueing of server connections.  Before, a new query could

--- a/doc/config.md
+++ b/doc/config.md
@@ -327,7 +327,7 @@ replacing `my_prepared_stamenent` with `PGBOUNCER_123`) before forwarding that
 command to the server. More importantly, if the prepared statement that the
 client wants to execute is not yet prepared on the server (e.g. because a
 different server is now assigned to the client then when the client prepared
-the statement), then PgBouncer transparrently prepares the statement before
+the statement), then PgBouncer transparently prepares the statement before
 executing it.
 
 Note: This tracking and rewriting of prepared statement commands does not work

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -15,7 +15,7 @@ Waiting for contributors...
 Problems / cleanups
 -------------------
 
-* Bad naming in data strctures:
+* Bad naming in data structures:
 
   * PgSocket->db [vs. PgPool->db]
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -170,7 +170,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 
 ;; Comma-separated list of parameters to track per client.  The
 ;; Postgres parameters listed here will be cached per client by
-;; pgbouncer and restored in server everytime the client runs a query.
+;; pgbouncer and restored in server every time the client runs a query.
 ;track_extra_parameters = IntervalStyle
 
 ;; Comma-separated list of parameters to ignore when given in startup

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -414,7 +414,7 @@ struct PgPool {
 	 *
 	 * A special case is when there are cancel requests waiting to be forwarded
 	 * to servers in waiting_cancel_req_list. In that case the server bails out
-	 * of the login flow, because a cancel reuest needs to be sent before
+	 * of the login flow, because a cancel request needs to be sent before
 	 * logging in.
 	 *
 	 * NOTE: This list can at most contain a single server due to the way

--- a/include/common/pg_wchar.h
+++ b/include/common/pg_wchar.h
@@ -274,7 +274,7 @@ typedef enum pg_enc
 	PG_KOI8U,					/* KOI8-U */
 	/* PG_ENCODING_BE_LAST points to the above entry */
 
-	/* followings are for client encoding only */
+	/* following are for client encoding only */
 	PG_SJIS,					/* Shift JIS (Windows-932) */
 	PG_BIG5,					/* Big5 (Windows-950) */
 	PG_GBK,						/* GBK (Windows-936) */

--- a/src/admin.c
+++ b/src/admin.c
@@ -159,7 +159,7 @@ bool admin_ready(PgSocket *admin, const char *desc)
 
 /*
  * some silly clients start actively messing with server parameters
- * without checking if thats necessary.  Fake some env for them.
+ * without checking if that's necessary.  Fake some env for them.
  */
 struct FakeParam {
 	const char *name;

--- a/src/objects.c
+++ b/src/objects.c
@@ -608,7 +608,7 @@ PgDatabase *find_database(const char *name)
 }
 
 /*
- * Similar to find_database. In case databse is not found, it will try to register
+ * Similar to find_database. In case database is not found, it will try to register
  * it if auto-database ('*') is configured.
  */
 PgDatabase *find_or_register_database(PgSocket *connection, const char *name)
@@ -768,7 +768,7 @@ void activate_client(PgSocket *client)
 
 	Assert(client->wait_start > 0);
 
-	/* acount for time client spent waiting for server */
+	/* account for time client spent waiting for server */
 	client->pool->stats.wait_time += (get_cached_time() - client->wait_start);
 
 	slog_debug(client, "activate_client");

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1317,7 +1317,7 @@ bool sbuf_tls_setup(void)
 	 * To change server TLS settings all connections are marked as dirty. This
 	 * way they are recycled and the new TLS settings will be used. Otherwise
 	 * old TLS settings, possibly less secure, could be used for old
-	 * connections indefinitly. If TLS is disabled, and it was disabled before
+	 * connections indefinitely. If TLS is disabled, and it was disabled before
 	 * as well then recycling connections is not necessary, since we know none
 	 * of the settings have changed. In all other cases we recycle the
 	 * connections to be on the safe side, even though it's possible nothing

--- a/src/server.c
+++ b/src/server.c
@@ -749,7 +749,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 			/*
 			 * It's possible that the client vars and server vars have
 			 * different string representations, but still Postgres did not
-			 * send a ParamaterStatus packet. This happens when the server
+			 * send a ParameterStatus packet. This happens when the server
 			 * variable is the canonical version of the client variable, i.e.
 			 * they mean the same just written slightly different. To make sure
 			 * that the canonical version is also stored in the client, we now

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,7 +64,7 @@ def shared_setup(tmp_path_factory, worker_id):
 
     It currently sets up 2 things:
     1. A cert directory, for TLS tests
-    2. A queueing disciplince (qdisc), for tests that require latency
+    2. A queueing disciplines (qdisc), for tests that require latency
 
     It yields the certificate directory, which is why the fixture name is
     cert_dir.

--- a/test/ctest6000.ini
+++ b/test/ctest6000.ini
@@ -4,7 +4,7 @@
 ; redirect bardb to bazdb on localhost
 conntest = host=127.0.0.1 port=7000 dbname=conntest
 
-;; Configuation section
+;; Configuration section
 [pgbouncer]
 
 logfile = ctest6000.log

--- a/test/ctest7000.ini
+++ b/test/ctest7000.ini
@@ -4,7 +4,7 @@
 ; redirect bardb to bazdb on localhost
 conntest = host=127.0.0.1 port=5432 dbname=marko password=kama
 
-;; Configuation section
+;; Configuration section
 [pgbouncer]
 
 logfile = ctest7000.log

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -607,7 +607,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     client_cert = cert_dir / "TestCA1" / "sites" / "04-pgbouncer.acme.org.crt"
 
     # The client connects to p0x using a client certificate with CN=pgbouncer.acme.org.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0x    all        0.0.0.0/0               cert    map=test
     # where "test" map is defined in pgident.conf as
     #    test            pgbouncer.acme.org      someuser
@@ -626,7 +626,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     bouncer.pg.sql("create user anotheruser with login;")
 
     # The client connects to p0x using a client certificate with CN=pgbouncer.acme.org.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0x    all        0.0.0.0/0               cert    map=test
     # where "test" map is defined in pgident.conf as
     #    test            pgbouncer.acme.org      someuser
@@ -643,7 +643,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     )
 
     # The client connects to p0x using a client certificate with CN=pgbouncer.acme.org.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0x    all        0.0.0.0/0               cert    map=test
     # where "test" map is defined in pgident.conf as
     #    test            pgbouncer.acme.org      someuser
@@ -670,7 +670,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     client_cert = cert_dir / "TestCA1" / "sites" / "02-bouncer.crt"
 
     # The client connects to p0 using a client certificate with CN=bouncer.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0              bouncer         0.0.0.0/0               cert
     # CN expected in map is "bouncer" which matches the CN in the client cert
     # hence the test succeeds.
@@ -685,7 +685,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     )
 
     # The client connects to p0y using a client certificate with CN=bouncer.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0y             all             0.0.0.0/0               cert    map=test2
     # where
     #   test2           bouncer                 all
@@ -706,7 +706,7 @@ def test_client_hba_cert(bouncer, cert_dir):
     client_cert = cert_dir / "TestCA1" / "sites" / "04-pgbouncer.acme.org.crt"
 
     # The client connects to p0y using a client certificate with CN=pgbouncer.acme.org.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0y             all             0.0.0.0/0               cert    map=test2
     # where
     #   test2           bouncer                 all
@@ -730,7 +730,7 @@ def test_client_hba_cert(bouncer, cert_dir):
             )
 
     # The client connects to p0y using a client certificate with CN=pgbouncer.acme.org.
-    # hba_eval returns the followign line:
+    # hba_eval returns the following line:
     #    hostssl p0y             all             0.0.0.0/0               cert    map=test2
     # where
     #   test2           bouncer                 all

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -312,7 +312,7 @@ def test_prepared_statement_pipeline_stress(bouncer):
                         assert curs[i].fetchall() == [(i, str(i).zfill(size_of_param))]
 
 
-def test_describe_non_existant_prepared_statement(bouncer):
+def test_describe_non_existent_prepared_statement(bouncer):
     bouncer.admin(f"set max_prepared_statements=100")
 
     with bouncer.conn() as conn:
@@ -331,7 +331,7 @@ def test_close_prepared_statement(bouncer):
         assert result.status == pq.ExecStatus.COMMAND_OK
         result = conn.pgconn.close_prepared(b"test")
         assert result.status == pq.ExecStatus.COMMAND_OK
-        # closing a non-existant prepared statement should not raise an error
+        # closing a non-existent prepared statement should not raise an error
         result = conn.pgconn.close_prepared(b"test")
         assert result.status == pq.ExecStatus.COMMAND_OK
         # ensure that the prepared statement is actually closed by trying to
@@ -501,7 +501,7 @@ def test_pipeline_flushes_on_full_pkt_buf(bouncer):
 
     # We want to construct a Parse packet that is exactly the size of pkt_buf,
     # so we don't trigger the logic to use the callback buffering logic, but do
-    # need the whole sbuf buffer to be availble. So let's calculate the exact
+    # need the whole sbuf buffer to be available. So let's calculate the exact
     # length of the statement name that we need to make this happen.
     size_type = 1  # 'P'
     size_length = 4  # int32

--- a/test/utils.py
+++ b/test/utils.py
@@ -217,7 +217,7 @@ class QueryRunner:
         # Always required for Ubuntu 18.04, but also needed for any tests
         # involving the varcache_change database. The difference between the
         # client_encoding specified in the config and client_encoding by the
-        # client will force a varcache change when a connectino is given.
+        # client will force a varcache change when a connection is given.
         options.setdefault("client_encoding", "UTF8")
 
     def conn(self, *, autocommit=True, **kwargs):
@@ -586,7 +586,7 @@ class Postgres(QueryRunner):
         return self.pgdata / "postgresql.conf"
 
     def commit_hba(self):
-        """Mark the current HBA contents as non-resetable by reset_hba"""
+        """Mark the current HBA contents as non-resettable by reset_hba"""
         with self.hba_path.open() as pghba:
             old_contents = pghba.read()
         with self.hba_path.open(mode="w") as pghba:


### PR DESCRIPTION
Found via `codespell -L ser,ue,parms` and `typos --hidden --format brief`