### PR TITLE
add uid to client object

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -644,6 +644,7 @@ struct PgSocket {
 
 	PgCredentials *login_user_credentials;	/* presented login, for client it may differ from pool->user */
 
+	int id;
 	int client_auth_type;	/* auth method decided by hba */
 
 	/* the queue of requests that we still expect a server response for */

--- a/include/objects.h
+++ b/include/objects.h
@@ -38,6 +38,8 @@ extern struct Slab *var_list_cache;
 extern struct Slab *server_prepared_statement_cache;
 extern PgPreparedStatement *prepared_statements;
 
+extern int max_client_id;
+
 PgDatabase *find_peer(int peer_id);
 PgDatabase *find_database(const char *name);
 PgDatabase *find_or_register_database(PgSocket *connection, const char *name);

--- a/src/admin.c
+++ b/src/admin.c
@@ -623,13 +623,13 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	return true;
 }
 
-#define SKF_STD "ssssssisiTTiiississi"
-#define SKF_DBG "ssssssisiTTiiississiiiiiiii"
+#define SKF_STD "issssssisiTTiiississi"
+#define SKF_DBG "issssssisiTTiiississiiiiiiii"
 
 static void socket_header(PktBuf *buf, bool debug)
 {
 	pktbuf_write_RowDescription(buf, debug ? SKF_DBG : SKF_STD,
-				    "type", "user", "database", "replication", "state",
+				    "id", "type", "user", "database", "replication", "state",
 				    "addr", "port", "local_addr", "local_port",
 				    "connect_time", "request_time",
 				    "wait", "wait_us", "close_needed",
@@ -701,6 +701,7 @@ static void socket_row(PktBuf *buf, PgSocket *sk, const char *state, bool debug)
 		replication = "physical";
 
 	pktbuf_write_DataRow(buf, debug ? SKF_DBG : SKF_STD,
+			     sk->id,
 			     is_server_socket(sk) ? "S" : "C",
 			     sk->login_user_credentials ? sk->login_user_credentials->name : "(nouser)",
 			     sk->pool && !sk->pool->db->peer_id ? sk->pool->db->name : "(nodb)",

--- a/src/objects.c
+++ b/src/objects.c
@@ -71,7 +71,7 @@ struct Slab *iobuf_cache;
 struct Slab *outstanding_request_cache;
 struct Slab *var_list_cache;
 struct Slab *server_prepared_statement_cache;
-
+int max_client_id;
 /*
  * libevent may still report events when event_del()
  * is called from somewhere else.  So hide just freed
@@ -104,13 +104,15 @@ int get_active_server_count(void)
 static void construct_client(void *obj)
 {
 	PgSocket *client = obj;
-
 	memset(client, 0, sizeof(PgSocket));
 	list_init(&client->head);
 	sbuf_init(&client->sbuf, client_proto);
 	client->vars.var_list = slab_alloc(var_list_cache);
 	client->state = CL_FREE;
 	client->client_prepared_statements = NULL;
+
+	max_client_id++;
+	client->id = max_client_id;
 }
 
 static void construct_server(void *obj)

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -35,6 +35,25 @@ def test_show(bouncer):
         bouncer.admin(f"SHOW {item}")
 
 
+def test_id(bouncer):
+    initial_id = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)[0]["id"]
+
+    clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
+    assert [
+        initial_id + 1,
+    ] == [client["id"] for client in clients]
+
+    clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
+    assert [
+        initial_id + 2,
+    ] == [client["id"] for client in clients]
+
+    clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
+    assert [
+        initial_id + 3,
+    ] == [client["id"] for client in clients]
+
+
 def test_show_version(bouncer):
     admin_version = bouncer.admin_value(f"SHOW VERSION")
     subprocess_result = capture(


### PR DESCRIPTION
This PR adds a numeric identifier to the PgSocket struct which can be used as a unique identifier for clients. Currently the unique identifier that pgbouncer uses is the pointer address of the struct, this suffices as a point in time identifier but over time these addresses are reused because of the dynamics of slab allocation.