### PR TITLE
Fix for #1107

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -176,7 +176,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 		return;
 	client->pool = get_pool(auth_db, client->db->auth_user_credentials);
 	if (!client->pool) {
-		disconnect_client(client, true, "no memory for auth_db pool");
+		disconnect_client(client, true, "no memory for authentication pool");
 		return;
 	}
 	if (!find_server(client)) {

--- a/src/client.c
+++ b/src/client.c
@@ -175,6 +175,10 @@ static void start_auth_query(PgSocket *client, const char *username)
 	if (!auth_db)
 		return;
 	client->pool = get_pool(auth_db, client->db->auth_user_credentials);
+	if (!client->pool) {
+		disconnect_client(client, true, "no memory for auth_db pool");
+		return;
+	}
 	if (!find_server(client)) {
 		client->wait_for_user_conn = true;
 		return;


### PR DESCRIPTION
start_auth_query does not check that get_pool returned NOT NULL pointer.

As result, find_server (in the next call) may get AV.

See #1107 for details.