### PR TITLE
Add values in ignore_startup_parameters

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -236,11 +236,16 @@ Default: IntervalStyle
 
 By default, PgBouncer allows only parameters it can keep track of in startup
 packets: `client_encoding`, `datestyle`, `timezone` and `standard_conforming_strings`.
-All others parameters will raise an error.  To allow others parameters, they can be
+All other parameters will raise an error. To allow other parameters, they can be
 specified here, so that PgBouncer knows that they are handled by the admin and it can ignore them.
 
-If you need to specify multiple values, use a comma-separated list (e.g.
-`options,extra_float_digits`)
+If you need to specify multiple parameters, use a comma-separated list (e.g.
+`options,extra_float_digits`).
+
+If you need to specify a value for the parameter, you can do so, e.g.,
+`options,extra_float_digits=2`. In this example, the parameter
+`extra_float_digits` with value `3` would still raise an error, but the same
+parameter with value `2` will be ignored by pgBouncer.
 
 The Postgres protocol allows specifying parameters settings, both directly as a
 parameter in the startup packet, or inside the [`options` startup

--- a/src/client.c
+++ b/src/client.c
@@ -677,7 +677,7 @@ static bool set_startup_options(PgSocket *client, const char *options)
 
 	while (*position) {
 		const char *key_string, *value_string;
-		char *equals;
+		char *equals, *key_value = NULL;
 		mbuf_rewind_writer(&arg);
 		position = cstr_skip_ws((char *) position);
 		if (strncmp("-c", position, 2) != 0)
@@ -690,22 +690,33 @@ static bool set_startup_options(PgSocket *client, const char *options)
 			return false;
 		}
 
+		key_value = (char *)malloc(strlen((char *)arg.data)*sizeof(char));
+		if (key_value == NULL)
+			return false;
+
+		strcpy(key_value, (char *)arg.data);
 		equals = strchr((char *) arg.data, '=');
-		if (!equals)
+		if (!equals) {
+			free(key_value);
 			goto fail;
+		}
 		*equals = '\0';
 
 		key_string = (const char *) arg.data;
 		value_string = (const char *) equals + 1;
 		if (varcache_set(&client->vars, key_string, value_string)) {
 			slog_debug(client, "got var from options: %s=%s", key_string, value_string);
-		} else if (strlist_contains(cf_ignore_startup_params, key_string) || strlist_contains(cf_ignore_startup_params, "options")) {
+		} else if (strlist_contains(cf_ignore_startup_params, key_value) ||
+					strlist_contains(cf_ignore_startup_params, key_string) ||
+					strlist_contains(cf_ignore_startup_params, "options")) {
 			slog_debug(client, "ignoring startup parameter from options: %s=%s", key_string, value_string);
 		} else {
 			slog_warning(client, "unsupported startup parameter in options: %s=%s", key_string, value_string);
+			free(key_value);
 			disconnect_client(client, true, "unsupported startup parameter in options: %s", key_string);
 			return false;
 		}
+		free(key_value);
 	}
 
 	return true;
@@ -741,6 +752,8 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 	const char *key, *val;
 	bool ok;
 	bool appname_found = false;
+	int key_value_len;
+	char *key_value = NULL;
 
 	while (1) {
 		ok = mbuf_get_string(&pkt->data, &key);
@@ -750,6 +763,13 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 		if (!ok)
 			break;
 
+		/* Concatenate key and val to a string: key=val */
+		key_value_len = strlen(key) + strlen(val) + 2;
+		key_value = (char *)malloc(key_value_len*sizeof(char));
+		if (key_value == NULL)
+			return false;
+		snprintf(key_value, key_value_len, "%s=%s", key, val);
+
 		if (strcmp(key, "database") == 0) {
 			slog_debug(client, "got var: %s=%s", key, val);
 			dbname = val;
@@ -757,21 +777,25 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			slog_debug(client, "got var: %s=%s", key, val);
 			username = val;
 		} else if (strcmp(key, "options") == 0) {
-			if (!set_startup_options(client, val))
+			if (!set_startup_options(client, val)) {
+				free(key_value);
 				return false;
+			}
 		} else if (strcmp(key, "application_name") == 0) {
 			set_appname(client, val);
 			appname_found = true;
 		} else if (varcache_set(&client->vars, key, val)) {
 			slog_debug(client, "got var: %s=%s", key, val);
-		} else if (strlist_contains(cf_ignore_startup_params, key)) {
+		} else if (strlist_contains(cf_ignore_startup_params, key) || strlist_contains(cf_ignore_startup_params, key_value)) {
 			slog_debug(client, "ignoring startup parameter: %s=%s", key, val);
 		} else {
 			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
+			free(key_value);
 			disconnect_client(client, true, "unsupported startup parameter: %s", key);
 			return false;
 		}
 	}
+	free(key_value);
 	if (!username || !username[0]) {
 		disconnect_client(client, true, "no username supplied");
 		return false;


### PR DESCRIPTION
Currently you can only define the key of a parameter in the `ignore_startup_parameters` section. With this change you can define a `key=value` string in that section. For example you can set the following:

```
[pgbouncer]
ignore_startup_parameters = options,extra_float_digits=2
```

If an application attempts to connect using as startup parameter the extra_float_digits=3, then pgBouncer will produce an error.

This is useful to avoid hidden bugs when using this section between application logic changes. Also it can function for clients as an indication of the expected startup parameters.