### PR TITLE
Add files pgbouncer_hba.conf and pgident.conf to tarball

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -9,8 +9,8 @@ SUBLOC = test
 DIST_SUBDIRS = ssl
 
 EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
-	     hba_test.eval hba_test.rules Makefile \
-	     test.ini stress.py userlist.txt \
+	     hba_test.eval hba_test.rules Makefile pgident.conf\
+	     test.ini stress.py userlist.txt pgbouncer_hba.conf \
 	     __init__.py conftest.py utils.py \
 	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
 	     test_misc.py test_no_database.py test_no_user.py test_operations.py \

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,8 @@ EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
 	     __init__.py conftest.py utils.py \
 	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
 	     test_misc.py test_no_database.py test_no_user.py test_operations.py \
-	     test_peering.py test_prepared.py test_ssl.py test_timeouts.py
+	     test_peering.py test_prepared.py test_ssl.py test_timeouts.py \
+		 test_replication.py
 
 
 UTHASH = ../uthash


### PR DESCRIPTION
These two files are required by regression tests since 1.23.0 but haven't been packed into tarball during make dist. This commit fixes this problem.