### PR TITLE
Exact compare function for PgGlobalUser::credentials::tree_node

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -126,6 +126,14 @@ static void construct_server(void *obj)
 	statlist_init(&server->outstanding_requests, "outstanding_requests");
 }
 
+/* compare string with PgGlobalUser->credentials.name, for usage with btree */
+static int global_user_node_cmp(uintptr_t userptr, struct AANode *node)
+{
+	const char *name = (const char *)userptr;
+	PgGlobalUser *global_user = container_of(node, PgGlobalUser, credentials.tree_node);
+	return strcmp(name, global_user->credentials.name);
+}
+
 /* compare string with PgCredentials->name, for usage with btree */
 static int credentials_node_cmp(uintptr_t userptr, struct AANode *node)
 {
@@ -144,7 +152,7 @@ static void credentials_node_release(struct AANode *node, void *arg)
 /* initialization before config loading */
 void init_objects(void)
 {
-	aatree_init(&user_tree, credentials_node_cmp, NULL);
+	aatree_init(&user_tree, global_user_node_cmp, NULL);
 	aatree_init(&pam_user_tree, credentials_node_cmp, NULL);
 	user_cache = slab_create("user_cache", sizeof(PgGlobalUser), 0, NULL, USUAL_ALLOC);
 	credentials_cache = slab_create("credentials_cache", sizeof(PgCredentials), 0, NULL, USUAL_ALLOC);


### PR DESCRIPTION
Hello,

It is a small proposal for improvements code to avoid any questions and problems in the future.

user_tree stores PgGlobalUser objects but uses credentials_node_cmp that oriented on PgCredentials.

Of course, it works because PgGlobalUser::credentials is a first member of PgGlobalUser.

To avoid any problems in the future, I offer to define and use exact compare function  for PgGlobalUser::credentials::tree_node - global_user_node_cmp.

Thanks.