### PR TITLE
Add kill_client command

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -750,11 +750,13 @@ Immediately drop all client and server connections on given database.
 New client connections to a killed database will wait until **RESUME**
 is called.
 
-#### KILL_CLIENT [ptr]
+#### KILL_CLIENT ptr
 
 Immediately kill specificed client connection along with any server 
 connections for the given client. The client to kill, is identified
 by the ptr value that can be found using the SHOW CLIENTS command.
+
+An example command will look something like `KILL_CLIENT 0x561a71404330`
 
 #### SUSPEND
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -750,6 +750,12 @@ Immediately drop all client and server connections on given database.
 New client connections to a killed database will wait until **RESUME**
 is called.
 
+#### KILL_CLIENT [ptr]
+
+Immediately kill specificed client connection along with any server 
+connections for the given client. The client to kill, is identified
+by the ptr value that can be found using the SHOW CLIENTS command.
+
 #### SUSPEND
 
 All socket buffers are flushed and PgBouncer stops listening for data on them.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -752,11 +752,21 @@ is called.
 
 #### KILL_CLIENT ptr
 
-Immediately kill specificed client connection along with any server 
+Immediately kill specificed client connection along with any server
 connections for the given client. The client to kill, is identified
-by the ptr value that can be found using the SHOW CLIENTS command.
+by the ptr value that can be found using the `SHOW CLIENTS` command.
 
-An example command will look something like `KILL_CLIENT 0x561a71404330`
+An example command will look something like `KILL_CLIENT 0x561a71404330`.
+
+Please note that memory addreses are reused and it is possible to kill
+an unintended client. For example if you run `SHOW CLIENTS`, grab a client
+ptr, that client disconnects, a new client connects, then you run `KILL_CLIENT`
+there is a high likelihood that the new client will have the old clients
+ptr and the new client will be disconnected. As such this command should
+only be used on a client who you are certain will not disconnect by themselves
+and should be run immediately after getting the ptr in `SHOW CLIENTS`, ideally
+in an automated script. This is a limitation that we are looking to addres
+in the future.
 
 #### SUSPEND
 

--- a/include/admin.h
+++ b/include/admin.h
@@ -26,5 +26,3 @@ bool admin_flush(PgSocket *admin, PktBuf *buf, const char *desc) /* _MUSTCHECK *
 bool admin_ready(PgSocket *admin, const char *desc)  _MUSTCHECK;
 void admin_handle_cancel(PgSocket *client);
 void admin_cleanup(void);
-PgSocket *find_client_global(const char *arg);
-PgSocket *find_socket_in_list(const char *arg, struct StatList *sockets);

--- a/include/admin.h
+++ b/include/admin.h
@@ -26,3 +26,5 @@ bool admin_flush(PgSocket *admin, PktBuf *buf, const char *desc) /* _MUSTCHECK *
 bool admin_ready(PgSocket *admin, const char *desc)  _MUSTCHECK;
 void admin_handle_cancel(PgSocket *client);
 void admin_cleanup(void);
+PgSocket *find_client_global(const char *arg);
+PgSocket *find_socket_in_list(const char *arg, struct StatList *sockets);

--- a/src/admin.c
+++ b/src/admin.c
@@ -1392,9 +1392,9 @@ static PgSocket *find_client_global(PgSocket *target_client)
 static bool admin_cmd_kill_client(PgSocket *admin, const char *arg)
 {
 	PgSocket *kill_client;
-	PgSocket *target_client;
+	PgSocket *target_client = NULL;
 
-	target_client = (PgSocket *) strtol(arg, NULL, 16);
+	sscanf(arg, "%p", &target_client);
 	kill_client = find_client_global(target_client);
 	if (kill_client == NULL) {
 		return admin_error(admin, "client not found");

--- a/src/admin.c
+++ b/src/admin.c
@@ -1392,15 +1392,18 @@ static PgSocket *find_client_global(PgSocket *target_client)
 static bool admin_cmd_kill_client(PgSocket *admin, const char *arg)
 {
 	PgSocket *kill_client;
-	PgSocket *target_client = NULL;
+	void *target_client = NULL;
 
-	sscanf(arg, "%p", &target_client);
-	kill_client = find_client_global(target_client);
+	if (sscanf(arg, "%p", &target_client) != 1) {
+		return admin_error(admin, "invalid client pointer supplied");
+	}
+
+	kill_client = find_client_global((PgSocket *) target_client);
 	if (kill_client == NULL) {
 		return admin_error(admin, "client not found");
 	}
 	disconnect_client(kill_client, true, "admin forced disconnect");
-	return admin_ready(admin, "KILL");
+	return admin_ready(admin, "KILL_CLIENT");
 }
 
 /* Command: KILL */

--- a/src/admin.c
+++ b/src/admin.c
@@ -1331,7 +1331,6 @@ static bool admin_cmd_enable(PgSocket *admin, const char *arg)
 }
 
 
-
 static PgSocket *find_socket_in_list(PgSocket *target_client, struct StatList *sockets)
 {
 	struct List *item;
@@ -1388,7 +1387,14 @@ static PgSocket *find_client_global(PgSocket *target_client)
 	return NULL;
 }
 
-/* Command: KILL_CLIENT */
+/*
+ * Command: KILL_CLIENT
+ * TODO: This command relies on the memory address of a client to identify which
+ * client to kill. This is potentially dangerous because memory addresses are reused.
+ * The long term solution to this is to assign an integer or UUID identifier to identify
+ * clients instead of memory addresses but we are going to wait to see how much of an
+ * issue this is in practice before implementing this.
+ */
 static bool admin_cmd_kill_client(PgSocket *admin, const char *arg)
 {
 	PgSocket *kill_client;

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -37,6 +37,28 @@ def test_show(bouncer):
         bouncer.admin(f"SHOW {item}")
 
 
+def test_kill_client_nonexisting(bouncer):
+    # Connect to client as user A
+    conn_1 = bouncer.conn(dbname="p0", user="maxedout")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS")
+    assert len(clients) == 2
+
+    # Issue kill client command
+    with pytest.raises(
+        psycopg.errors.ProtocolViolation,
+        match=r"client not found",
+    ):
+        clients = bouncer.admin("KILL_CLIENT non_existant_client_id")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS")
+    assert len(clients) == 2
+
+    conn_1.close()
+
+
 def test_kill_client(bouncer):
     # Connect to client as user A
     conn_1 = bouncer.conn(dbname="p0", user="maxedout")

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,3 +1,5 @@
+import psycopg
+import pytest
 from psycopg.rows import dict_row
 
 from .utils import capture, run
@@ -33,6 +35,27 @@ def test_show(bouncer):
 
     for item in show_items:
         bouncer.admin(f"SHOW {item}")
+
+
+def test_kill_client(bouncer):
+    # Connect to client as user A
+    conn_1 = bouncer.conn(dbname="p0", user="maxedout")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS")
+    assert len(clients) == 2
+
+    # Get clients id
+    client_id = [client for client in clients if client[2] == "p0"][0][-6]
+
+    # Issue kill client command
+    clients = bouncer.admin(f"KILL_CLIENT {client_id}")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS")
+    assert len(clients) == 1
+
+    conn_1.close()
 
 
 def test_show_version(bouncer):


### PR DESCRIPTION
This PR adds a kill_client command to the admin console. This command is the equivalent of the Postgres pg_terminate_backend() function. Similar functionality also exists in other Postgres connection poolers.

In general this functionality is a useful last resort to undisciplined users opening a lot of connections and which block out other users. This is especially prominent with front end GUI DB applications that open a new session for every SQL editor tab.