### PR TITLE
Change systemd service file to automatically restart PgBouncer

### DIFF
--- a/etc/pgbouncer.service
+++ b/etc/pgbouncer.service
@@ -35,6 +35,7 @@ User=postgres
 ExecStart=/usr/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
+Restart=on-failure
 #LimitNOFILE=1024
 
 [Install]


### PR DESCRIPTION
In production environments most people will want PgBouncer to
automatically restart if it crashes for some reason. This changes our
systemd template file to do that.

As suggested by @phemmer in https://github.com/pgbouncer/pgbouncer/issues/314#issuecomment-2129664358
