### PR TITLE
Add support for "all" address type in HBA file

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1438,7 +1438,7 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 * Supported record types: `local`, `host`, `hostssl`, `hostnossl`.
 * Database field: Supports `all`, `replication`, `sameuser`, `@file`, multiple names.  Not supported: `samerole`, `samegroup`.
 * User name field: Supports `all`, `@file`, multiple names.  Not supported: `+groupname`.
-* Address field: Supports IPv4, IPv6.  Not supported: DNS names, domain prefixes.
+* Address field: Supports `all`, IPv4, IPv6.  Not supported: `samehost`, `samenet`, DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`
   are supported, plus `peer` and `reject`, but except `any` and `pam`, which only work globally.
 * User name map (`map=`) parameter is supported when `auth_type` is `cert` or `peer`.

--- a/include/hba.h
+++ b/include/hba.h
@@ -16,6 +16,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#define ADDRESS_ALL             1
+
 #define NAME_ALL                1
 #define NAME_SAMEUSER           2
 #define NAME_REPLICATION        4
@@ -27,10 +29,13 @@ enum RuleType {
 	RULE_HOSTNOSSL,
 };
 
-struct NameSlot {
-	size_t strlen;
-	char str[];
+struct HBAAddress {
+	unsigned int flags;
+	int family;
+	uint8_t addr[16];
+	uint8_t mask[16];
 };
+
 struct HBAName {
 	unsigned int flags;
 	struct StrSet *name_set;
@@ -40,9 +45,7 @@ struct HBARule {
 	struct List node;
 	enum RuleType rule_type;
 	int rule_method;
-	int rule_af;
-	uint8_t rule_addr[16];
-	uint8_t rule_mask[16];
+	struct HBAAddress address;
 	struct HBAName db_name;
 	struct HBAName user_name;
 	struct IdentMap *identmap;

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -105,7 +105,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 			res = 0;
 		} else {
 			log_warning("FAIL on line %d: expected '%s' got '%s' - user=%s db=%s addr=%s",
-			    linenr, exp, method2string(res), user, db, addr);
+			    linenr, exp, method2string(rule->rule_method), user, db, addr);
 			res = 1;
 		}
 	}

--- a/test/hba_test.eval
+++ b/test/hba_test.eval
@@ -80,6 +80,12 @@ md5		mdb	muser		ff22:3::1
 trust		mdb	muser		::1
 reject		mdb	muser		::2
 
+# "all" address
+scram-sha-256	mdb3	muser		1.2.3.4
+scram-sha-256	mdb3	muser		face::1
+reject		mdb4	muser		1.2.3.4
+reject		mdb4	muser		face::1
+
 # replication
 reject		mdb		muser		::1	replication
 reject		db		userp		unix	replication

--- a/test/hba_test.rules
+++ b/test/hba_test.rules
@@ -54,6 +54,10 @@ host		mdb	muser		ff11::0/16		md5
 host		mdb	muser		ff20::/12		md5
 host		mdb	muser		::1/128			trust
 
+# "all" address
+host		mdb3	muser		all			scram-sha-256
+host		mdb4	muser		all			reject
+
 # replication
 host		replication	admin	::1/128			trust
 host		db2,replication	admin2	::1/128			trust


### PR DESCRIPTION
This change adds support for "all" address type in HBA file that matches both 0.0.0.0/0 and ::/0, similar to PostgreSQL HBA.

https://postgresql.org/docs/16/auth-pg-hba-conf.html#:~:text=You%20can%20also%20write%20all%20to%20match%20any%20IP%20address