### PR TITLE
Fix for #1104 [free PgCredentials]

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -31,6 +31,7 @@ extern struct Slab *peer_cache;
 extern struct Slab *peer_pool_cache;
 extern struct Slab *pool_cache;
 extern struct Slab *user_cache;
+extern struct Slab *credentials_cache;
 extern struct Slab *iobuf_cache;
 extern struct Slab *outstanding_request_cache;
 extern struct Slab *var_list_cache;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -844,7 +844,7 @@ void kill_database(PgDatabase *db)
 	free(db->host);
 
 	if (db->forced_user_credentials)
-		slab_free(user_cache, db->forced_user_credentials);
+		slab_free(credentials_cache, db->forced_user_credentials);
 	free(db->connect_query);
 	if (db->inactive_time) {
 		statlist_remove(&autodatabase_idle_list, &db->head);

--- a/src/objects.c
+++ b/src/objects.c
@@ -138,7 +138,7 @@ static int credentials_node_cmp(uintptr_t userptr, struct AANode *node)
 static void credentials_node_release(struct AANode *node, void *arg)
 {
 	PgCredentials *user = container_of(node, PgCredentials, tree_node);
-	slab_free(user_cache, user);
+	slab_free(credentials_cache, user);
 }
 
 /* initialization before config loading */

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -5,13 +5,7 @@ import time
 import psycopg
 import pytest
 
-from .utils import (
-    HAVE_IPV6_LOCALHOST,
-    PG_MAJOR_VERSION,
-    PKT_BUF_SIZE,
-    USE_UNIX_SOCKETS,
-    WINDOWS,
-)
+from .utils import HAVE_IPV6_LOCALHOST, PG_MAJOR_VERSION, PKT_BUF_SIZE, WINDOWS
 
 
 def test_connect_query(bouncer):
@@ -389,16 +383,13 @@ def test_qa_gh1104(bouncer):
             listen_addr = {bouncer.host}
             listen_port = {bouncer.port}
 
-            auth_type = md5
+            auth_type = trust
             auth_file = {bouncer.auth_path}
+
+            admin_users = pgbouncer
+            
             logfile = {bouncer.log_path}
         """
-
-        if not USE_UNIX_SOCKETS:
-            config += f"unix_socket_dir = \n"
-            config += f"admin_users = pgbouncer\n"
-        else:
-            config += f"unix_socket_dir = {bouncer.admin_host}\n"
 
         with bouncer.run_with_config(config):
             bouncer.admin("RELOAD")  # again

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -395,7 +395,6 @@ def test_qa_gh1104(bouncer):
             bouncer.admin("RELOAD")  # again
 
     n = 0
-
-    while n < 50:
+    while n < 15:
         n = n + 1
         do_attempt(bouncer, n)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -387,7 +387,7 @@ def test_qa_gh1104(bouncer):
             auth_file = {bouncer.auth_path}
 
             admin_users = pgbouncer
-            
+
             logfile = {bouncer.log_path}
         """
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -388,7 +388,6 @@ def test_qa_gh1104(bouncer):
             auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
             auth_user = postgres
             auth_dbname = postgres
-            admin_users = pswcheck
             logfile = {bouncer.log_path}
         """
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -385,9 +385,6 @@ def test_qa_gh1104(bouncer):
 
             auth_type = md5
             auth_file = {bouncer.auth_path}
-            auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
-            auth_user = postgres
-            auth_dbname = postgres
             logfile = {bouncer.log_path}
         """
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -363,19 +363,17 @@ def test_sigusr2_during_shutdown(bouncer):
                 time.sleep(1)
 
 
-def test_qa_gh1104(bouncer):
-    # QA test for GitHub issue #1104 [PgCredentials objects are freed incorrectly]
+def test_issue_1104(bouncer):
+    # regression test for GitHub issue #1104 [PgCredentials objects are freed incorrectly]
 
-    def do_attempt(bouncer, passNum):
-        config = f"""
+    for i in range(1, 15):
+        config = """
             [databases]
         """
 
-        n = 0
-        while n < (10 * passNum):
-            n = n + 1
+        for j in range(1, 10 * i):
             config += f"""
-                testdb_{passNum}_{n} = host={bouncer.pg.host} port={bouncer.pg.port} user=dummy_user_{passNum}_{n}
+                testdb_{i}_{j} = host={bouncer.pg.host} port={bouncer.pg.port} user=dummy_user_{i}_{j}
             """
 
         config += f"""
@@ -392,9 +390,4 @@ def test_qa_gh1104(bouncer):
         """
 
         with bouncer.run_with_config(config):
-            bouncer.admin("RELOAD")  # again
-
-    n = 0
-    while n < 15:
-        n = n + 1
-        do_attempt(bouncer, n)
+            bouncer.admin("RELOAD")

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -5,7 +5,13 @@ import time
 import psycopg
 import pytest
 
-from .utils import HAVE_IPV6_LOCALHOST, PG_MAJOR_VERSION, PKT_BUF_SIZE, WINDOWS
+from .utils import (
+    HAVE_IPV6_LOCALHOST,
+    PG_MAJOR_VERSION,
+    PKT_BUF_SIZE,
+    USE_UNIX_SOCKETS,
+    WINDOWS,
+)
 
 
 def test_connect_query(bouncer):
@@ -387,6 +393,12 @@ def test_qa_gh1104(bouncer):
             auth_file = {bouncer.auth_path}
             logfile = {bouncer.log_path}
         """
+
+        if not USE_UNIX_SOCKETS:
+            config += f"unix_socket_dir = \n"
+            config += f"admin_users = pgbouncer\n"
+        else:
+            config += f"unix_socket_dir = {bouncer.admin_host}\n"
 
         with bouncer.run_with_config(config):
             bouncer.admin("RELOAD")  # again

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -361,3 +361,42 @@ def test_sigusr2_during_shutdown(bouncer):
             with bouncer.log_contains(r"got SIGUSR2 while shutting down, ignoring"):
                 bouncer.sigusr2()
                 time.sleep(1)
+
+
+def test_qa_gh1104(bouncer):
+    # QA test for GitHub issue #1104 [PgCredentials objects are freed incorrectly]
+
+    def do_attempt(bouncer, passNum):
+        config = f"""
+            [databases]
+        """
+
+        n = 0
+        while n < (10 * passNum):
+            n = n + 1
+            config += f"""
+                testdb_{passNum}_{n} = host={bouncer.pg.host} port={bouncer.pg.port} user=dummy_user_{passNum}_{n}
+            """
+
+        config += f"""
+            [pgbouncer]
+            listen_addr = {bouncer.host}
+            listen_port = {bouncer.port}
+
+            auth_type = md5
+            auth_file = {bouncer.auth_path}
+            auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+            auth_user = postgres
+            auth_dbname = postgres
+            admin_users = pswcheck
+            logfile = {bouncer.log_path}
+        """
+
+        with bouncer.run_with_config(config):
+            bouncer.admin("RELOAD")  # again
+
+    n = 0
+
+    while n < 50:
+        n = n + 1
+        do_attempt(bouncer, n)


### PR DESCRIPTION
After the refactoring of the user managament in #1052, we incorrectly freed credentials by calling `slab_free` on a user_cache, instead of `credentials_cache` in two places. This could later cause segfaults because ththe user type is larger than the credentials type, so out of bound reads would be possible when the credential that was put into the user_cache was taken out again and used as a user instead.
