### PR TITLE
Move string checking utility to libusual

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -70,5 +70,3 @@ bool cf_set_authdb(struct CfValue *cv, const char *value);
 
 /* reserved database name checking */
 bool check_reserved_database(const char *value);
-
-bool strings_equal(const char *str_left, const char *str_right) _MUSTCHECK;

--- a/src/loader.c
+++ b/src/loader.c
@@ -126,7 +126,7 @@ static char * cstr_get_pair(char *p,
  */
 static bool set_param_value(char **old_value, const char *new_value)
 {
-	if (strings_equal(*old_value, new_value))
+	if (strcmpeq(*old_value, new_value))
 		return true;
 
 	if (*old_value)
@@ -376,7 +376,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		bool changed = false;
 		if (strcmp(db->dbname, dbname) != 0) {
 			changed = true;
-		} else if (!strings_equal(host, db->host)) {
+		} else if (!strcmpeq(host, db->host)) {
 			changed = true;
 		} else if (port != db->port) {
 			changed = true;
@@ -386,11 +386,11 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			changed = true;
 		} else if (!username && db->forced_user_credentials) {
 			changed = true;
-		} else if (!strings_equal(connect_query, db->connect_query)) {
+		} else if (!strcmpeq(connect_query, db->connect_query)) {
 			changed = true;
-		} else if (!strings_equal(db->auth_dbname, auth_dbname)) {
+		} else if (!strcmpeq(db->auth_dbname, auth_dbname)) {
 			changed = true;
-		} else if (!strings_equal(db->auth_query, auth_query)) {
+		} else if (!strcmpeq(db->auth_query, auth_query)) {
 			changed = true;
 		}
 		if (changed)

--- a/src/util.c
+++ b/src/util.c
@@ -532,18 +532,3 @@ bool check_reserved_database(const char *value)
 	}
 	return true;
 }
-
-/*
- * Same as strcmp, but handles NULLs. If both sides are NULL, returns "true".
- */
-bool strings_equal(const char *str_left, const char *str_right)
-{
-	if (str_left == NULL && str_right == NULL)
-		return true;
-
-	if (str_left == NULL || str_right == NULL)
-		return false;
-
-	return strcmp(str_left, str_right) == 0;
-}
-

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -79,8 +79,8 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	user = get_token(&ln);
 	addr = get_token(&ln);
 	modifier = get_token(&ln);
-	tls = strings_equal(modifier, "tls");
-	replication = strings_equal(modifier, "replication") ?  REPLICATION_PHYSICAL : REPLICATION_NONE;
+	tls = strcmpeq(modifier, "tls");
+	replication = strcmpeq(modifier, "replication") ?  REPLICATION_PHYSICAL : REPLICATION_NONE;
 	if (!exp)
 		return 0;
 	if (!db || !user)


### PR DESCRIPTION
In the lib it was renamed strings_equal => strcmpeq for naming consistency within libusual

https://github.com/libusual/libusual/pull/57