### PR TITLE
Allow pool_size per user

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1255,6 +1255,11 @@ Example:
 
 Only a few settings are available here.
 
+### pool_size
+
+Set the maximum size of pools for all connections from this user.  If not set,
+the database or `default_pool_size` is used.
+
 ### pool_mode
 
 Set the pool mode to be used for all connections from this user. If not set, the

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -503,8 +503,11 @@ dns_pending
 name
 :   The user name
 
+pool_size
+:   The user's override pool_size. or NULL if not set.
+
 pool_mode
-:   The user's override pool_mode, or NULL if the default will be used instead.
+:   The user's override pool_mode, or NULL if not set.
 
 max_user_connections
 :   The user's max_user_connections setting. If this setting is not set

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -36,7 +36,7 @@
 ;; User-specific configuration
 [users]
 
-;user1 = pool_mode=transaction max_user_connections=10
+;user1 = pool_size=5 pool_mode=transaction max_user_connections=10
 
 ;; Configuration section
 [pgbouncer]

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -499,7 +499,7 @@ struct PgUser {
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
 	int pool_mode;
-  int pool_size;		/* max server connections in one pool */
+	int pool_size;		/* max server connections in one pool */
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
 };

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -499,6 +499,7 @@ struct PgUser {
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
 	int pool_mode;
+  int pool_size;		/* max server connections in one pool */
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
 };

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -499,7 +499,7 @@ struct PgUser {
 	bool has_scram_keys;		/* true if the above two are valid */
 	bool mock_auth;			/* not a real user, only for mock auth */
 	int pool_mode;
-	int pool_size;		/* max server connections in one pool */
+	int pool_size;				/* max server connections in one pool */
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */
 };

--- a/src/admin.c
+++ b/src/admin.c
@@ -587,7 +587,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	struct List *item;
 	PktBuf *buf = pktbuf_dynamic(256);
 	struct CfValue cv;
-	char pool_size_str[10] = "";
+	char pool_size_str[12] = "";
 	const char *pool_mode_str;
 
 	if (!buf) {

--- a/src/admin.c
+++ b/src/admin.c
@@ -587,7 +587,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	struct List *item;
 	PktBuf *buf = pktbuf_dynamic(256);
 	struct CfValue cv;
-  char pool_size_str[10] = "";
+	char pool_size_str[10] = "";
 	const char *pool_mode_str;
 
 	if (!buf) {
@@ -599,15 +599,15 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	pktbuf_write_RowDescription(buf, "sssii", "name", "pool_size", "pool_mode", "max_user_connections", "current_connections");
 	statlist_for_each(item, &user_list) {
 		user = container_of(item, PgUser, head);
-    if (user->pool_size >= 0)
-      snprintf(pool_size_str, sizeof(pool_size_str), "% 9d", user->pool_size);
+		if (user->pool_size >= 0)
+			snprintf(pool_size_str, sizeof(pool_size_str), "% 9d", user->pool_size);
 		pool_mode_str = NULL;
 		cv.value_p = &user->pool_mode;
 		if (user->pool_mode != POOL_INHERIT)
 			pool_mode_str = cf_get_lookup(&cv);
 
 		pktbuf_write_DataRow(buf, "sssii", user->name,
-             pool_size_str,
+					 pool_size_str,
 				     pool_mode_str,
 				     user_max_connections(user),
 				     user->connection_count

--- a/src/admin.c
+++ b/src/admin.c
@@ -600,7 +600,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	statlist_for_each(item, &user_list) {
 		user = container_of(item, PgUser, head);
 		if (user->pool_size >= 0)
-			snprintf(pool_size_str, sizeof(pool_size_str), "% 9d", user->pool_size);
+			snprintf(pool_size_str, sizeof(pool_size_str), "%9d", user->pool_size);
 		pool_mode_str = NULL;
 		cv.value_p = &user->pool_mode;
 		if (user->pool_mode != POOL_INHERIT)

--- a/src/admin.c
+++ b/src/admin.c
@@ -607,7 +607,7 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 			pool_mode_str = cf_get_lookup(&cv);
 
 		pktbuf_write_DataRow(buf, "sssii", user->name,
-					 pool_size_str,
+				     pool_size_str,
 				     pool_mode_str,
 				     user_max_connections(user),
 				     user->connection_count

--- a/src/loader.c
+++ b/src/loader.c
@@ -492,6 +492,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	PgUser *user;
 	struct CfValue cv;
 	int pool_mode = POOL_INHERIT;
+  int pool_size = -1;
 	int max_user_connections = -1;
 
 
@@ -519,9 +520,11 @@ bool parse_user(void *base, const char *name, const char *connstr)
 				log_error("invalid pool mode: %s", val);
 				goto fail;
 			}
-		} else if (strcmp("max_user_connections", key) == 0) {
-			max_user_connections = atoi(val);
-		} else {
+		} else if (strcmp("pool_size", key) == 0) {
+      pool_size = atoi(val);
+    } else if (strcmp("max_user_connections", key) == 0) {
+      max_user_connections = atoi(val);
+    } else {
 			log_error("unrecognized user parameter: %s", key);
 			goto fail;
 		}
@@ -537,6 +540,8 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	}
 
 	user->pool_mode = pool_mode;
+  user->pool_size = pool_size;
+  log_info("Setting pool_size for user %s: %d", user->name, user->pool_size);
 	user->max_user_connections = max_user_connections;
 
 	free(tmp_connstr);

--- a/src/loader.c
+++ b/src/loader.c
@@ -492,7 +492,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	PgUser *user;
 	struct CfValue cv;
 	int pool_mode = POOL_INHERIT;
-  int pool_size = -1;
+	int pool_size = -1;
 	int max_user_connections = -1;
 
 
@@ -521,10 +521,10 @@ bool parse_user(void *base, const char *name, const char *connstr)
 				goto fail;
 			}
 		} else if (strcmp("pool_size", key) == 0) {
-      pool_size = atoi(val);
-    } else if (strcmp("max_user_connections", key) == 0) {
-      max_user_connections = atoi(val);
-    } else {
+			pool_size = atoi(val);
+		} else if (strcmp("max_user_connections", key) == 0) {
+			max_user_connections = atoi(val);
+		} else {
 			log_error("unrecognized user parameter: %s", key);
 			goto fail;
 		}
@@ -540,8 +540,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	}
 
 	user->pool_mode = pool_mode;
