### PR TITLE
Fix for #1098 [memory leaks]

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -464,9 +464,6 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	/* remember dbname */
 	db->dbname = (char *)msg->buf + dbname_ofs;
 
-	Assert(host == NULL);
-	Assert(connect_query == NULL);
-
 	free(tmp_connstr);
 	return true;
 fail:

--- a/src/loader.c
+++ b/src/loader.c
@@ -303,6 +303,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		if (strcmp("dbname", key) == 0) {
 			dbname = val;
 		} else if (strcmp("host", key) == 0) {
+			free(host);
 			host = strdup(val);
 			if (!host) {
 				log_error("out of memory");
@@ -344,6 +345,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 				goto fail;
 			}
 		} else if (strcmp("connect_query", key) == 0) {
+			free(connect_query);
 			connect_query = strdup(val);
 			if (!connect_query) {
 				log_error("out of memory");
@@ -399,6 +401,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 
 	free(db->host);
 	db->host = host;
+	host = NULL;
 	db->port = port;
 	db->pool_size = pool_size;
 	db->min_pool_size = min_pool_size;
@@ -408,6 +411,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	db->server_lifetime = server_lifetime;
 	free(db->connect_query);
 	db->connect_query = connect_query;
+	connect_query = NULL;
 
 	if (!set_param_value(&db->auth_dbname, auth_dbname))
 		goto fail;
@@ -470,10 +474,15 @@ bool parse_database(void *base, const char *name, const char *connstr)
 	/* remember dbname */
 	db->dbname = (char *)msg->buf + dbname_ofs;
 
+	Assert(host == NULL);
+	Assert(connect_query == NULL);
+
 	free(tmp_connstr);
 	return true;
 fail:
 	free(tmp_connstr);
+	free(host);
+	free(connect_query);
 	return false;
 }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -198,6 +198,7 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 		}
 
 		if (strcmp("host", key) == 0) {
+			free(host);
 			host = strdup(val);
 			if (!host) {
 				log_error("out of memory");
@@ -233,13 +234,17 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 
 	free(peer->host);
 	peer->host = host;
+	host = NULL;
 	peer->port = port;
 	peer->pool_size = pool_size;
+
+	Assert(host == NULL);
 
 	free(tmp_connstr);
 	return true;
 fail:
 	free(tmp_connstr);
+	free(host);
 	return false;
 }
 /* fill PgDatabase from connstr */

--- a/src/loader.c
+++ b/src/loader.c
@@ -230,11 +230,8 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 
 	free(peer->host);
 	peer->host = host;
-	host = NULL;
 	peer->port = port;
 	peer->pool_size = pool_size;
-
-	Assert(host == NULL);
 
 	free(tmp_connstr);
 	return true;

--- a/src/loader.c
+++ b/src/loader.c
@@ -198,12 +198,8 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 		}
 
 		if (strcmp("host", key) == 0) {
-			free(host);
-			host = strdup(val);
-			if (!host) {
-				log_error("out of memory");
+			if (!set_param_value(&host, val))
 				goto fail;
-			}
 		} else if (strcmp("port", key) == 0) {
 			port = atoi(val);
 			if (port == 0) {
@@ -308,12 +304,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		if (strcmp("dbname", key) == 0) {
 			dbname = val;
 		} else if (strcmp("host", key) == 0) {
-			free(host);
-			host = strdup(val);
-			if (!host) {
-				log_error("out of memory");
+			if (!set_param_value(&host, val))
 				goto fail;
-			}
 		} else if (strcmp("port", key) == 0) {
 			port = atoi(val);
 			if (port == 0) {
@@ -350,12 +342,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 				goto fail;
 			}
 		} else if (strcmp("connect_query", key) == 0) {
-			free(connect_query);
-			connect_query = strdup(val);
-			if (!connect_query) {
-				log_error("out of memory");
+			if (!set_param_value(&connect_query, val))
 				goto fail;
-			}
 		} else if (strcmp("application_name", key) == 0) {
 			appname = val;
 		} else if (strcmp("auth_query", key) == 0) {


### PR DESCRIPTION
This PR fixes memory leaks in parse_database and parse_peer functions.

See #1098 for details.