### PR TITLE
Silence deprecation warnings of c-ares

### DIFF
--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -32,6 +32,7 @@
 #endif /* USE_EVDNS */
 
 #ifdef USE_CARES
+#define CARES_NO_DEPRECATED
 #include <ares.h>
 #include <ares_dns.h>
 #ifdef HAVE_ARES_NAMESER_H


### PR DESCRIPTION
The newest version of c-ares has started adding deprecation warnings.
Let's silence those for now to make MacOS builds pass again.

We might want to actually start using the new APIs in the future, but
since we want to support some fairly old systems I'm not sure that's a
good plan now. And given [the library author stated that the old
functions would probably never be removed][1], I think we're fine with
simply ignoring the warnings.

[1]: https://github.com/c-ares/c-ares/pull/732#issuecomment-2028454381
