### PR TITLE
ci: install PAM development package

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ task:
     - echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main $PGVERSION" | tee /etc/apt/sources.list.d/pgdg.list
     - if [ "$PGVERSION" = 17 ]; then echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg-snapshot main 17" | tee /etc/apt/sources.list.d/pgdg.list; fi
     - apt-get update
-    - pkgs="autoconf automake ca-certificates cpio libc-ares-dev libevent-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv sudo iptables"
+    - pkgs="autoconf automake ca-certificates cpio libc-ares-dev libevent-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv sudo iptables"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi


### PR DESCRIPTION
Although --with-pam option has been used, since the PAM development files are not installed, it was not building with PAM support.

It was the reason that the CI does not detect an issue with the commit b003f7b8b9dbea6a2b95980dc66bd1bd7da964aa.