-  user->pool_size = pool_size;
-  log_info("Setting pool_size for user %s: %d", user->name, user->pool_size);
+	user->pool_size = pool_size;
 	user->max_user_connections = max_user_connections;
 
 	free(tmp_connstr);

--- a/src/objects.c
+++ b/src/objects.c
@@ -497,6 +497,7 @@ PgUser *add_user(const char *name, const char *passwd)
 
 		aatree_insert(&user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
+    user->pool_size = -1;
 	}
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
@@ -522,6 +523,7 @@ PgUser *add_db_user(PgDatabase *db, const char *name, const char *passwd)
 
 		aatree_insert(&db->user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
+    user->pool_size = -1;
 	}
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
@@ -547,6 +549,7 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 
 		aatree_insert(&pam_user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
+    user->pool_size = -1;
 	}
 	if (passwd)
 		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
@@ -564,6 +567,7 @@ PgUser *force_user(PgDatabase *db, const char *name, const char *passwd)
 		list_init(&user->head);
 		list_init(&user->pool_list);
 		user->pool_mode = POOL_INHERIT;
+    user->pool_size = -1;
 	}
 	safe_strcpy(user->name, name, sizeof(user->name));
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));

--- a/src/objects.c
+++ b/src/objects.c
@@ -497,7 +497,7 @@ PgUser *add_user(const char *name, const char *passwd)
 
 		aatree_insert(&user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
-    user->pool_size = -1;
+		user->pool_size = -1;
 	}
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
@@ -523,7 +523,7 @@ PgUser *add_db_user(PgDatabase *db, const char *name, const char *passwd)
 
 		aatree_insert(&db->user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
-    user->pool_size = -1;
+		user->pool_size = -1;
 	}
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
@@ -549,7 +549,7 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 
 		aatree_insert(&pam_user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
-    user->pool_size = -1;
+		user->pool_size = -1;
 	}
 	if (passwd)
 		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
@@ -567,7 +567,7 @@ PgUser *force_user(PgDatabase *db, const char *name, const char *passwd)
 		list_init(&user->head);
 		list_init(&user->pool_list);
 		user->pool_mode = POOL_INHERIT;
-    user->pool_size = -1;
+		user->pool_size = -1;
 	}
 	safe_strcpy(user->name, name, sizeof(user->name));
 	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));

--- a/src/server.c
+++ b/src/server.c
@@ -225,16 +225,15 @@ int pool_pool_mode(PgPool *pool)
 	return pool_mode;
 }
 
-int pool_pool_size(PgPool *pool)
-{
-  int pool_size;
-  if (pool->user->pool_size >= 0)
-    pool_size = pool->user->pool_size;
+int pool_pool_size(PgPool *pool) {
+	int pool_size;
+	if (pool->user->pool_size >= 0)
+		pool_size = pool->user->pool_size;
 	else if (pool->db->pool_size >= 0)
-    pool_size = pool->db->pool_size;
+		pool_size = pool->db->pool_size;
 	else
-    pool_size = cf_default_pool_size;
-  return pool_size;
+		pool_size = cf_default_pool_size;
+	return pool_size;
 }
 
 /* min_pool_size of the pool's db */

--- a/src/server.c
+++ b/src/server.c
@@ -225,7 +225,8 @@ int pool_pool_mode(PgPool *pool)
 	return pool_mode;
 }
 
