### PR TITLE
Fix tests on non US datestyle configured systems

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -516,6 +516,9 @@ class Postgres(QueryRunner):
             # are the same.
             pgconf.write("extra_float_digits = 1\n")
 
+            # Make sure this is consistent across platforms
+            pgconf.write("datestyle = 'iso, mdy'\n")
+
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)
 


### PR DESCRIPTION
This fixes an issue that I ran into where
`test_equivalent_startup_param` failed on my new laptop because initdb
would use `'iso, dmy'` as datestyle instead of `'iso, mdy'`.
