### PR TITLE
ci: unbreak Postgres 17

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
-    - if [ "$PGVERSION" = 17 ]; then pkgs="$pkgs libpq5=$(apt-cache show libpq5 | grep "^Version: $PGVERSION" | awk '{print $2}')"; fi
+    - if [ "$PGVERSION" = 17 ]; then pkgs="$pkgs libpq5=$(apt-cache show libpq5 | grep "^Version: $PGVERSION" | awk '{print $2}' | sort | tail -n 1)"; fi
     - if [ "$PGVERSION" = 17 ]; then pkgs="$pkgs postgresql-common=$(apt-cache show postgresql-common | grep "^Version: .*pgdg" | awk '{print $2}')"; fi
     - if [ "$PGVERSION" = 17 ]; then pkgs="$pkgs postgresql-client-common=$(apt-cache show postgresql-client-common | grep "^Version: .*pgdg" | awk '{print $2}')"; fi
     - apt-get -y install $pkgs


### PR DESCRIPTION
There are multiple libpq packages to the same version (rc1). Pick the last one.

root@jammy:~# apt-cache show libpq5 | grep "^Version: 17"
Version: 17~rc1-1.pgdg22.04+~20240913.1535.g9b3c3c0
Version: 17~rc1-1.pgdg22.04+~20240906.2136.ge69030c