### PR TITLE
QA test for issue #1103

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ PG_LDFLAGS = -L$(shell pg_config --libdir)
 USUAL_DIR = ../lib
 
 SUBLOC = test
-DIST_SUBDIRS = ssl
+DIST_SUBDIRS = ssl qa/github
 
 EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 	     hba_test.eval hba_test.rules Makefile \
@@ -14,7 +14,8 @@ EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 	     __init__.py conftest.py utils.py \
 	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
 	     test_misc.py test_no_database.py test_no_user.py test_operations.py \
-	     test_peering.py test_prepared.py test_ssl.py test_timeouts.py
+	     test_peering.py test_prepared.py test_ssl.py test_timeouts.py \
+	     test_qa_gh1103__put_in_order.py
 
 
 UTHASH = ../uthash

--- a/test/qa/github/test_qa_gh001103__put_in_order.py
+++ b/test/qa/github/test_qa_gh001103__put_in_order.py
@@ -16,12 +16,12 @@ def test_qa_gh001103__put_in_order__v01__get_pool(bouncer):
         listen_addr = {bouncer.host}
         listen_port = {bouncer.port}
 
-        auth_type = md5
+        auth_type = trust
         auth_file = {bouncer.auth_path}
         auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
         auth_user = postgres
         auth_dbname = postgres
-        admin_users = pswcheck
+        admin_users = pgbouncer
         logfile = {bouncer.log_path}
     """
 

--- a/test/qa/github/test_qa_gh001103__put_in_order.py
+++ b/test/qa/github/test_qa_gh001103__put_in_order.py
@@ -1,0 +1,41 @@
+import time
+
+import psycopg
+import pytest
+
+
+def test_qa_gh001103__put_in_order__v01__get_pool(bouncer):
+    """
+    Check that the pgbouncer handles correctly multiple credentials with one name (isue #1103).
+    """
+
+    config = f"""
+        [databases]
+        * = host={bouncer.pg.host} port={bouncer.pg.port} user=postgres min_pool_size=2
+        [pgbouncer]
+        listen_addr = {bouncer.host}
+        listen_port = {bouncer.port}
+
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1
+        auth_user = postgres
+        auth_dbname = postgres
+        admin_users = pswcheck
+        logfile = {bouncer.log_path}
+    """
+
+    with bouncer.run_with_config(config):
+        # Let's get an error "no such user"
+        print("POINT #001")
+        with pytest.raises(psycopg.OperationalError, match="no such user"):
+            bouncer.conn(dbname="dummydb2", user="dummyuser2", password="dummypswd2")
+        # Let's wait a few seconds to allow pgbouncer to crash in put_in_order
+        time.sleep(5)
+        # Now we will try to connect with OK parameters
+        print("POINT #002")
+        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
+            with cn.cursor() as cur:
+                cur.execute("select 1")
+
+    print("OK!")


### PR DESCRIPTION
Hello,

Let me to offer this QA test for an issue #1103 - test/qa/github/test_qa_gh001103__put_in_order.py

You may decline it without any problems.

---
This PR will fail without PR #1106.

`FAILED test/qa/github/test_qa_gh001103__put_in_order.py::test_qa_gh001103__put_in_order__v01__get_pool - psycopg.OperationalError: connection is bad: connection to server on socket "/tmp/pytest-of-dima/pytest-105/popen-gw0/test_qa_gh001103__put_in_order0/bouncer/.s.PGSQ...
`

It is an expected behavior.