### PR TITLE
Improve run python function

### DIFF
--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -39,14 +39,13 @@ def test_show_version(bouncer):
     admin_version = bouncer.admin_value(f"SHOW VERSION")
     subprocess_result = capture(
         [*bouncer.base_command(), "--version"],
-        shell=False,
     )
     subprocess_version = subprocess_result.split("\n")[0]
     assert admin_version == subprocess_version
 
 
 def test_help(bouncer):
-    run([*bouncer.base_command(), "--help"], shell=False)
+    run([*bouncer.base_command(), "--help"])
 
 
 def test_show_stats(bouncer):

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -226,9 +226,8 @@ def test_physical_rep_pg_basebackup(bouncer, tmp_path):
             bouncer.make_conninfo(),
             "--checkpoint=fast",
             "--pgdata",
-            str(dump_dir),
+            dump_dir,
         ],
-        shell=False,
     )
     children = list(dump_dir.iterdir())
     assert len(children) > 0


### PR DESCRIPTION
This improves the ergonomics of the `run` helper function in our test suit. It now autodetects if `shell=True` or `shell=False` should be passed based on the type of the first argument. It also automatically converts arguments to string in case a list is passed.
