### PR TITLE
Fix put_in_order crashes

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -516,7 +516,6 @@ struct PgPool {
  * that use these credentials.
  */
 struct PgCredentials {
-	struct List pool_list;		/* list of pools where pool->user == this user */
 	struct AANode tree_node;	/* used to attach user to tree */
 	char name[MAX_USERNAME];
 	char passwd[MAX_PASSWORD];
@@ -543,6 +542,7 @@ struct PgCredentials {
 struct PgGlobalUser {
 	PgCredentials credentials;	/* needs to be first for AAtree */
 	struct List head;	/* used to attach user to list */
+	struct List pool_list;		/* list of pools where pool->user == this user */
 	int pool_mode;
 	int pool_size;				/* max server connections in one pool */
 	int max_user_connections;	/* how much server connections are allowed */

--- a/src/main.c
+++ b/src/main.c
@@ -427,6 +427,7 @@ void load_config(void)
 {
 	static bool loaded = false;
 	bool ok;
+	PgGlobalUser *auth_user;
 
 	set_dbs_dead(true);
 	set_peers_dead(true);
@@ -466,6 +467,15 @@ void load_config(void)
 	} else {
 		hba_free(parsed_hba);
 		parsed_hba = NULL;
+	}
+
+	if (cf_auth_user) {
+		auth_user = find_global_user(cf_auth_user);
+		if (auth_user) {
+			auth_user->credentials.passwd[0] = 0;
+		}
+		auth_user = add_global_user(cf_auth_user, "");
+		auth_user->credentials.dynamic_passwd = false;
 	}
 
 	/* kill dbs */

--- a/src/main.c
+++ b/src/main.c
@@ -469,13 +469,13 @@ void load_config(void)
 		parsed_hba = NULL;
 	}
 
+	/* ensure auth_user is added as a global user even if it isn't in the auth_file */
 	if (cf_auth_user) {
 		auth_user = find_global_user(cf_auth_user);
-		if (auth_user) {
-			auth_user->credentials.passwd[0] = 0;
+		if (!auth_user) {
+			auth_user = add_global_user(cf_auth_user, "");
+			auth_user->credentials.dynamic_passwd = false;
 		}
-		auth_user = add_global_user(cf_auth_user, "");
-		auth_user->credentials.dynamic_passwd = false;
 	}
 
 	/* kill dbs */

--- a/src/main.c
+++ b/src/main.c
@@ -427,7 +427,6 @@ void load_config(void)
 {
 	static bool loaded = false;
 	bool ok;
-	PgGlobalUser *auth_user;
 
 	set_dbs_dead(true);
 	set_peers_dead(true);
@@ -467,15 +466,6 @@ void load_config(void)
 	} else {
 		hba_free(parsed_hba);
 		parsed_hba = NULL;
-	}
-
-	/* ensure auth_user is added as a global user even if it isn't in the auth_file */
-	if (cf_auth_user) {
-		auth_user = find_global_user(cf_auth_user);
-		if (!auth_user) {
-			auth_user = add_global_user(cf_auth_user, "");
-			auth_user->credentials.dynamic_passwd = false;
-		}
 	}
 
 	/* kill dbs */

--- a/src/objects.c
+++ b/src/objects.c
@@ -500,7 +500,7 @@ PgGlobalUser *add_global_user(const char *name, const char *passwd)
 		user->credentials.global_user = user;
 
 		list_init(&user->head);
-		list_init(&user->credentials.pool_list);
+		list_init(&user->pool_list);
 		safe_strcpy(user->credentials.name, name, sizeof(user->credentials.name));
 		put_in_order(&user->head, &user_list, cmp_user);
 
@@ -544,7 +544,6 @@ PgCredentials *add_dynamic_credentials(PgDatabase *db, const char *name, const c
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&db->user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -574,7 +573,6 @@ PgCredentials *add_pam_credentials(const char *name, const char *passwd)
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&pam_user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -597,7 +595,6 @@ PgCredentials *force_user_credentials(PgDatabase *db, const char *name, const ch
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		credentials->global_user = find_global_user(name);
 		if (!credentials->global_user) {
 			credentials->global_user = add_global_user(name, NULL);
@@ -711,7 +708,7 @@ static PgPool *new_pool(PgDatabase *db, PgCredentials *user_credentials)
 	statlist_init(&pool->active_cancel_server_list, "active_cancel_server_list");
 	statlist_init(&pool->being_canceled_server_list, "being_canceled_server_list");
 
-	list_append(&user_credentials->pool_list, &pool->map_head);
+	list_append(&user_credentials->global_user->pool_list, &pool->map_head);
 
 	/* keep pools in db/user order to make stats faster */
 	put_in_order(&pool->head, &pool_list, cmp_pool);
@@ -760,7 +757,7 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
 	if (!db || !user_credentials)
 		return NULL;
 
-	list_for_each(item, &user_credentials->pool_list) {
+	list_for_each(item, &user_credentials->global_user->pool_list) {
 		pool = container_of(item, PgPool, map_head);
 		if (pool->db == db)
 			return pool;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -130,6 +130,8 @@ def pg(tmp_path_factory, cert_dir):
 
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
+
+    pg.sql("create user pgbouncer_auth with superuser")
     pg.sql("create user pswcheck with superuser createdb password 'pgbouncer-check';")
     pg.sql("create user someuser with password 'anypasswd';")
     pg.sql("create user maxedout;")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -131,7 +131,7 @@ def pg(tmp_path_factory, cert_dir):
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
 
-    pg.sql("create user pgbouncer_not_in_auth_file with superuser;")
+    pg.sql("create user pswcheck_not_in_auth_file with superuser;")
     pg.sql("create user pswcheck with superuser createdb password 'pgbouncer-check';")
     pg.sql("create user someuser with password 'anypasswd';")
     pg.sql("create user maxedout;")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -131,7 +131,7 @@ def pg(tmp_path_factory, cert_dir):
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
 
-    pg.sql("create user pgbouncer_auth with superuser")
+    pg.sql("create user pgbouncer_not_in_auth_file with superuser;")
     pg.sql("create user pswcheck with superuser createdb password 'pgbouncer-check';")
     pg.sql("create user someuser with password 'anypasswd';")
     pg.sql("create user maxedout;")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -897,6 +897,9 @@ def test_auth_user_trust_auth_without_auth_file(bouncer) -> None:
     Test that for issue that causes pgbouncer to crash given the following conditions
       1. Connect to pgbouncer as auth user
       2. Auth user is not listed in userlist.txt
+      3. Auth type is trust
+
+    This is a regression test for issue #1116
     """
     config = f"""
         [databases]

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -892,15 +892,12 @@ def test_peer_auth_ident_map(bouncer):
     )
 
 
-def test_auth_user_crash_issue(bouncer) -> None:
+def test_auth_user_trust_auth_without_auth_file(bouncer) -> None:
     """
     Test that for issue that causes pgbouncer to crash given the following conditions
       1. Connect to pgbouncer as auth user
       2. Auth user is not listed in userlist.txt
     """
-
-    hba_conf_file = bouncer.config_dir / "hba.conf"
-
     config = f"""
         [databases]
         postgres = host={bouncer.pg.host} dbname=postgres port={bouncer.pg.port} min_pool_size=2
@@ -908,17 +905,40 @@ def test_auth_user_crash_issue(bouncer) -> None:
         [pgbouncer]
         listen_addr = {bouncer.host}
         listen_port = {bouncer.port}
-        auth_type = hba
-        auth_hba_file = {hba_conf_file}
-        auth_user = pgbouncer_auth
+        auth_type = trust
+        auth_user = pgbouncer_not_in_auth_file
         auth_dbname = postgres
         logfile = {bouncer.log_path}
+        auth_file = {bouncer.auth_path}
     """
 
-    with open(hba_conf_file, "w") as f:
-        f.write(f"host postgres  pgbouncer_auth 0.0.0.0/0 trust")
+    with bouncer.run_with_config(config):
+        with bouncer.conn(
+            dbname="postgres",
+            user="pgbouncer_not_in_auth_file",
+        ) as cn:
+            with cn.cursor() as cur:
+                cur.execute("select 1")
+
+
+def test_auth_user_password_auth_with_auth_file(bouncer):
+    config = f"""
+        [databases]
+        postgres = host={bouncer.pg.host} dbname=postgres port={bouncer.pg.port} min_pool_size=2
+
+        [pgbouncer]
+        listen_addr = {bouncer.host}
+        listen_port = {bouncer.port}
+        auth_type = md5
+        auth_user = pswcheck
+        auth_dbname = postgres
+        logfile = {bouncer.log_path}
+        auth_file = {bouncer.auth_path}
+    """
 
     with bouncer.run_with_config(config):
-        with bouncer.conn(dbname="postgres", user="pgbouncer_auth") as cn:
+        with bouncer.conn(
+            dbname="postgres", user="pswcheck", password="pgbouncer-check"
+        ) as cn:
             with cn.cursor() as cur:
                 cur.execute("select 1")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -935,7 +935,7 @@ def test_auth_user_trust_auth_without_auth_file_reload(bouncer) -> None:
                 cur.execute("select 1")
 
 
-def test_auth_user_trust_auth_without_auth_file_reload_dbname(bouncer) -> None:
+def test_auth_user_at_db_level_trust_auth_without_auth_file_reload(bouncer) -> None:
     """
     This is a regression test for issue #1116, when auth_user was set at the
     database level
@@ -976,6 +976,36 @@ def test_auth_user_with_same_forced_user(bouncer):
         listen_port = {bouncer.port}
         auth_type = trust
         auth_user = postgres
+        auth_dbname = postgres
+        logfile = {bouncer.log_path}
+        auth_file = {bouncer.auth_path}
+    """
+
+    with bouncer.run_with_config(config):
+        # Let's get an error "no such user"
+        with pytest.raises(psycopg.OperationalError, match="no such user"):
+            bouncer.conn(dbname="dummydb2", user="dummyuser2", password="dummypswd2")
+        # Let's wait a few seconds for the janitor to kick in and crash pgbouncer
+        time.sleep(2)
+        # Now we will try to connect with OK parameters
+        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
+            with cn.cursor() as cur:
+                cur.execute("select 1")
+
+
+def test_auth_user_at_db_level_with_same_forced_user(bouncer):
+    """
+    Check that the pgbouncer correctly handles correctly multiple credentials
+    with the same name (isue #1103).
+    """
+
+    config = f"""
+        [databases]
+        * = host={bouncer.pg.host} port={bouncer.pg.port} auth_user=postgres user=postgres min_pool_size=2
+        [pgbouncer]
+        listen_addr = {bouncer.host}
+        listen_port = {bouncer.port}
+        auth_type = trust
         auth_dbname = postgres
         logfile = {bouncer.log_path}
         auth_file = {bouncer.auth_path}

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -38,6 +38,7 @@ def test_auth_dbname_global(bouncer):
     bouncer.admin(f"set auth_type='md5'")
 
     bouncer.test(dbname="p7a", user="someuser", password="anypasswd")
+    bouncer.test(dbname="p7a", user="pswcheck", password="pgbouncer-check")
 
 
 @pytest.mark.md5
@@ -83,6 +84,7 @@ def test_auth_dbname_with_auto_database(bouncer):
     bouncer.admin(f"set auth_type='md5'")
     # postgres is not defined in test.ini
     bouncer.test(dbname="postgres", user="someuser", password="anypasswd")
+    bouncer.test(dbname="postgres", user="pswcheck", password="pgbouncer-check")
 
 
 @pytest.mark.md5
@@ -892,14 +894,23 @@ def test_peer_auth_ident_map(bouncer):
     )
 
 
-def test_auth_user_trust_auth_without_auth_file(bouncer) -> None:
+async def test_auth_user_trust_auth_without_auth_file_set(bouncer) -> None:
     """
-    Test that for issue that causes pgbouncer to crash given the following conditions
-      1. Connect to pgbouncer as auth user
-      2. Auth user is not listed in userlist.txt
-      3. Auth type is trust
+    This is a regression test for issue #1116, using the SET command
+    """
+    bouncer.admin("set auth_user='pswcheck_not_in_auth_file'")
+    bouncer.admin("set auth_type='trust'")
+    with bouncer.conn(
+        dbname="p7a",
+        user="pswcheck_not_in_auth_file",
+    ) as cn:
+        with cn.cursor() as cur:
+            cur.execute("select 1")
 
-    This is a regression test for issue #1116
+
+def test_auth_user_trust_auth_without_auth_file_reload(bouncer) -> None:
+    """
+    This is a regression test for issue #1116, using the RELOAD command
     """
     config = f"""
         [databases]
@@ -909,7 +920,7 @@ def test_auth_user_trust_auth_without_auth_file(bouncer) -> None:
         listen_addr = {bouncer.host}
         listen_port = {bouncer.port}
         auth_type = trust
-        auth_user = pgbouncer_not_in_auth_file
+        auth_user = pswcheck_not_in_auth_file
         auth_dbname = postgres
         logfile = {bouncer.log_path}
         auth_file = {bouncer.auth_path}
@@ -918,22 +929,25 @@ def test_auth_user_trust_auth_without_auth_file(bouncer) -> None:
     with bouncer.run_with_config(config):
         with bouncer.conn(
             dbname="postgres",
-            user="pgbouncer_not_in_auth_file",
+            user="postgres",
         ) as cn:
             with cn.cursor() as cur:
                 cur.execute("select 1")
 
 
-def test_auth_user_password_auth_with_auth_file(bouncer):
+def test_auth_user_trust_auth_without_auth_file_reload_dbname(bouncer) -> None:
+    """
+    This is a regression test for issue #1116, when auth_user was set at the
+    database level
+    """
     config = f"""
         [databases]
-        postgres = host={bouncer.pg.host} dbname=postgres port={bouncer.pg.port} min_pool_size=2
+        postgres = host={bouncer.pg.host} dbname=postgres port={bouncer.pg.port} min_pool_size=2 auth_user=pswcheck_not_in_auth_file
 
         [pgbouncer]
         listen_addr = {bouncer.host}
         listen_port = {bouncer.port}
-        auth_type = md5
-        auth_user = pswcheck
+        auth_type = trust
         auth_dbname = postgres
         logfile = {bouncer.log_path}
         auth_file = {bouncer.auth_path}
@@ -941,7 +955,39 @@ def test_auth_user_password_auth_with_auth_file(bouncer):
 
     with bouncer.run_with_config(config):
         with bouncer.conn(
-            dbname="postgres", user="pswcheck", password="pgbouncer-check"
+            dbname="postgres",
+            user="pswcheck_not_in_auth_file",
         ) as cn:
+            with cn.cursor() as cur:
+                cur.execute("select 1")
+
+
+def test_auth_user_with_same_forced_user(bouncer):
+    """
+    Check that the pgbouncer correctly handles correctly multiple credentials
+    with the same name (isue #1103).
+    """
+
+    config = f"""
+        [databases]
+        * = host={bouncer.pg.host} port={bouncer.pg.port} user=postgres min_pool_size=2
+        [pgbouncer]
+        listen_addr = {bouncer.host}
+        listen_port = {bouncer.port}
+        auth_type = trust
+        auth_user = postgres
+        auth_dbname = postgres
+        logfile = {bouncer.log_path}
+        auth_file = {bouncer.auth_path}
+    """
+
+    with bouncer.run_with_config(config):
+        # Let's get an error "no such user"
+        with pytest.raises(psycopg.OperationalError, match="no such user"):
+            bouncer.conn(dbname="dummydb2", user="dummyuser2", password="dummypswd2")
+        # Let's wait a few seconds for the janitor to kick in and crash pgbouncer
+        time.sleep(2)
+        # Now we will try to connect with OK parameters
+        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
             with cn.cursor() as cur:
                 cur.execute("select 1")


### PR DESCRIPTION
This PR attempts to fix issue #1116. 

The user refactor #1052 led to an issue with pgbouncer instances that use auth pass through. Attempting to connect to the auth_db with the auth_user from a sql client through pgbouncer causes pgbouncer to crash. The workaround for is to add the auth_user to the auth_file so that pgbouncer instantiates a non dynamic user and thus does not attempt to acquire the auth_users credentials in a dynamic way.