### PR TITLE
fixed doc build race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,11 @@ htmls:
 		mkdir -p html && $(PANDOC) $$f -o html/`basename $$f`.html; \
 	done
 
-doc/pgbouncer.1 doc/pgbouncer.5:
-	$(MAKE) -C doc $(@F)
+doc/pgbouncer.1:
+	$(MAKE) -C doc pgbouncer.1
+
+doc/pgbouncer.5:
+	$(MAKE) -C doc pgbouncer.5
 
 lint:
 	flake8

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,7 @@ export PACKAGE_VERSION
 
 pgbouncer.%: pgbouncer_%.md
 	$(PANDOC) -s -t man -o $@ $<
+	rm $<
 
 pgbouncer_1.md: filter.py frag-usage-man.md usage.md
 	$(PYTHON) $^ >$@


### PR DESCRIPTION
To run nightly unit tests, we build a bouncer and sometimes encounter an error caused by parallel build, when one part causes files to be cleared. 