### PR TITLE
Add ability to authenticate a user against a specific database

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -496,6 +496,16 @@ is used, it needs to be installed into each database.
 
 Default: `SELECT usename, passwd FROM pg_shadow WHERE usename=$1`
 
+### auth_query_param_count
+
+Parameter count to bind for `auth_query`
+
+Possible values are 1 and 2.
+If the value is set to 1 only username will be passed as $1,
+if the value will be set to 2 dbname will be passed as $2 param.
+
+Default: 1
+
 ### auth_dbname
 
 Database name in the `[database]` section to be used for authentication purposes. This

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -132,6 +132,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; must have 2 columns - username and password hash.
 ;auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1
 
+;; Number of parameters passed to auth_query
+;; 1: (only username will be passed), 2: (username and dbname will be passed)
+;auth_query_param_count = 1
+
 ;; Authentication database that can be set globally to run "auth_query".
 ;auth_dbname =
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -575,6 +575,7 @@ struct PgDatabase {
 	PgCredentials *forced_user_credentials;	/* if not NULL, the user/psw is forced */
 	PgCredentials *auth_user_credentials;	/* if not NULL, users not in userlist.txt will be looked up on the server */
 	char *auth_query;	/* if not NULL, will be used to fetch password from database. */
+	int auth_query_param_count;	/* parameter count to pass for auth_query, allowed values are: 1 (only username will be passed), 2 (username and dbname will be passed) */
 
 	/*
 	 * run-time state
@@ -798,6 +799,7 @@ extern usec_t cf_dns_zone_check_period;
 extern char *cf_resolv_conf;
 
 extern int cf_auth_type;
+extern int cf_auth_query_param_count;
 extern char *cf_auth_file;
 extern char *cf_auth_query;
 extern char *cf_auth_user;

--- a/src/main.c
+++ b/src/main.c
@@ -110,6 +110,7 @@ int cf_tcp_keepcnt;
 int cf_tcp_keepidle;
 int cf_tcp_keepintvl;
 int cf_tcp_user_timeout;
+int cf_auth_query_param_count;
 
 int cf_auth_type = AUTH_MD5;
 char *cf_auth_file;
@@ -241,6 +242,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT usename, passwd FROM pg_shadow WHERE usename=$1"),
+	CF_ABS("auth_query_param_count", CF_INT, cf_auth_query_param_count, 0, "1"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 	CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),


### PR DESCRIPTION
This PR adds `auth_query_param_count` parameter which can be either `1` or `2`.
 
In case of `1` it will work as before sending binding auth_query with only username parameter, but if it will be set to `2` we will bind the `auth_query` with `username` ($1) and `dbname` ($2) parameters, thus adding ability to check the database in `auth_query` to which the client is trying to connect.

### Usecase

We at Lantern have a usecase where databases are being added dynamically, so under `[databases]` in config file we set `* = host = ..., port = 5432` . But we need to restrict each user to connect to a single database. 

There are currently 2 options to achieve this functionality:
- Using `pg_hba` file and setting `auth_type` to `hba` , but this requires to somehow add and remove lines to `pg_hba` file each time new database is created and deleted and `RELOAD` pgbouncer. This approach also adds additional overhead on backup & restore of the database
- Removing `auth_dbname` config and letting the `auth_db` to fallback to the database user is trying to connect. This approach adds ability to get the database name by using `current_database()` function in the query, but then you can never connect to pgbouncer console anymore as it tries to set the auth_db to pgbouncer and errors as it is forbidden.

This PR will allow to use a central database for auth, table mapping of (rolname , dbname) and use an `auth_query` where we can check if there exists a record in the table where `rolname=$1 and dbname=$2`

### Notes
- When connecting to database directly the pgbouncer auth flow will be bypassed, so in the case described above it will be needed to expose only pgbouncer
- When trying to connect to another database using `\c $dbname` the auth flow will be the same and `auth_query` will prevent connecting to the database if needed.