### PR TITLE
Handle auth_query correctly for replication connections

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -21,4 +21,5 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 bool handle_auth_query_response(PgSocket *client, PktHdr *pkt);
 bool check_db_connection_count(PgSocket *client);
 bool check_user_connection_count(PgSocket *client);
+bool sending_auth_query(PgSocket *client);
 PgDatabase *prepare_auth_database(PgSocket *client) _MUSTCHECK;

--- a/src/client.c
+++ b/src/client.c
@@ -799,7 +799,12 @@ static bool set_startup_options(PgSocket *client, const char *options)
 		 * GUC_REPORT flag, specifically extra_float_digits which is a
 		 * configuration that is set by CREATE SUBSCRIPTION in the
 		 * options parameter.
+		 *
+		 * First free it, because set_startup_options might be called
+		 * multiple times in some cases. One of these being when
+		 * auth_user is enabled.
 		 */
+		free(client->startup_options);
 		client->startup_options = strdup(options);
 		if (!client->startup_options)
 			disconnect_client(client, true, "out of memory");

--- a/src/client.c
+++ b/src/client.c
@@ -164,6 +164,14 @@ static bool send_client_authreq(PgSocket *client)
 	return res;
 }
 
+/*
+ * Returns true if the currently trying to send an auth query to the server.
+ */
+bool sending_auth_query(PgSocket *client)
+{
+	return client->wait_for_user_conn || client->wait_for_user;
+}
+
 static void start_auth_query(PgSocket *client, const char *username)
 {
 	int res;
@@ -179,8 +187,8 @@ static void start_auth_query(PgSocket *client, const char *username)
 		disconnect_client(client, true, "no memory for authentication pool");
 		return;
 	}
+	client->wait_for_user_conn = true;
 	if (!find_server(client)) {
-		client->wait_for_user_conn = true;
 		return;
 	}
 	slog_noise(client, "doing auth_conn query: %s", auth_query);

--- a/src/client.c
+++ b/src/client.c
@@ -165,7 +165,8 @@ static bool send_client_authreq(PgSocket *client)
 }
 
 /*
- * Returns true if the currently trying to send an auth query to the server.
+ * Returns true if the client is currently trying to send an auth query to the
+ * server.
  */
 bool sending_auth_query(PgSocket *client)
 {
@@ -1217,7 +1218,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 
-		if (client->pool && !client->wait_for_user_conn && !client->wait_for_user) {
+		if (client->pool && !sending_auth_query(client)) {
 			disconnect_client(client, true, "client re-sent startup pkt");
 			return false;
 		}

--- a/src/proto.c
+++ b/src/proto.c
@@ -613,7 +613,7 @@ bool send_startup_packet(PgSocket *server)
 	 * to do some special stuff for it.
 	 */
 	client = first_socket(&pool->waiting_client_list);
-	if (client && client->replication) {
+	if (client && client->replication && !sending_auth_query(client)) {
 		server->replication = client->replication;
 		pktbuf_put_string(pkt, "replication");
 		slog_debug(server, "send_startup_packet: creating replication connection");


### PR DESCRIPTION
The way we send an auth_query is a bit strange. We temporarily set the
pool of the client to the pool for the auth_user, and then continue
connection startup like normal. This broke for replication connections
because we would send the replication parameter for that connection too.
This fixes that by only doing our special connection setup logic for
replication connections if we're not currently trying to send an
auth_query.

Fixes #1164
