### PR TITLE
reset pam_user_tree in objects_cleanup

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -2602,6 +2602,7 @@ void objects_cleanup(void)
 	memset(&user_list, 0, sizeof user_list);
 	memset(&database_list, 0, sizeof database_list);
 	memset(&pool_list, 0, sizeof pool_list);
+	memset(&pam_user_tree, 0, sizeof pam_user_tree);
 	memset(&user_tree, 0, sizeof user_tree);
 	memset(&autodatabase_idle_list, 0, sizeof autodatabase_idle_list);
 


### PR DESCRIPTION
objects_cleanup resets user_tree but not do it for pam_user_tree.