### PR TITLE
Support --config=value format in options startup parameter

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -711,10 +711,14 @@ static bool set_startup_options(PgSocket *client, const char *options)
 		char *equals;
 		mbuf_rewind_writer(&arg);
 		position = cstr_skip_ws((char *) position);
-		if (strncmp("-c", position, 2) != 0)
+		if (strncmp("-c", position, 2) == 0) {
+			position += 2;
+			position = cstr_skip_ws((char *) position);
+		} else if (strncmp("--", position, 2) == 0) {
+			position += 2;
+		} else {
 			goto fail;
-		position += 2;
-		position = cstr_skip_ws((char *) position);
+		}
 
 		if (!read_escaped_token(&position, &arg)) {
 			if (arg.fixed) {
@@ -749,7 +753,7 @@ static bool set_startup_options(PgSocket *client, const char *options)
 	mbuf_free(&arg);
 	return true;
 fail:
-	disconnect_client(client, true, "unsupported options startup parameter: only '-c config=val' is allowed");
+	disconnect_client(client, true, "unsupported options startup parameter: only '-c config=val' and '--config=val' are allowed");
 	mbuf_free(&arg);
 	return false;
 }

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -165,6 +165,13 @@ def test_options_startup_param(bouncer):
 
     assert (
         bouncer.sql_value(
+            "SHOW timezone", options="--timezone=Portugal  --datestyle=German,\\ YMD"
+        )
+        == "Portugal"
+    )
+
+    assert (
+        bouncer.sql_value(
             "SHOW timezone",
             options="-c t\\imezone=\\P\\o\\r\\t\\ugal  -c    dat\\estyle\\=\\Ge\\rman,\\ YMD",
         )
@@ -180,13 +187,13 @@ def test_options_startup_param(bouncer):
 
     with pytest.raises(
         psycopg.OperationalError,
-        match="unsupported options startup parameter: only '-c config=val' is allowed",
+        match="unsupported options startup parameter: only '-c config=val' and '--config=val' are allowed",
     ):
         bouncer.test(options="-d")
 
     with pytest.raises(
         psycopg.OperationalError,
-        match="unsupported options startup parameter: only '-c config=val' is allowed",
+        match="unsupported options startup parameter: only '-c config=val' and '--config=val' are allowed",
     ):
         bouncer.test(options="-c timezone")
 


### PR DESCRIPTION
The `-c config=value` pattern has been supported in PgBouncer since
PR #878. As described in #952 Postgres also allows to use the
`--config=value`, which honestly seems more readable, but for some
reason is mentioned almost nowhere in the Postgres documentation.

Since #878 this always throws an error, and putting `options` in
`ignore_startup_parameters` wouldn't get rid of this error. So this
should actually be considered a regression for the same reason as #907
was considered a regression (although a much less impactful one given
we've only received two reports of this causing issues).

Fixes #952
