### PR TITLE
ci: update FreeBSD image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-1
   env:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true


### PR DESCRIPTION
According to Fedor Korotkov (Cirrus Labs), FreeBSD 14.0 is not supported anymore. Instead, the current version is 14.1 [1].

[1] https://www.freebsd.org/releases/