### PR TITLE
Fix all known put_in_order crashes

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -516,7 +516,6 @@ struct PgPool {
  * that use these credentials.
  */
 struct PgCredentials {
-	struct List pool_list;		/* list of pools where pool->user == this user */
 	struct AANode tree_node;	/* used to attach user to tree */
 	char name[MAX_USERNAME];
 	char passwd[MAX_PASSWORD];
@@ -543,6 +542,7 @@ struct PgCredentials {
 struct PgGlobalUser {
 	PgCredentials credentials;	/* needs to be first for AAtree */
 	struct List head;	/* used to attach user to list */
+	struct List pool_list;		/* list of pools where pool->user == this user */
 	int pool_mode;
 	int pool_size;				/* max server connections in one pool */
 	int max_user_connections;	/* how much server connections are allowed */

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -505,15 +505,6 @@ struct PgPool {
 
 /*
  * Credentials for a user in login db.
- *
- * For databases where remote user is forced, the pool is:
- * first(db->forced_user_credentials->pool_list), where pool_list has only one entry.
- *
- * For dynamic credentials coming from auth_query, the pool list only contains
- * one pool.
- *
- * Otherwise, ->pool_list contains multiple pools, for all PgDatabases
- * that use these credentials.
  */
 struct PgCredentials {
 	struct AANode tree_node;	/* used to attach user to tree */
@@ -536,6 +527,9 @@ struct PgCredentials {
  * The global user is used for configuration settings and connection count. It
  * includes credentials, but these are empty if the user is not configured in
  * the auth_file.
+ *
+ * global_user->pool_list contains all the pools that this user is used for
+ * each PgDatabases that uses this global user.
  *
  * FIXME: remove ->head as ->tree_node should be enough.
  */

--- a/src/objects.c
+++ b/src/objects.c
@@ -500,7 +500,7 @@ PgGlobalUser *add_global_user(const char *name, const char *passwd)
 		user->credentials.global_user = user;
 
 		list_init(&user->head);
-		list_init(&user->credentials.pool_list);
+		list_init(&user->pool_list);
 		safe_strcpy(user->credentials.name, name, sizeof(user->credentials.name));
 		put_in_order(&user->head, &user_list, cmp_user);
 
@@ -544,7 +544,6 @@ PgCredentials *add_dynamic_credentials(PgDatabase *db, const char *name, const c
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&db->user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -574,7 +573,6 @@ PgCredentials *add_pam_credentials(const char *name, const char *passwd)
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
 
 		aatree_insert(&pam_user_tree, (uintptr_t)credentials->name, &credentials->tree_node);
@@ -597,7 +595,6 @@ PgCredentials *force_user_credentials(PgDatabase *db, const char *name, const ch
 		if (!credentials)
 			return NULL;
 
-		list_init(&credentials->pool_list);
 		credentials->global_user = find_global_user(name);
 		if (!credentials->global_user) {
 			credentials->global_user = add_global_user(name, NULL);
@@ -711,7 +708,7 @@ static PgPool *new_pool(PgDatabase *db, PgCredentials *user_credentials)
 	statlist_init(&pool->active_cancel_server_list, "active_cancel_server_list");
 	statlist_init(&pool->being_canceled_server_list, "being_canceled_server_list");
 
-	list_append(&user_credentials->pool_list, &pool->map_head);
+	list_append(&user_credentials->global_user->pool_list, &pool->map_head);
 
 	/* keep pools in db/user order to make stats faster */
 	put_in_order(&pool->head, &pool_list, cmp_pool);
@@ -760,7 +757,7 @@ PgPool *get_pool(PgDatabase *db, PgCredentials *user_credentials)
 	if (!db || !user_credentials)
 		return NULL;
 
-	list_for_each(item, &user_credentials->pool_list) {
+	list_for_each(item, &user_credentials->global_user->pool_list) {
 		pool = container_of(item, PgPool, map_head);
 		if (pool->db == db)
 			return pool;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -130,6 +130,8 @@ def pg(tmp_path_factory, cert_dir):
 
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")
+
+    pg.sql("create user pswcheck_not_in_auth_file with superuser;")
     pg.sql("create user pswcheck with superuser createdb password 'pgbouncer-check';")
     pg.sql("create user someuser with password 'anypasswd';")
     pg.sql("create user maxedout;")


### PR DESCRIPTION
For a long time we've had issues where users with the same named in the
config would cause strange "put_in_order" errors. These errors happened
in even more cases following the user management refactor that was done
in #1052. Luckily this same user management refactor made fixing the
root-cause very easy: By moving the pool_list to the global user struct
from the credential struct we now ensure that a single pool is only
added once.

Fixes #1116
Fixes #1103
Fixes #502

Resolves #1117
Resolves #1106

Related to #817
Related to #1052
