### PR TITLE
Add target_session_attrs support for PG 14+ servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,11 +15,13 @@
 /test/hba_test
 /test/log
 /test/pgdata/
+/test/pgdata-standby/
 /test/test.log
 /test/test.pid
 /test/ssl/log
 /test/ssl/tmp/
 /test/ssl/pgdata/
+/test/ssl/pgdata-standby/
 /test/ssl/test.log
 /test/ssl/test.pid
 /test/ssl/TestCA[1-9]/

--- a/doc/config.md
+++ b/doc/config.md
@@ -1237,6 +1237,32 @@ they are logged but ignored otherwise.
 Set the pool mode specific to this database. If not set,
 the default `pool_mode` is used.
 
+### target_session_attrs
+
+Note: This configuration only applies to backend servers that report `hot_standby`
+or `default_transaction_read_only` in startup parameters (i.e. Postgres 14+).
+
+Only allow connections with certain properties, similar to libpq's `target_session_attrs`
+connection parameter. For example: given a comma-separated list of hosts where only is
+writable, `target_session_attrs=primary` will disconnect from any hosts that are not writable.
+
+any
+:   any connection is allowed
+
+read-write
+:   session must accept read-write transactions by default
+
+read-only
+:   session must not accept read-write transactions by default
+
+primary
+:   server must not be in hot standby
+
+standby
+:   server must be in hot standby
+
+Default: `any`
+
 ### max_db_connections
 
 Configure a database-wide maximum (i.e. all pools within the database will

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -447,6 +447,9 @@ maxwait_us
 pool_mode
 :   The pooling mode in use.
 
+target_session_attrs
+:   The target_session_attrs setting in use
+
 #### SHOW PEER_POOLS
 
 A new peer_pool entry is made for each configured peer.
@@ -562,6 +565,9 @@ server_lifetime
 
 pool_mode
 :   The database's override pool_mode, or NULL if the default will be used instead.
+
+target_session_attrs
+:   The database's target_session_attrs if set to a value other than `any`.
 
 max_connections
 :   Maximum number of allowed connections for this database, as set by

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -140,6 +140,14 @@ enum PacketCallbackFlag {
 };
 
 
+enum TargetSessionAttrs {
+	TARGET_SESSION_ANY,
+	TARGET_SESSION_READWRITE,
+	TARGET_SESSION_READONLY,
+	TARGET_SESSION_PRIMARY,
+	TARGET_SESSION_STANDBY
+};
+
 #define is_server_socket(sk) ((sk)->state >= SV_FREE)
 
 
@@ -568,6 +576,7 @@ struct PgDatabase {
 	int max_db_connections;	/* max server connections between all pools */
 	usec_t server_lifetime;	/* max lifetime of server connection */
 	char *connect_query;	/* startup commands to send to server after connect */
+	enum TargetSessionAttrs target_session_attrs;	/* target server type */
 
 	struct PktBuf *startup_params;	/* partial StartupMessage (without user) be sent to server */
 	const char *dbname;	/* server-side name, pointer to inside startup_msg */
@@ -853,6 +862,7 @@ extern char *cf_server_tls_ciphers;
 extern int cf_max_prepared_statements;
 
 extern const struct CfLookup pool_mode_map[];
+extern const struct CfLookup target_session_attrs_map[];
 
 extern usec_t g_suspend_start;
 

--- a/include/server.h
+++ b/include/server.h
@@ -27,3 +27,4 @@ int database_min_pool_size(PgDatabase *db) _MUSTCHECK;
 int pool_res_pool_size(PgPool *pool) _MUSTCHECK;
 int database_max_connections(PgDatabase *db) _MUSTCHECK;
 int user_max_connections(PgGlobalUser *user) _MUSTCHECK;
+bool valid_target_session_attrs(PgSocket *server) _MUSTCHECK;

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -6,6 +6,8 @@ enum VarCacheIdx {
 	VTimeZone,
 	VStdStr,
 	VAppName,
+	VInHotStandby,
+	VDefaultTransactionReadOnly,
 	NumVars
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -230,6 +230,15 @@ const struct CfLookup sslmode_map[] = {
 	{ NULL }
 };
 
+const struct CfLookup target_session_attrs_map[] = {
+	{ "any", TARGET_SESSION_ANY },
+	{ "read-write", TARGET_SESSION_READWRITE },
+	{ "read-only", TARGET_SESSION_READONLY },
+	{ "primary", TARGET_SESSION_PRIMARY },
+	{ "standby", TARGET_SESSION_STANDBY },
+	{ NULL }
+};
+
 /*
  * Add new parameters in alphabetical order. This order is used by SHOW CONFIG.
  */

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -88,7 +88,7 @@ static void init_var_lookup_from_config(const char *cf_track_extra_parameters, i
 
 void init_var_lookup(const char *cf_track_extra_parameters)
 {
-	const char *names[] = { "DateStyle", "client_encoding", "TimeZone", "standard_conforming_strings", "application_name", "in_hot_standby", NULL };
+	const char *names[] = { "DateStyle", "client_encoding", "TimeZone", "standard_conforming_strings" "in_hot_standby", "default_transaction_read_only", NULL };
 	int idx = 0;
 
 	struct var_lookup *lookup = NULL;

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -88,7 +88,7 @@ static void init_var_lookup_from_config(const char *cf_track_extra_parameters, i
 
 void init_var_lookup(const char *cf_track_extra_parameters)
 {
-	const char *names[] = { "DateStyle", "client_encoding", "TimeZone", "standard_conforming_strings", "application_name", NULL };
+	const char *names[] = { "DateStyle", "client_encoding", "TimeZone", "standard_conforming_strings", "application_name", "in_hot_standby", NULL };
 	int idx = 0;
 
 	struct var_lookup *lookup = NULL;

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -258,6 +258,8 @@ void varcache_apply_startup(PktBuf *pkt, PgSocket *client)
 		struct PStr *val = get_value(&client->vars, lk);
 		if (!val)
 			continue;
+		if (strcmp(lk->name, "in_hot_standby") == 0 || strcmp(lk->name, "default_transaction_read_only") == 0)
+			continue;
 
 		slog_debug(client, "varcache_apply_startup: %s=%s", lk->name, val->str);
 		pktbuf_put_string(pkt, lk->name);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -167,6 +167,20 @@ def pg(tmp_path_factory, cert_dir):
     pg.cleanup()
 
 
+@pytest.fixture(scope="session")
+def replica(pg, tmp_path_factory):
+    """Starts a new Postgres replica db that is shared for tests in this process"""
+    replica = Postgres(tmp_path_factory.getbasetemp() / "pgdata_replica")
+    replica.host = "127.0.0.2"
+    replica.port = pg.port
+    replica.init_from(pg)
+    replica.start()
+
+    yield replica
+
+    replica.cleanup()
+
+
 @pytest.mark.asyncio
 @pytest.fixture
 async def bouncer(pg, tmp_path):

--- a/test/test.ini
+++ b/test/test.ini
@@ -48,6 +48,11 @@ non_existing_pg_db = port=6666 host=127.0.0.1 dbname=non_existing_pg_db
 ; https://www.postgresql.org/message-id/flat/CAGECzQTw-dZkVT_RELRzfWRzY714-VaTjoBATYfZq93R8C-auA@mail.gmail.com
 replication = port=6666 host=127.0.0.1 dbname=replication
 
+primary_first = port=6666 host=127.0.0.1,127.0.0.2 dbname=p0 user=bouncer target_session_attrs=primary
+primary_second = port=6666 host=127.0.0.2,127.0.0.1 dbname=p0 user=bouncer target_session_attrs=primary
+standby_first = port=6666 host=127.0.0.2,127.0.0.1 dbname=p0 user=bouncer target_session_attrs=standby
+standby_second = port=6666 host=127.0.0.1,127.0.0.2 dbname=p0 user=bouncer target_session_attrs=standby
+
 ; commented out except for auto-database tests
 ;* = port=6666 host=127.0.0.1
 
@@ -87,3 +92,6 @@ tcp_socket_buffer = 4096
 ;bgbouncer will only track the parameters with GUC_REPORT flag set in Postgres
 track_extra_parameters = search_path, intervalstyle
 ignore_startup_parameters = extra_float_digits
+
+server_login_retry = 1
+client_login_timeout = 5

--- a/test/test_target_session_attrs.py
+++ b/test/test_target_session_attrs.py
@@ -1,0 +1,35 @@
+import psycopg
+import pytest
+
+from .utils import PG_MAJOR_VERSION, Bouncer
+
+if PG_MAJOR_VERSION < 14:
+    pytest.skip(
+        "target_session_attrs only supported on PG 14+", allow_module_level=True
+    )
+
+
+def test_target_session_attrs_primary_first(bouncer, replica):
+    with bouncer.log_contains(r"127.0.0.1:\d+ new connection to server", 1):
+        bouncer.test(dbname="primary_first")
+
+
+def test_target_session_attrs_primary_second(bouncer, replica):
+    with bouncer.log_contains(
+        r"127.0.0.2:\d+ closing because: server does not satisfy target_session_attrs",
+        1,
+    ):
+        bouncer.test(dbname="primary_second")
+
+
+def test_target_session_attrs_standby_first(bouncer, replica):
+    with bouncer.log_contains(r"127.0.0.2:\d+ new connection to server", 1):
+        bouncer.test(dbname="standby_first")
+
+
+def test_target_session_attrs_standby_second(bouncer, replica):
+    with bouncer.log_contains(
+        r"127.0.0.1:\d+ closing because: server does not satisfy target_session_attrs",
+        1,
+    ):
+        bouncer.test(dbname="standby_second")

--- a/test/utils.py
+++ b/test/utils.py
@@ -717,8 +717,7 @@ class Postgres(QueryRunner):
 
     def init_from(self, pg):
         run(
-            f"""pg_basebackup --host={pg.host} --port={pg.port} --username=postgres
-            --checkpoint=fast --no-sync --write-recovery-conf --pgdata={self.pgdata}""",
+            f"pg_basebackup --host={pg.host} --port={pg.port} --username=postgres --checkpoint=fast --no-sync --write-recovery-conf --pgdata={self.pgdata}",
             stdout=subprocess.DEVNULL,
         )
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -715,6 +715,13 @@ class Postgres(QueryRunner):
             if HAVE_IPV6_LOCALHOST:
                 pgconf.write("listen_addresses='127.0.0.1,::1'\n")
 
+    def init_from(self, pg):
+        run(
+            f"""pg_basebackup --host={pg.host} --port={pg.port} --username=postgres
+            --checkpoint=fast --no-sync --write-recovery-conf --pgdata={self.pgdata}""",
+            stdout=subprocess.DEVNULL,
+        )
+
     def pgctl(self, command, **kwargs):
         run(f"pg_ctl -w --pgdata {self.pgdata} {command}", **kwargs)
 
@@ -725,7 +732,9 @@ class Postgres(QueryRunner):
 
     def start(self):
         try:
-            self.pgctl(f'-o "-p {self.port}" -l {self.log_path} start')
+            self.pgctl(
+                f"-o \" -k '' -h {self.host} -p {self.port}\" -l {self.log_path} start"
+            )
         except Exception:
             print("\n\nPG_LOG\n")
             with self.log_path.open() as f:


### PR DESCRIPTION
This is @dpirotte's work to add support for target_session_attrs, allowing pgbouncer to only connect to a database's host if it is in a given state, such as primary or standby.

The implementation relies on specific params from the server that are only passed starting with PG 14, and therefore it only supports PG 14 or later. On older versions, target_session_attrs has no effect.

This is complementary to the proposed `load_balance_hosts` and [was discussed](https://github.com/pgbouncer/pgbouncer/pull/736#discussion_r1222977478) in change in #736