### PR TITLE
Proposal to fix #1103 [problem with pool_list and put_in_order]

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -345,7 +345,6 @@ struct PgStats {
  */
 struct PgPool {
 	struct List head;			/* entry in global pool_list */
-	struct List map_head;			/* entry in user->pool_list */
 
 	PgDatabase *db;			/* corresponding database */
 	/*
@@ -516,7 +515,6 @@ struct PgPool {
  * that use these credentials.
  */
 struct PgCredentials {
-	struct List pool_list;		/* list of pools where pool->user == this user */
 	struct AANode tree_node;	/* used to attach user to tree */
 	char name[MAX_USERNAME];
 	char passwd[MAX_PASSWORD];

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -801,7 +801,6 @@ void kill_pool(PgPool *pool)
 
 	pktbuf_free(pool->welcome_msg);
 
-	list_del(&pool->map_head);
 	statlist_remove(&pool_list, &pool->head);
 	varcache_clean(&pool->orig_vars);
 	slab_free(var_list_cache, pool->orig_vars.var_list);
@@ -819,7 +818,6 @@ void kill_peer_pool(PgPool *pool)
 
 	pktbuf_free(pool->welcome_msg);
 
-	list_del(&pool->map_head);
 	statlist_remove(&peer_pool_list, &pool->head);
 	varcache_clean(&pool->orig_vars);
 	slab_free(var_list_cache, pool->orig_vars.var_list);

--- a/src/objects.c
+++ b/src/objects.c
@@ -506,7 +506,6 @@ PgGlobalUser *add_global_user(const char *name, const char *passwd)
 		user->credentials.global_user = user;
 
 		list_init(&user->head);
-		list_init(&user->credentials.pool_list);
 		safe_strcpy(user->credentials.name, name, sizeof(user->credentials.name));
 		put_in_order(&user->head, &user_list, cmp_user);
 
@@ -550,7 +549,6 @@ PgCredentials *add_dynamic_credentials(PgDatabase *db, const char *name, const c
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&db->user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -580,7 +578,6 @@ PgCredentials *add_pam_credentials(const char *name, const char *passwd)
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&pam_user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -603,7 +600,6 @@ PgCredentials *force_user_credentials(PgDatabase *db, const char *name, const ch
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		credentials->global_user = find_global_user(name);
 		if (!credentials->global_user) {
 			credentials->global_user = add_global_user(name, NULL);
@@ -699,7 +695,6 @@ static PgPool *new_pool(PgDatabase *db, PgCredentials *user_credentials)
 		return NULL;
 
 	list_init(&pool->head);
-	list_init(&pool->map_head);
 	pool->orig_vars.var_list = slab_alloc(var_list_cache);
 
 	pool->user_credentials = user_credentials;
@@ -716,8 +711,6 @@ static PgPool *new_pool(PgDatabase *db, PgCredentials *user_credentials)
 	statlist_init(&pool->active_cancel_req_list, "active_cancel_req_list");
 	statlist_init(&pool->active_cancel_server_list, "active_cancel_server_list");
 	statlist_init(&pool->being_canceled_server_list, "being_canceled_server_list");
-
-	list_append(&user_credentials->pool_list, &pool->map_head);
 
 	/* keep pools in db/user order to make stats faster */
 	put_in_order(&pool->head, &pool_list, cmp_pool);
@@ -742,7 +735,6 @@ static PgPool *new_peer_pool(PgDatabase *db)
 		return NULL;
 
 	list_init(&pool->head);
-	list_init(&pool->map_head);
 	pool->orig_vars.var_list = slab_alloc(var_list_cache);
 
 	pool->db = db;

--- a/src/objects.c
+++ b/src/objects.c
@@ -366,7 +366,7 @@ static int cmp_pool(struct List *i1, struct List *i2)
 
 	if (p1->db != p2->db) {
 		const int c1 = strcmp(p1->db->name, p2->db->name);
-		Assert(c1 != 0); /* databases must be unigue! */
+		Assert(c1 != 0);/* databases must be unigue! */
 		return c1;
 	}
 	{

--- a/src/objects.c
+++ b/src/objects.c
@@ -358,16 +358,22 @@ static int cmp_pool(struct List *i1, struct List *i2)
 {
 	PgPool *p1 = container_of(i1, PgPool, head);
 	PgPool *p2 = container_of(i2, PgPool, head);
-	if (p1->db != p2->db)
-		return strcmp(p1->db->name, p2->db->name);
-	if (p1->user_credentials != p2->user_credentials) {
-		if (p1->user_credentials == NULL) {
-			return 1;
-		}
-		if (p2->user_credentials == NULL) {
-			return -1;
-		}
-		return strcmp(p1->user_credentials->name, p2->user_credentials->name);
+
+	Assert(p1->db);
+	Assert(p2->db);
+	Assert(p1->user_credentials);
+	Assert(p2->user_credentials);
+
+	if (p1->db != p2->db) {
+		const int c1 = strcmp(p1->db->name, p2->db->name);
+		Assert(c1 != 0); /* databases must be unigue! */
+		return c1;
+	}
+	{
+		// It is simplifying a debugging. Compiler, feel free to optimize it.
+		const int c2 = strcmp(p1->user_credentials->name, p2->user_credentials->name);
+		if (c2)
+			return c2;
 	}
 	return 0;
 }
@@ -760,10 +766,18 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
 	if (!db || !user_credentials)
 		return NULL;
 
-	list_for_each(item, &user_credentials->pool_list) {
-		pool = container_of(item, PgPool, map_head);
-		if (pool->db == db)
-			return pool;
+	Assert(user_credentials->name[0]);
+
+	list_for_each(item, &pool_list.head) {
+		pool = container_of(item, PgPool, head);
+		Assert(pool->db);
+		Assert(pool->user_credentials);
+		Assert(pool->user_credentials->name[0]);
+		if (pool->db != db)
+			continue;
+		if (strcmp(pool->user_credentials->name, user_credentials->name) != 0)
+			continue;
+		return pool;
 	}
 
 	return new_pool(db, user_credentials);

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -890,3 +890,40 @@ def test_peer_auth_ident_map(bouncer):
         host=f"{bouncer.admin_host}",
         user="bouncer",
     )
+
+
+def test_qa_gh1103__put_in_order(bouncer):
+    """
+    Check that the pgbouncer handles correctly multiple credentials with one name (isue #1103).
+    """
+
+    config = f"""
+        [databases]
+        * = host={bouncer.pg.host} port={bouncer.pg.port} user=postgres min_pool_size=2
+        [pgbouncer]
+        listen_addr = {bouncer.host}
+        listen_port = {bouncer.port}
+
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+        auth_user = postgres
+        auth_dbname = postgres
+        admin_users = pswcheck
+        logfile = {bouncer.log_path}
+    """
+
+    with bouncer.run_with_config(config):
+        # Let's get an error "no such user"
+        print("POINT #001")
+        with pytest.raises(psycopg.OperationalError, match="no such user"):
+            bouncer.conn(dbname="dummydb2", user="dummyuser2", password="dummypswd2")
+        # Let's wait a few seconds to allow pgbouncer to crash in put_in_order
+        time.sleep(5)
+        # Now we will try to connect with OK parameters
+        print("POINT #002")
+        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
+            with cn.cursor() as cur:
+                cur.execute("select 1")
+
+    print("OK!")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -904,12 +904,12 @@ def test_qa_gh1103__put_in_order(bouncer):
         listen_addr = {bouncer.host}
         listen_port = {bouncer.port}
 
-        auth_type = md5
+        auth_type = trust
         auth_file = {bouncer.auth_path}
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = postgres
         auth_dbname = postgres
-        admin_users = pswcheck
+        admin_users = pgbouncer
         logfile = {bouncer.log_path}
     """
 


### PR DESCRIPTION
Hello,

It is an implementation of my idea to fix an issue #1103.

**Description**

PgCredentials::pool_list is useless and incorrect.

get_pool must work with global pool_list and must check Credentials names (not pointers). The second thing is important because we can have multiple Credentials with one name.