### PR TITLE
Document current maximum verbosity config value

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -554,6 +554,7 @@ Default: 1
 
 Increase verbosity.  Mirrors the "-v" switch on the command line.
 For example, using "-v -v" on the command line is the same as `verbose=2`.
+2 is the highest currently-supported verbosity.
 
 Default: 0
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -554,7 +554,7 @@ Default: 1
 
 Increase verbosity.  Mirrors the "-v" switch on the command line.
 For example, using "-v -v" on the command line is the same as `verbose=2`.
-2 is the highest currently-supported verbosity.
+3 is the highest currently-supported verbosity.
 
 Default: 0
 


### PR DESCRIPTION
Hey @JelteF, today I was looking to crank the log verbosity up to hopefully diagnose a vexing issue and had to look at the source to learn that setting it to anything higher than 2 would be useless.

Cheers