### PR TITLE
Make PostgreSQL listen on both IPv4 and IPv6 during tests if IPv6 interface is supported

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -713,7 +713,7 @@ class Postgres(QueryRunner):
 
             # Make PostgreSQL listen on both IPv4 and IPv6 (if supported)
             if HAVE_IPV6_LOCALHOST:
-                pgconf.write("listen_addresses='0.0.0.0,::'\n")
+                pgconf.write("listen_addresses='127.0.0.1,::1'\n")
 
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)

--- a/test/utils.py
+++ b/test/utils.py
@@ -711,6 +711,10 @@ class Postgres(QueryRunner):
             # Make sure this is consistent across platforms
             pgconf.write("datestyle = 'iso, mdy'\n")
 
+            # Make PostgreSQL listen on both IPv4 and IPv6 (if supported)
+            if HAVE_IPV6_LOCALHOST:
+                pgconf.write("listen_addresses='0.0.0.0,::'\n")
+
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)
 


### PR DESCRIPTION
On certain test environments, there can be unconfigurable hosts where IPv6 takes precedence over IPv4 (normally, one could control that through /etc/gai.conf, but if the environment is restricted, it is not possible.) This leads PgBouncer to PostgreSQL connections to be opened in IPv6 traffic, where PostgreSQL doesn't accept such communication since it is not configured to do so. Eventually, the test times out. As an example:

