### PR TITLE
Correctly handle large and partial startup packets

### DIFF
--- a/include/proto.h
+++ b/include/proto.h
@@ -80,10 +80,22 @@ static inline bool incomplete_header(const struct MBuf *data)
 	return data->data[data->read_pos] == 0;
 }
 
-/* rewind the body of a v3 packet. Does not work for v2 packets, e.g. startup packets */
+/*
+ * rewind the body of a v3 packet. Does not work for v2 packets, e.g. startup
+ * packets
+ */
 static inline void pkt_rewind_v3(PktHdr *pkt)
 {
 	pkt->data.read_pos = NEW_HEADER_LEN;
+}
+
+/*
+ * rewind the body of a v2 packet. Does not work for v3 packets, i.e.
+ * everything except a startup packet
+ */
+static inline void pkt_rewind_v2(PktHdr *pkt)
+{
+	pkt->data.read_pos = OLD_HEADER_LEN;
 }
 
 /* one char desc */

--- a/src/client.c
+++ b/src/client.c
@@ -915,14 +915,34 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 
 	/* don't tolerate partial packets */
 	if (incomplete_pkt(pkt)) {
-		disconnect_client(client, true, "client sent partial pkt in startup phase");
-		return false;
+		if (pkt->len > (unsigned) cf_sbuf_len) {
+			/*
+			 * We need to handle the complete packet, but it is too
+			 * large to fit into our sbuf buffer size (determined
+			 * by the pkt_buf config). So now we need to fetch the
+			 * whole packet using our dynamically sized packet
+			 * buffering logic.
+			 */
+			client->packet_cb_state.flag = CB_WANT_COMPLETE_PACKET;
+			sbuf_prepare_fetch(sbuf, pkt->len);
+			return true;
+		} else {
+			/*
+			 * We need to handle the complete packet, but it fits
+			 * in our sbuf buffer, so we can simply return false to
+			 * indicate to sbuf to retry once it has received more
+			 * data
+			 */
+			return false;
+		}
 	}
 
 	if (client->wait_for_welcome || client->wait_for_auth) {
 		if (finish_client_login(client)) {
-			/* the packet was already parsed */
-			sbuf_prepare_skip(sbuf, pkt->len);
+			if (client->packet_cb_state.flag != CB_HANDLE_COMPLETE_PACKET) {
+				/* the packet was already parsed */
+				sbuf_prepare_skip(sbuf, pkt->len);
+			}
 			return true;
 		} else {
 			return false;
@@ -1089,7 +1109,9 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 		disconnect_client(client, false, "bad packet");
 		return false;
 	}
-	sbuf_prepare_skip(sbuf, pkt->len);
+	if (client->packet_cb_state.flag != CB_HANDLE_COMPLETE_PACKET) {
+		sbuf_prepare_skip(sbuf, pkt->len);
+	}
 	client->request_time = get_cached_time();
 	return true;
 }
@@ -1343,6 +1365,34 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	return true;
 }
 
+
+/*
+ * expect_startup_packet chooses returns true if we expect a startup packet and
+ * false if we expect a regular packet.
+ */
+static bool expect_startup_packet(PgSocket *client)
+{
+	switch (client->state) {
+	case CL_LOGIN:
+		return true;
+		break;
+	case CL_ACTIVE:
+		if (client->wait_for_welcome)
+			return true;
+		else
+			return false;
+		break;
+	case CL_WAITING:
+		fatal("why waiting client in client_proto()");
+	case CL_WAITING_CANCEL:
+	case CL_ACTIVE_CANCEL:
+		fatal("why canceling client in client_proto()");
+	default:
+		fatal("bad client state: %d", client->state);
+	}
+}
+
+
 /* callback from SBuf */
 bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 {
@@ -1409,24 +1459,12 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		}
 
 		client->request_time = get_cached_time();
-		switch (client->state) {
-		case CL_LOGIN:
+		if (expect_startup_packet(client)) {
 			res = handle_client_startup(client, &pkt);
-			break;
-		case CL_ACTIVE:
-			if (client->wait_for_welcome)
-				res = handle_client_startup(client, &pkt);
-			else
-				res = handle_client_work(client, &pkt);
-			break;
-		case CL_WAITING:
-			fatal("why waiting client in client_proto()");
-		case CL_WAITING_CANCEL:
-		case CL_ACTIVE_CANCEL:
-			fatal("why canceling client in client_proto()");
-		default:
-			fatal("bad client state: %d", client->state);
+		} else {
+			res = handle_client_work(client, &pkt);
 		}
+
 		break;
 	case SBUF_EV_FLUSH:
 		/* client is not interested in it */
@@ -1482,8 +1520,13 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		/* fallthrough */
 		case CB_HANDLE_COMPLETE_PACKET:
 			/* Make sure we start reading after the header. */
-			pkt_rewind_v3(&client->packet_cb_state.pkt);
-			res = handle_client_work(client, &client->packet_cb_state.pkt);
+			if (expect_startup_packet(client)) {
+				pkt_rewind_v2(&client->packet_cb_state.pkt);
+				res = handle_client_startup(client, &client->packet_cb_state.pkt);
+			} else {
+				pkt_rewind_v3(&client->packet_cb_state.pkt);
+				res = handle_client_work(client, &client->packet_cb_state.pkt);
+			}
 			if (!res) {
 				return false;
 			}

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -5,7 +5,7 @@ import time
 import psycopg
 import pytest
 
-from .utils import HAVE_IPV6_LOCALHOST, PG_MAJOR_VERSION, WINDOWS
+from .utils import HAVE_IPV6_LOCALHOST, PG_MAJOR_VERSION, PKT_BUF_SIZE, WINDOWS
 
 
 def test_connect_query(bouncer):
@@ -190,14 +190,6 @@ def test_options_startup_param(bouncer):
     ):
         bouncer.test(options="-c timezone")
 
-    too_long_param = "a" * 1000
-
-    with pytest.raises(
-        psycopg.OperationalError,
-        match="unsupported options startup parameter: parameter too long",
-    ):
-        bouncer.test(options="-c timezone=" + too_long_param)
-
     with pytest.raises(
         psycopg.OperationalError,
         match="unsupported startup parameter in options: enable_seqscan",
@@ -223,6 +215,11 @@ def test_options_startup_param(bouncer):
         )
         == "Portugal"
     )
+
+
+def test_startup_packet_larger_than_pktbuf(bouncer):
+    long_string = "1" * PKT_BUF_SIZE
+    bouncer.test(options=f"-c extra_float_digits={long_string}")
 
 
 def test_empty_application_name(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -5,9 +5,7 @@ import psycopg
 import pytest
 from psycopg import pq, sql
 
-from .utils import LIBPQ_SUPPORTS_PIPELINING, LINUX, USE_SUDO
-
-PKT_BUF_SIZE = 4096
+from .utils import LIBPQ_SUPPORTS_PIPELINING, LINUX, PKT_BUF_SIZE, USE_SUDO
 
 
 def test_prepared_statement(bouncer):

--- a/test/utils.py
+++ b/test/utils.py
@@ -132,6 +132,7 @@ def get_max_password_length():
     return max_password_length
 
 
+PKT_BUF_SIZE = 4096
 MAX_PASSWORD_LENGTH = get_max_password_length()
 LONG_PASSWORD = "a" * MAX_PASSWORD_LENGTH
 


### PR DESCRIPTION
We were bailing out from a connection if we did not receive the full
startup packet in one go, or if it didn't fit in pkt_buf. This fixes
these issues by reusing the packet buffering logic that was introduced
for prepared statement support for our startup packet parsing.

Fixes #1056
