### PR TITLE
Add pycache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ venv
 .venv
 
 /uncrustify
+
+__pycache__/


### PR DESCRIPTION
This PR adds \_\_pycache\_\_ to pgbouncers .gitignore file. This file is created when running pytest and needs to be manually excluded from commits/PR's. 

Just for some external backup: see the link below  for Githubs recommendations for  python .gitignore files, they incude \_\_pycache\_\_ in this file.

https://github.com/github/gitignore/blob/main/Python.gitignore