-int pool_pool_size(PgPool *pool) {
+int pool_pool_size(PgPool *pool)
+{
 	int pool_size;
 	if (pool->user->pool_size >= 0)
 		pool_size = pool->user->pool_size;

--- a/src/server.c
+++ b/src/server.c
@@ -230,9 +230,9 @@ int pool_pool_size(PgPool *pool)
 	if (pool->user && pool->user->pool_size >= 0)
 		return pool->user->pool_size;
 	else if (pool->db->pool_size >= 0)
-    return pool->db->pool_size;
+		return pool->db->pool_size;
 	else
-    return cf_default_pool_size;
+		return cf_default_pool_size;
 }
 
 /* min_pool_size of the pool's db */

--- a/src/server.c
+++ b/src/server.c
@@ -227,10 +227,14 @@ int pool_pool_mode(PgPool *pool)
 
 int pool_pool_size(PgPool *pool)
 {
-	if (pool->db->pool_size < 0)
-		return cf_default_pool_size;
+  int pool_size;
+  if (pool->user->pool_size >= 0)
+    pool_size = pool->user->pool_size;
+	else if (pool->db->pool_size >= 0)
+    pool_size = pool->db->pool_size;
 	else
-		return pool->db->pool_size;
+    pool_size = cf_default_pool_size;
+  return pool_size;
 }
 
 /* min_pool_size of the pool's db */

--- a/src/server.c
+++ b/src/server.c
@@ -227,14 +227,12 @@ int pool_pool_mode(PgPool *pool)
 
 int pool_pool_size(PgPool *pool)
 {
-	int pool_size;
-	if (pool->user->pool_size >= 0)
-		pool_size = pool->user->pool_size;
+	if (pool->user && pool->user->pool_size >= 0)
+		return pool->user->pool_size;
 	else if (pool->db->pool_size >= 0)
-		pool_size = pool->db->pool_size;
+    return pool->db->pool_size;
 	else
-		pool_size = cf_default_pool_size;
-	return pool_size;
+    return cf_default_pool_size;
 }
 
 /* min_pool_size of the pool's db */

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -133,6 +133,7 @@ def pg(tmp_path_factory, cert_dir):
     pg.sql("create user someuser with password 'anypasswd';")
     pg.sql("create user maxedout;")
     pg.sql("create user maxedout2;")
+    pg.sql("create user poolsize1;")
     pg.sql(f"create user longpass with password '{LONG_PASSWORD}';")
     pg.sql("create user stats password 'stats';")
     pg.sql("grant all on schema public to public", dbname="p0")

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,5 +1,6 @@
 [databases]
 p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
+p0a= port=6666 host=127.0.0.1 dbname=p0 pool_size=2
 p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
 p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=2
 ; for testing 'min_pool_size' with forced user
@@ -42,6 +43,7 @@ non_existing_pg_db = port=6666 host=127.0.0.1 dbname=non_existing_pg_db
 [users]
 maxedout = max_user_connections=3
 maxedout2 = max_user_connections=2
+poolsize1 = pool_size=1
 
 [pgbouncer]
 logfile = test.log

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -24,10 +24,10 @@ async def test_max_client_conn(bouncer):
 @pytest.mark.asyncio
 async def test_pool_size(pg, bouncer):
     # per user pool_size
-    await bouncer.asleep(0.5, dbname="p0a", user="poolsize1", times=10)
+    await bouncer.asleep(0.5, dbname="p0a", user="poolsize1", times=3)
     assert pg.connection_count(dbname="p0", users=("poolsize1",)) == 1
     # even though we connect using user poolsize1 its setting do not apply is forced user is configured for db
-    await bouncer.asleep(0.5, dbname="p0", user="poolsize1", times=10)
+    await bouncer.asleep(0.5, dbname="p0", user="poolsize1", times=5)
     assert pg.connection_count(dbname="p0", users=("bouncer",)) == 2
 
     # per db pool_size

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -26,9 +26,9 @@ async def test_pool_size(pg, bouncer):
     # per user pool_size
     await bouncer.asleep(0.5, dbname="p0a", user="poolsize1", times=10)
     assert pg.connection_count(dbname="p0", users=("poolsize1",)) == 1
-
+    # even though we connect using user poolsize1 its setting do not apply is forced user is configured for db
     await bouncer.asleep(0.5, dbname="p0", user="poolsize1", times=10)
-    assert pg.connection_count(dbname="p0", users=("bouncer",)) == 2  # p0 uses forced user 'bouncer' hence settings from poolsize1 do not apply
+    assert pg.connection_count(dbname="p0", users=("bouncer",)) == 2
 
     # per db pool_size
     await bouncer.asleep(0.5, times=5)

--- a/test/userlist.txt
+++ b/test/userlist.txt
@@ -5,6 +5,7 @@
 "pswcheck" "pgbouncer-check"
 "maxedout" ""
 "maxedout2" ""
+"poolsize1" ""
 "bouncer" "zzzz"
 
 ;the following pairs of passwords are "foo" and "bar"


### PR DESCRIPTION
Specifying `pool_size` is now possible in section `[users]` beside `[databases]` or as a global param. Possibility of specifying `pool_size` in user configuration was requested in the associated issue. Resolves #911.

Looking forward to discussing the implementation details or the issue ratioinale if needed.

Thanks,
Michal

Note: This is my first pull request for this project. I picked this issue as it was labeled as 'good-first-issue' and I wanted to get acquainted with the project. 