```
#18 231.3 ____________________________ test_client_ssl_scram _____________________________
#18 231.3 [gw0] linux -- Python 3.9.19 /usr/bin/python3
#18 231.3 /orcasql-pgbouncer/test/test_ssl.py:330: in test_client_ssl_scram
#18 231.3     bouncer.psql_test(
#18 231.3         bouncer    = <test.utils.Bouncer object at 0x7f76a7a89070>
#18 231.3         cert       = PosixPath('/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/sites/01-localhost.crt')
#18 231.3         cert_dir   = PosixPath('/tmp/pytest-of-postgres/pytest-0/certs')
#18 231.3         key        = PosixPath('/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/sites/01-localhost.key')
#18 231.3         root       = PosixPath('/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt')
#18 231.3 /orcasql-pgbouncer/test/utils.py:371: in psql_test
#18 231.3     return self.psql("select 1", **kwargs)
#18 231.3         kwargs     = {'host': 'localhost', 'password': 'zzzz', 'sslmode': 'verify-full', 'sslrootcert': PosixPath('/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt'), ...}
#18 231.3         self       = <test.utils.Bouncer object at 0x7f76a7a89070>
#18 231.3 /orcasql-pgbouncer/test/utils.py:319: in psql
#18 231.3     run(["psql", f"port={self.port} {connect_options}", "-c", query], shell=False)
#18 231.3         connect_options = 'host=localhost user=bouncer password=zzzz sslmode=verify-full sslrootcert=/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt dbname=p0 connect_timeout=3 client_encoding=UTF8'
#18 231.3         kwargs     = {'client_encoding': 'UTF8', 'connect_timeout': 3, 'dbname': 'p0', 'host': 'localhost', ...}
#18 231.3         query      = 'select 1'
#18 231.3         self       = <test.utils.Bouncer object at 0x7f76a7a89070>
#18 231.3 /orcasql-pgbouncer/test/utils.py:93: in run
#18 231.3     return subprocess.run(command, *args, check=check, shell=shell, **kwargs)
#18 231.3         args       = ()
#18 231.3         check      = True
#18 231.3         command    = ['psql', 'port=10309 host=localhost user=bouncer password=zzzz sslmode=verify-full sslrootcert=/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt dbname=p0 connect_timeout=3 client_encoding=UTF8', '-c', 'select 1']
#18 231.3         kwargs     = {}
#18 231.3         shell      = False
#18 231.3         silent     = False
#18 231.3 /usr/lib/python3.9/subprocess.py:528: in run
#18 231.3     raise CalledProcessError(retcode, process.args,
#18 231.3 E   subprocess.CalledProcessError: Command '['psql', 'port=10309 host=localhost user=bouncer password=zzzz sslmode=verify-full sslrootcert=/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt dbname=p0 connect_timeout=3 client_encoding=UTF8', '-c', 'select 1']' returned non-zero exit status 2.
#18 231.3         capture_output = False
#18 231.3         check      = True
#18 231.3         input      = None
#18 231.3         kwargs     = {'shell': False}
#18 231.3         popenargs  = (['psql', 'port=10309 host=localhost user=bouncer password=zzzz sslmode=verify-full sslrootcert=/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt dbname=p0 connect_timeout=3 client_encoding=UTF8', '-c', 'select 1'],)
#18 231.3         process    = <Popen: returncode: 2 args: ['psql', 'port=10309 host=localhost user=bouncer...>
#18 231.3         retcode    = 2
#18 231.3         stderr     = None
#18 231.3         stdout     = None
#18 231.3         timeout    = None
#18 231.3 ---------------------------- Captured stdout setup -----------------------------
#18 231.3 server signaled
#18 231.3 ---------------------------- Captured stderr setup -----------------------------
#18 231.3 + pg_ctl -w --pgdata /tmp/pytest-of-postgres/pytest-0/popen-gw0/pgdata reload 
#18 231.3 ----------------------------- Captured stderr call -----------------------------
#18 231.3 + ['psql', 'port=10309 host=localhost user=bouncer password=zzzz sslmode=verify-full sslrootcert=/tmp/pytest-of-postgres/pytest-0/certs/TestCA1/ca.crt dbname=p0 connect_timeout=3 client_encoding=UTF8', '-c', 'select 1'] 
#18 231.3 psql: error: connection to server at "localhost" (127.0.0.1), port 10309 failed: timeout expired
#18 231.3 --------------------------- Captured stdout teardown ---------------------------
#18 231.3 
#18 231.3 
#18 231.3 BOUNCER_LOG /tmp/pytest-of-postgres/pytest-0/popen-gw0/test_client_ssl_scram0/bouncer
#18 231.3 
#18 231.3 2024-07-15 19:43:47.153 UTC [1485] LOG kernel file descriptor limit: 8000 (hard: 65536); max_client_conn: 10, max expected fd use: 29
#18 231.3 2024-07-15 19:43:47.153 UTC [1485] LOG listening on 127.0.0.1:10309
#18 231.3 2024-07-15 19:43:47.153 UTC [1485] LOG listening on unix:/tmp/pytest-of-postgres/pytest-0/popen-gw0/test_client_ssl_scram0/bouncer/.s.PGSQL.10309
#18 231.3 2024-07-15 19:43:47.153 UTC [1485] LOG process up: PgBouncer 1.22.1, libevent 2.1.12-stable (epoll), adns: c-ares 1.19.1, tls: OpenSSL 1.1.1k  FIPS 25 Mar 2021
#18 231.3 2024-07-15 19:43:47.254 UTC [1485] LOG C-0x55f76e478f90: (nodb)/pgbouncer@unix(240):10309 pgbouncer access from unix socket
#18 231.3 2024-07-15 19:43:47.254 UTC [1485] LOG C-0x55f76e478f90: pgbouncer/pgbouncer@unix(240):10309 login attempt: db=pgbouncer user=pgbouncer tls=no
#18 231.3 2024-07-15 19:43:47.255 UTC [1485] LOG C-0x55f76e478f90: pgbouncer/pgbouncer@unix(240):10309 closing because: client close request (age=0s)
#18 231.3 2024-07-15 19:43:47.259 UTC [1485] LOG C-0x55f76e478f90: (nodb)/pgbouncer@unix(240):10309 pgbouncer access from unix socket
#18 231.3 2024-07-15 19:43:47.259 UTC [1485] LOG C-0x55f76e478f90: pgbouncer/pgbouncer@unix(240):10309 login attempt: db=pgbouncer user=pgbouncer tls=no
#18 231.3 2024-07-15 19:43:47.259 UTC [1485] LOG RELOAD command issued
#18 231.3 2024-07-15 19:43:47.262 UTC [1485] LOG C-0x55f76e478f90: pgbouncer/pgbouncer@unix(240):10309 closing because: client close request (age=0s)
#18 231.3 2024-07-15 19:43:47.275 UTC [1485] LOG C-0x55f76e478f90: p0/bouncer@127.0.0.1:44934 login attempt: db=p0 user=bouncer tls=TLSv1.3/TLS_AES_256_GCM_SHA384
#18 231.3 2024-07-15 19:43:47.294 UTC [1485] LOG S-0x55f76e4b6c00: p0/bouncer@[::1]:10201 closing because: connect failed (age=0s)
#18 231.3 2024-07-15 19:43:48.487 UTC [1485] LOG S-0x55f76e4b6c00: p0/bouncer@[::1]:10201 closing because: connect failed (age=0s)
#18 231.3 2024-07-15 19:43:49.815 UTC [1485] LOG S-0x55f76e4b6c00: p0/bouncer@[::1]:10201 closing because: connect failed (age=0s)
#18 231.3 2024-07-15 19:43:50.394 UTC [1485] LOG got SIGTERM, fast exit
```

Below, you can find how PostgreSQL starts, where it doesn't listen on IPv6:

```
cat pg.log
2024-07-19 14:51:52.959 UTC [3355] LOG:  starting PostgreSQL 14.12 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 11.2.0, 64-bit
2024-07-19 14:51:52.960 UTC [3355] LOG:  listening on IPv4 address "127.0.0.1", port 10201
2024-07-19 14:51:52.960 UTC [3355] LOG:  listening on Unix socket "/tmp/.s.PGSQL.10201"
2024-07-19 14:51:52.961 UTC [3356] LOG:  database system was shut down at 2024-07-19 14:51:52 UTC
```

This PR adds a line in postgresql.conf file during test startup to have it listen both IPv4 and IPv6 if the environment variable is set.