### PR TITLE
Enable prepared statement support by default

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -399,7 +399,7 @@ existing table. In those cases you can run `RECONNECT` on the PgBouncer admin
 console after doing the migration to force a re-prepare of the query and make
 the error go away.
 
-Default: 0
+Default: 200
 
 
 ## Authentication settings

--- a/src/main.c
+++ b/src/main.c
@@ -274,7 +274,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("max_client_conn", CF_INT, cf_max_client_conn, 0, "100"),
 	CF_ABS("max_db_connections", CF_INT, cf_max_db_connections, 0, "0"),
 	CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),
-	CF_ABS("max_prepared_statements", CF_INT, cf_max_prepared_statements, 0, "0"),
+	CF_ABS("max_prepared_statements", CF_INT, cf_max_prepared_statements, 0, "200"),
 	CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
 	CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),
 	CF_ABS("peer_id", CF_INT, cf_peer_id, 0, "0"),

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -10,7 +10,6 @@ from .utils import LIBPQ_SUPPORTS_PIPELINING, LINUX, PKT_BUF_SIZE, USE_SUDO
 
 def test_prepared_statement(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
-    bouncer.admin(f"set max_prepared_statements=100")
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
@@ -32,7 +31,6 @@ def test_prepared_statement(bouncer):
 
 def test_prepared_statement_params(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
-    bouncer.admin(f"set max_prepared_statements=100")
     prepared_query = "SELECT %s"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
@@ -54,7 +52,6 @@ def test_prepared_statement_params(bouncer):
 
 def test_deallocate_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
-    bouncer.admin(f"set max_prepared_statements=100")
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
@@ -84,7 +81,6 @@ def test_deallocate_all(bouncer):
 
 def test_discard_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
-    bouncer.admin(f"set max_prepared_statements=100")
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur1:
         with bouncer.cur() as cur2:
@@ -113,7 +109,6 @@ def test_discard_all(bouncer):
 
 
 def test_parse_larger_than_pkt_buf(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
     long_string = "1" * PKT_BUF_SIZE * 10
     prepared_query = "SELECT '" + long_string + "'"
     with bouncer.cur() as cur1:
@@ -122,7 +117,6 @@ def test_parse_larger_than_pkt_buf(bouncer):
 
 
 def test_bind_larger_than_pkt_buf(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
     long_string = "1" * PKT_BUF_SIZE * 10
     prepared_query = "SELECT %s::text"
     with bouncer.cur() as cur1:
@@ -136,7 +130,6 @@ def test_bind_larger_than_pkt_buf(bouncer):
 # buffer becomes larger than that it will be freed.
 # (see sbuf_process_pending in  sbuf.c)
 def test_parse_larger_than_pkt_buf_but_smaller_than_4x(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
     long_string = "1" * PKT_BUF_SIZE * 2
     prepared_query = "SELECT '" + long_string + "'"
     with bouncer.cur() as cur1:
@@ -145,7 +138,6 @@ def test_parse_larger_than_pkt_buf_but_smaller_than_4x(bouncer):
 
 
 def test_bind_larger_than_pkt_buf_but_smaller_than_4x(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
     long_string = "1" * PKT_BUF_SIZE * 2
     prepared_query = "SELECT %s::text"
     with bouncer.cur() as cur1:
@@ -159,7 +151,6 @@ def test_bind_larger_than_pkt_buf_but_smaller_than_4x(bouncer):
 # a bug, that if a varcache change was needed, then the callback would not be
 # called again correctly later.
 def test_parse_larger_than_pkt_buf_with_varcache_change(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
     long_string = "1" * PKT_BUF_SIZE * 10
     prepared_query = "SELECT '" + long_string + "'"
     with bouncer.cur(dbname="varcache_change") as cur1:
@@ -246,8 +237,6 @@ def test_evict_statement_cache_pipeline_failure(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_statement_pipeline(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     # Prepare query on the server connection and then disconnect again
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur:
@@ -322,8 +311,6 @@ def test_describe_non_existent_prepared_statement(bouncer):
 # libpq before PG17 does not support sending Close messages
 @pytest.mark.skipif("psycopg.pq.version() < 170000")
 def test_close_prepared_statement(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     with bouncer.conn() as conn:
         result = conn.pgconn.prepare(b"test", b"SELECT 1")
         assert result.status == pq.ExecStatus.COMMAND_OK
@@ -339,8 +326,6 @@ def test_close_prepared_statement(bouncer):
 
 
 def test_statement_name_longer_than_pkt_buf(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     name = b"a" * PKT_BUF_SIZE * 4
 
     with bouncer.conn() as conn:
@@ -363,8 +348,6 @@ def test_statement_name_longer_than_pkt_buf(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_statement_pipeline_error(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     # Prepare query on the server connection and then disconnect again
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur:
@@ -385,8 +368,6 @@ def test_prepared_statement_pipeline_error(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_statement_pipeline_error_delayed_sync(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     # Prepare query on the server connection and then disconnect again
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur:
@@ -416,8 +397,6 @@ def test_prepared_statement_pipeline_error_delayed_sync(bouncer):
 
 
 def test_prepared_failed_prepare(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     with bouncer.cur() as cur:
         with pytest.raises(psycopg.errors.UndefinedTable):
             cur.execute("SELECT * FROM doesnotexistyet", prepare=True)
@@ -428,8 +407,6 @@ def test_prepared_failed_prepare(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_failed_prepare_pipeline(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     with bouncer.conn() as conn:
         with conn.pipeline() as p, conn.cursor() as cur:
             cur.execute("SELECT 1", prepare=True)
@@ -448,8 +425,6 @@ def test_prepared_failed_prepare_pipeline(bouncer):
 
 
 def test_prepared_disallow_name_reuse(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     with bouncer.conn() as conn:
         result = conn.pgconn.prepare(b"test", b"SELECT 1")
         assert result.status == pq.ExecStatus.COMMAND_OK
@@ -466,8 +441,6 @@ def test_prepared_disallow_name_reuse(bouncer):
 # more data.
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_pipeline_with_half_pkt_buf_prepare(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     long_string1 = "1" * (PKT_BUF_SIZE // 2)
     long_string2 = "2" * (PKT_BUF_SIZE // 2)
 
@@ -493,8 +466,6 @@ def test_pipeline_with_half_pkt_buf_prepare(bouncer):
 # data to do so.
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_pipeline_flushes_on_full_pkt_buf(bouncer):
-    bouncer.admin(f"set max_prepared_statements=100")
-
     query = b"SELECT 1"
 
     # We want to construct a Parse packet that is exactly the size of pkt_buf,


### PR DESCRIPTION
By the time we'll release the next PgBouncer version it will be roughly
a year since we added prepared statement support as an opt-in feature.
Quite a few managed services enabled this feature by default. Only very
few issues were reported that were related to it, and all of them have
been fixed.

Since defaults matter, I think it's time that we change the default to
enable this feature by default in the next release. I'd like to merge
this early in the release cycle so that devs have the highest chance of
finding any more issues with it. But I expect no new issues to be found.
