### PR TITLE
Add support for Type=notify-reload with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ systemd integration
 -------------------
 
 To enable systemd integration, use the `configure` option
-`--with-systemd`.  This allows using `Type=notify` service units as
-well as socket activation.  See `etc/pgbouncer.service` and
-`etc/pgbouncer.socket` for examples.
+`--with-systemd`.  This allows using `Type=notify` (or `Type=notify-reload` if
+you are using systemd 253 or later) as well as socket activation.  See
+`etc/pgbouncer.service` and `etc/pgbouncer.socket` for examples.
 
 Building from Git
 -----------------

--- a/etc/pgbouncer.service
+++ b/etc/pgbouncer.service
@@ -2,8 +2,8 @@
 #
 # - Adjust the paths in ExecStart for your installation.
 #
-# - For systemd 253 and later, pgbouncer supports Type=notify-reload (instead of
-#   Type=notify with ExecReload= command).
+# - For systemd 253 and later, PgBouncer supports Type=notify-reload
+#   (instead of Type=notify with ExecReload= command).
 #
 # - The User setting requires careful consideration.  PgBouncer needs
 #   to be able to place a Unix-domain socket file where PostgreSQL

--- a/etc/pgbouncer.service
+++ b/etc/pgbouncer.service
@@ -2,6 +2,9 @@
 #
 # - Adjust the paths in ExecStart for your installation.
 #
+# - For systemd 253 and later, pgbouncer supports Type=notify-reload (instead of
+#   Type=notify with ExecReload= command).
+#
 # - The User setting requires careful consideration.  PgBouncer needs
 #   to be able to place a Unix-domain socket file where PostgreSQL
 #   clients will look for it.  In the olden days, this was in /tmp,

--- a/src/main.c
+++ b/src/main.c
@@ -565,10 +565,31 @@ static void handle_sigusr2(int sock, short flags, void *arg)
 	}
 }
 
+/*
+ * Notify systemd that we are reloading, including a CLOCK_MONOTONIC timestamp in usec
+ * so that the program is compatible with a Type=notify-reload service.
+ *
+ * See https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
+ *
+ * Note that get_cached_time/get_time_usec from libusual uses gettimeofday
+ * instead of a monotonic clock, otherwise this function would be a single line:
+ *     sd_notifyf(0, "RELOADING=1\nMONOTONIC_USEC=%" PRIu64, get_cached_time());
+ */
+static void notify_reloading(void)
+{
+#ifdef USE_SYSTEMD
+	struct timespec ts;
+	usec_t usec;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	usec = (usec_t)ts.tv_sec * USEC + (usec_t)ts.tv_nsec / (usec_t)1000;
+	sd_notifyf(0, "RELOADING=1\nMONOTONIC_USEC=%" PRIu64, usec);
+#endif
+}
+
 static void handle_sighup(int sock, short flags, void *arg)
 {
 	log_info("got SIGHUP, re-reading config");
-	sd_notify(0, "RELOADING=1");
+	notify_reloading();
 	load_config();
 	if (!sbuf_tls_setup())
 		log_error("TLS configuration could not be reloaded, keeping old configuration");

--- a/src/main.c
+++ b/src/main.c
@@ -566,14 +566,10 @@ static void handle_sigusr2(int sock, short flags, void *arg)
 }
 
 /*
- * Notify systemd that we are reloading, including a CLOCK_MONOTONIC timestamp in usec
- * so that the program is compatible with a Type=notify-reload service.
+ * Notify systemd that we are reloading, including a CLOCK_MONOTONIC timestamp
+ * in usec so that the program is compatible with a Type=notify-reload service.
  *
  * See https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
- *
- * Note that get_cached_time/get_time_usec from libusual uses gettimeofday
- * instead of a monotonic clock, otherwise this function would be a single line:
- *     sd_notifyf(0, "RELOADING=1\nMONOTONIC_USEC=%" PRIu64, get_cached_time());
  */
 static void notify_reloading(void)
 {


### PR DESCRIPTION
This PR adds support for using pgbouncer with `Type=notify-reload` systemd service.

See https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html

Note that `Type=notify-reload` services do not need `ExecReload=` command and use `ReloadSignal=` that conveniently defaults to SIGHUP.