### PR TITLE
Improve documentation on connecting to AWS RDS and SCRAM

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1435,7 +1435,7 @@ file from the `pg_shadow` system table.  Alternatively, use
 `auth_query` instead of `auth_file` to avoid having to maintain a
 separate authentication file.
 
-### Notes on managed servers
+### Note on managed servers
 If the backend server is configured to use SCRAM password authentication PgBouncer cannot 
 successfully authenticate if it does not know either a) user password in plain text or 
 b) corresponding SCRAM secret.
@@ -1450,15 +1450,20 @@ Therefore, fetching an existing SCRAM secret once it has been stored in a manage
 is impossible which makes it hard to configure PgBouncer to use the same SCRAM secret. 
 Nevertheless, SCRAM secret can still be configured and used on both sides using the following trick: 
 
-Generate SCRAM secret for arbitrary password locally (using a custom script or local postgres installation 
-running on your desktop). Then take the secret and set it inside PgBouncer's `userlist.txt` 
-as well as inside managed server via alter role command.
-
-```sql
-alter role <role_name> password 'SCRAM-SHA-256$<iterations>:<salt>$<storedkey>:<serverkey>';
+Generate SCRAM secret for arbitrary password with a tool that is capable of printing out the secret. 
+For example `psql --echo-hidden` and the command `\password` prints out the SCRAM secret 
+to the console before sending it over to the server. 
 ```
-The option of supplying password string that is already in SCRAM-encrypted format is officially supported 
-by PostgreSQL (see <https://www.postgresql.org/docs/current/sql-createrole.htm> for more details).
+Enter new password for user "<role_name>": 
+Enter it again: 
+********* QUERY **********
+ALTER USER <role_name> PASSWORD 'SCRAM-SHA-256$<iterations>:<salt>$<storedkey>:<serverkey>'
+**************************
+```
+Note down the SCRAM secret from the QUERY and set it in PgBouncer's `userlist.txt`. 
+
+If you used a tool other than `psql -E` then you need to set the SCRAM secret also in the server 
+(you can use `alter role <role_name> password '<scram_secret>'` for that).
 
 ## HBA file format
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1464,7 +1464,7 @@ ALTER USER <role_name> PASSWORD 'SCRAM-SHA-256$<iterations>:<salt>$<storedkey>:<
 ```
 Note down the SCRAM secret from the QUERY and set it in PgBouncer's `userlist.txt`. 
 
-If you used a tool other than `psql -E` then you need to set the SCRAM secret also in the server 
+If you used a tool other than `psql --echo-hidden` then you need to set the SCRAM secret also in the server 
 (you can use `alter role <role_name> password '<scram_secret>'` for that).
 
 ## HBA file format

--- a/doc/config.md
+++ b/doc/config.md
@@ -1454,6 +1454,8 @@ Generate SCRAM secret for arbitrary password with a tool that is capable of prin
 For example `psql --echo-hidden` and the command `\password` prints out the SCRAM secret 
 to the console before sending it over to the server. 
 ```
+$ psql --echo-hidden <connection_string>
+postgres=# \password <role_name>
 Enter new password for user "<role_name>": 
 Enter it again: 
 ********* QUERY **********


### PR DESCRIPTION
Improving documentation on connecting to AWS RDS that uses SCRAM authentication.

Some managed servers such as AWS RDS for PostgreSQL restrict access to `pg_authid` (`pg_shadow`) which makes configuration of authentication between PgBouncer and backend server somewhat difficult. Configuring SCRAM for both PgBouncer and backend server has been clearly a pain point for some PgBouncer users who experienced connection problems related to failing authentication (see #787, #981). 

Therefore a better documentation could help clarify these restrictions and prevent some of these issues. Introduced two new sub-chapters: 
## Authentication file format
### Limitations
### Notes on managed servers

one for existing limitations regarding using SCRAM authentication for PgBouncer
and one for restrictions of managed servers (AWS RDS).

Feedback is welcome (especially on clarity of used terminology and brevity).

Resolves #787
Resolves #981 

CC: @petere 