### PR TITLE
use server_tls_sslmode default in configuration file

### DIFF
--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -97,8 +97,8 @@ listen_port = 6432
 ;;; TLS settings for connecting to backend databases
 ;;;
 
-;; disable, allow, require, verify-ca, verify-full
-;server_tls_sslmode = disable
+;; disable, allow, prefer, require, verify-ca, verify-full
+;server_tls_sslmode = prefer
 
 ;; Path to that contains trusted CA certs
 ;server_tls_ca_file = <system default>


### PR DESCRIPTION
Issue #866 changed the default server_tls_sslmode to prefer but forgot to update the configuration file.