### PR TITLE
Use PqMsg_ symbols from PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ pgbouncer_SOURCES = \
 	include/common/builtins.h \
 	include/common/pg_wchar.h \
 	include/common/postgres_compat.h \
+	include/common/protocol.h \
 	include/common/saslprep.h \
 	include/common/scram-common.h \
 	include/common/unicode_combining_table.h \

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -212,37 +212,20 @@ extern int cf_sbuf_len;
 #define MAX_PASSWORD    2048
 
 /*
- * AUTH_* symbols are used for both protocol handling and
- * configuration settings (auth_type, hba).  Some are only applicable
- * to one or the other.
+ * Symbols for authentication type settings (auth_type, hba).
  */
-
-/* no-auth modes */
-#define AUTH_ANY        -1	/* same as trust but without username check */
-#define AUTH_TRUST      AUTH_OK
-
-/* protocol codes in Authentication* 'R' messages from server */
-#define AUTH_OK         0
-#define AUTH_KRB4       1	/* not supported */
-#define AUTH_KRB5       2	/* not supported */
-#define AUTH_PLAIN      3
-#define AUTH_CRYPT      4	/* not supported */
-#define AUTH_MD5        5
-#define AUTH_SCM_CREDS  6	/* not supported */
-#define AUTH_GSS        7	/* not supported */
-#define AUTH_GSS_CONT   8	/* not supported */
-#define AUTH_SSPI       9	/* not supported */
-#define AUTH_SASL       10
-#define AUTH_SASL_CONT  11
-#define AUTH_SASL_FIN   12
-
-/* internal codes */
-#define AUTH_CERT       107
-#define AUTH_PEER       108
-#define AUTH_HBA        109
-#define AUTH_REJECT     110
-#define AUTH_PAM        111
-#define AUTH_SCRAM_SHA_256      112
+enum auth_type {
+	AUTH_TYPE_ANY,
+	AUTH_TYPE_TRUST,
+	AUTH_TYPE_PLAIN,
+	AUTH_TYPE_MD5,
+	AUTH_TYPE_CERT,
+	AUTH_TYPE_HBA,
+	AUTH_TYPE_PAM,
+	AUTH_TYPE_SCRAM_SHA_256,
+	AUTH_TYPE_PEER,
+	AUTH_TYPE_REJECT,
+};
 
 /* type codes for weird pkts */
 #define PKT_STARTUP_V2  0x20000

--- a/include/common/protocol.h
+++ b/include/common/protocol.h
@@ -1,0 +1,89 @@
+/*-------------------------------------------------------------------------
+ *
+ * protocol.h
+ *		Definitions of the request/response codes for the wire protocol.
+ *
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/libpq/protocol.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PROTOCOL_H
+#define PROTOCOL_H
+
+/* These are the request codes sent by the frontend. */
+
+#define PqMsg_Bind					'B'
+#define PqMsg_Close					'C'
+#define PqMsg_Describe				'D'
+#define PqMsg_Execute				'E'
+#define PqMsg_FunctionCall			'F'
+#define PqMsg_Flush					'H'
+#define PqMsg_Parse					'P'
+#define PqMsg_Query					'Q'
+#define PqMsg_Sync					'S'
+#define PqMsg_Terminate				'X'
+#define PqMsg_CopyFail				'f'
+#define PqMsg_GSSResponse			'p'
+#define PqMsg_PasswordMessage		'p'
+#define PqMsg_SASLInitialResponse	'p'
+#define PqMsg_SASLResponse			'p'
+
+
+/* These are the response codes sent by the backend. */
+
+#define PqMsg_ParseComplete			'1'
+#define PqMsg_BindComplete			'2'
+#define PqMsg_CloseComplete			'3'
+#define PqMsg_NotificationResponse	'A'
+#define PqMsg_CommandComplete		'C'
+#define PqMsg_DataRow				'D'
+#define PqMsg_ErrorResponse			'E'
+#define PqMsg_CopyInResponse		'G'
+#define PqMsg_CopyOutResponse		'H'
+#define PqMsg_EmptyQueryResponse	'I'
+#define PqMsg_BackendKeyData		'K'
+#define PqMsg_NoticeResponse		'N'
+#define PqMsg_AuthenticationRequest 'R'
+#define PqMsg_ParameterStatus		'S'
+#define PqMsg_RowDescription		'T'
+#define PqMsg_FunctionCallResponse	'V'
+#define PqMsg_CopyBothResponse		'W'
+#define PqMsg_ReadyForQuery			'Z'
+#define PqMsg_NoData				'n'
+#define PqMsg_PortalSuspended		's'
+#define PqMsg_ParameterDescription	't'
+#define PqMsg_NegotiateProtocolVersion 'v'
+
+
+/* These are the codes sent by both the frontend and backend. */
+
+#define PqMsg_CopyDone				'c'
+#define PqMsg_CopyData				'd'
+
+
+/* These are the codes sent by parallel workers to leader processes. */
+#define PqMsg_Progress              'P'
+
+
+/* These are the authentication request codes sent by the backend. */
+
+#define AUTH_REQ_OK			0	/* User is authenticated  */
+#define AUTH_REQ_KRB4		1	/* Kerberos V4. Not supported any more. */
+#define AUTH_REQ_KRB5		2	/* Kerberos V5. Not supported any more. */
+#define AUTH_REQ_PASSWORD	3	/* Password */
+#define AUTH_REQ_CRYPT		4	/* crypt password. Not supported any more. */
+#define AUTH_REQ_MD5		5	/* md5 password */
+/* 6 is available.  It was used for SCM creds, not supported any more. */
+#define AUTH_REQ_GSS		7	/* GSSAPI without wrap() */
+#define AUTH_REQ_GSS_CONT	8	/* Continue GSS exchanges */
+#define AUTH_REQ_SSPI		9	/* SSPI negotiate without wrap() */
+#define AUTH_REQ_SASL	   10	/* Begin SASL authentication */
+#define AUTH_REQ_SASL_CONT 11	/* Continue SASL authentication */
+#define AUTH_REQ_SASL_FIN  12	/* Final SASL message */
+#define AUTH_REQ_MAX	   AUTH_REQ_SASL_FIN	/* maximum AUTH_REQ_* value */
+
+#endif							/* PROTOCOL_H */

--- a/include/objects.h
+++ b/include/objects.h
@@ -70,8 +70,8 @@ PgCredentials *add_global_credentials(const char *name, const char *passwd) _MUS
 PgCredentials * add_dynamic_credentials(PgDatabase *db, const char *name, const char *passwd) _MUSTCHECK;
 PgCredentials * force_user_credentials(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
 bool add_outstanding_request(PgSocket *client, char type, ResponseAction action) _MUSTCHECK;
-bool pop_outstanding_request(PgSocket *client, char *types, bool *skip);
-bool clear_outstanding_requests_until(PgSocket *server, char *types) _MUSTCHECK;
+bool pop_outstanding_request(PgSocket *client, const char types[], bool *skip);
+bool clear_outstanding_requests_until(PgSocket *server, const char types[]) _MUSTCHECK;
 bool queue_fake_response(PgSocket *client, char request_type) _MUSTCHECK;
 
 PgCredentials * add_pam_credentials(const char *name, const char *passwd) _MUSTCHECK;

--- a/include/pktbuf.h
+++ b/include/pktbuf.h
@@ -20,6 +20,8 @@
  * Safe & easy creation of PostgreSQL packets.
  */
 
+#include "common/protocol.h"
+
 typedef struct PktBuf PktBuf;
 struct PktBuf {
 	uint8_t *buf;
@@ -80,19 +82,19 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
  * Shortcuts for actual packets.
  */
 #define pktbuf_write_ParameterStatus(buf, key, val) \
-	pktbuf_write_generic(buf, 'S', "ss", key, val)
+	pktbuf_write_generic(buf, PqMsg_ParameterStatus, "ss", key, val)
 
 #define pktbuf_write_AuthenticationOk(buf) \
-	pktbuf_write_generic(buf, 'R', "i", 0)
+	pktbuf_write_generic(buf, PqMsg_AuthenticationRequest, "i", 0)
 
 #define pktbuf_write_ReadyForQuery(buf) \
-	pktbuf_write_generic(buf, 'Z', "c", 'I')
+	pktbuf_write_generic(buf, PqMsg_ReadyForQuery, "c", 'I')
 
 #define pktbuf_write_CommandComplete(buf, desc) \
-	pktbuf_write_generic(buf, 'C', "s", desc)
+	pktbuf_write_generic(buf, PqMsg_CommandComplete, "s", desc)
 
 #define pktbuf_write_BackendKeyData(buf, key) \
-	pktbuf_write_generic(buf, 'K', "b", key, 8)
+	pktbuf_write_generic(buf, PqMsg_BackendKeyData, "b", key, 8)
 
 #define pktbuf_write_CancelRequest(buf, key) \
 	pktbuf_write_generic(buf, PKT_CANCEL, "b", key, 8)
@@ -102,37 +104,37 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...);
 		unsupported_protocol_extensions_count, \
 		unsupported_protocol_extensions_bytes, \
 		unsupported_protocol_extensions_bytes_length) \
-	pktbuf_write_generic(buf, 'v', "iib", PKT_STARTUP_V3, unsupported_protocol_extensions_count, unsupported_protocol_extensions_bytes, unsupported_protocol_extensions_bytes_length)
+	pktbuf_write_generic(buf, PqMsg_NegotiateProtocolVersion, "iib", PKT_STARTUP_V3, unsupported_protocol_extensions_count, unsupported_protocol_extensions_bytes, unsupported_protocol_extensions_bytes_length)
 
 #define pktbuf_write_PasswordMessage(buf, psw) \
-	pktbuf_write_generic(buf, 'p', "s", psw)
+	pktbuf_write_generic(buf, PqMsg_PasswordMessage, "s", psw)
 
 #define pkgbuf_write_SASLInitialResponseMessage(buf, mech, cir) \
-	pktbuf_write_generic(buf, 'p', "sib", mech, strlen(cir), cir, strlen(cir))
+	pktbuf_write_generic(buf, PqMsg_SASLInitialResponse, "sib", mech, strlen(cir), cir, strlen(cir))
 
 #define pkgbuf_write_SASLResponseMessage(buf, cr) \
-	pktbuf_write_generic(buf, 'p', "b", cr, strlen(cr))
+	pktbuf_write_generic(buf, PqMsg_SASLResponse, "b", cr, strlen(cr))
 
 #define pktbuf_write_Notice(buf, msg) \
-	pktbuf_write_generic(buf, 'N', "sscss", "SNOTICE", "C00000", 'M', msg, "");
+	pktbuf_write_generic(buf, PqMsg_NoticeResponse, "sscss", "SNOTICE", "C00000", 'M', msg, "");
 
 #define pktbuf_write_SSLRequest(buf) \
 	pktbuf_write_generic(buf, PKT_SSLREQ, "")
 
 #define pktbuf_write_Parse(buf, stmt, query_and_parameters, query_and_parameters_len) \
-	pktbuf_write_generic(buf, 'P', "sb", stmt, query_and_parameters, query_and_parameters_len)
+	pktbuf_write_generic(buf, PqMsg_Parse, "sb", stmt, query_and_parameters, query_and_parameters_len)
 
 #define pktbuf_write_ParseComplete(buf) \
-	pktbuf_write_generic(buf, '1', "")
+	pktbuf_write_generic(buf, PqMsg_ParseComplete, "")
 
 #define pktbuf_write_DescribeStmt(buf, stmt) \
-	pktbuf_write_generic(buf, 'D', "cs", 'S', stmt)
+	pktbuf_write_generic(buf, PqMsg_Describe, "cs", 'S', stmt)
 
 #define pktbuf_write_CloseStmt(buf, stmt) \
-	pktbuf_write_generic(buf, 'C', "cs", 'S', stmt)
+	pktbuf_write_generic(buf, PqMsg_Close, "cs", 'S', stmt)
 
 #define pktbuf_write_CloseComplete(buf) \
-	pktbuf_write_generic(buf, '3', "")
+	pktbuf_write_generic(buf, PqMsg_CloseComplete, "")
 
 /*
  * Shortcut for creating DataRow in memory.

--- a/src/admin.c
+++ b/src/admin.c
@@ -355,7 +355,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 		password = sk->login_user_credentials->passwd;
 
 	/* PAM requires passwords as well since they are not stored externally */
-	if (cf_auth_type == AUTH_PAM && !find_global_user(sk->login_user_credentials->name))
+	if (cf_auth_type == AUTH_TYPE_PAM && !find_global_user(sk->login_user_credentials->name))
 		password = sk->login_user_credentials->passwd;
 
 	if (sk->pool && sk->pool->user_credentials && sk->pool->user_credentials->has_scram_keys)
@@ -1769,7 +1769,7 @@ bool admin_pre_login(PgSocket *client, const char *username)
 	 * auth_type=any does not keep original username around,
 	 * so username based check has to take place here
 	 */
-	if (cf_auth_type == AUTH_ANY) {
+	if (cf_auth_type == AUTH_TYPE_ANY) {
 		if (strlist_contains(cf_admin_users, username)) {
 			client->login_user_credentials = admin_pool->db->forced_user_credentials;
 			client->admin_user = true;
@@ -1789,7 +1789,7 @@ bool admin_post_login(PgSocket *client)
 {
 	const char *username = client->login_user_credentials->name;
 
-	if (cf_auth_type == AUTH_ANY)
+	if (cf_auth_type == AUTH_TYPE_ANY)
 		return true;
 
 	if (client->admin_user || strlist_contains(cf_admin_users, username)) {

--- a/src/admin.c
+++ b/src/admin.c
@@ -1529,7 +1529,7 @@ static bool copy_arg(const char *src, regmatch_t *glist,
 static bool admin_show_help(PgSocket *admin, const char *arg)
 {
 	bool res;
-	SEND_generic(res, admin, 'N',
+	SEND_generic(res, admin, PqMsg_NoticeResponse,
 		     "sssss",
 		     "SNOTICE", "C00000", "MConsole usage",
 		     "D\n\tSHOW HELP|CONFIG|DATABASES"
@@ -1707,7 +1707,7 @@ bool admin_handle_client(PgSocket *admin, PktHdr *pkt)
 	}
 
 	switch (pkt->type) {
-	case 'Q':
+	case PqMsg_Query:
 		if (!mbuf_get_string(&pkt->data, &q)) {
 			disconnect_client(admin, true, "incomplete query");
 			return false;
@@ -1717,12 +1717,12 @@ bool admin_handle_client(PgSocket *admin, PktHdr *pkt)
 		if (res)
 			sbuf_prepare_skip(&admin->sbuf, pkt->len);
 		return res;
-	case 'X':
+	case PqMsg_Terminate:
 		disconnect_client(admin, false, "close req");
 		break;
-	case 'P':
-	case 'B':
-	case 'E':
+	case PqMsg_Parse:
+	case PqMsg_Bind:
+	case PqMsg_Execute:
 		/*
 		 * Effectively the same as the default case, but give
 		 * a more helpful error message in these cases.

--- a/src/client.c
+++ b/src/client.c
@@ -94,7 +94,7 @@ static bool check_client_passwd(PgSocket *client, const char *passwd)
 		return false;
 
 	switch (auth_type) {
-	case AUTH_PLAIN:
+	case AUTH_TYPE_PLAIN:
 		switch (get_password_type(user->passwd)) {
 		case PASSWORD_TYPE_PLAINTEXT:
 			return strcmp(user->passwd, passwd) == 0;
@@ -109,7 +109,7 @@ static bool check_client_passwd(PgSocket *client, const char *passwd)
 		default:
 			return false;
 		}
-	case AUTH_MD5: {
+	case AUTH_TYPE_MD5: {
 		char *stored_passwd;
 		char md5[MD5_PASSWD_LEN + 1];
 
@@ -143,14 +143,14 @@ static bool send_client_authreq(PgSocket *client)
 	int res;
 	int auth_type = client->client_auth_type;
 
-	if (auth_type == AUTH_MD5) {
+	if (auth_type == AUTH_TYPE_MD5) {
 		uint8_t saltlen = 4;
 		get_random_bytes((void *)client->tmp_login_salt, saltlen);
-		SEND_generic(res, client, PqMsg_AuthenticationRequest, "ib", AUTH_MD5, client->tmp_login_salt, saltlen);
-	} else if (auth_type == AUTH_PLAIN || auth_type == AUTH_PAM) {
-		SEND_generic(res, client, PqMsg_AuthenticationRequest, "i", AUTH_PLAIN);
-	} else if (auth_type == AUTH_SCRAM_SHA_256) {
-		SEND_generic(res, client, PqMsg_AuthenticationRequest, "iss", AUTH_SASL, "SCRAM-SHA-256", "");
+		SEND_generic(res, client, PqMsg_AuthenticationRequest, "ib", AUTH_REQ_MD5, client->tmp_login_salt, saltlen);
+	} else if (auth_type == AUTH_TYPE_PLAIN || auth_type == AUTH_TYPE_PAM) {
+		SEND_generic(res, client, PqMsg_AuthenticationRequest, "i", AUTH_REQ_PASSWORD);
+	} else if (auth_type == AUTH_TYPE_SCRAM_SHA_256) {
+		SEND_generic(res, client, PqMsg_AuthenticationRequest, "iss", AUTH_REQ_SASL, "SCRAM-SHA-256", "");
 	} else {
 		return false;
 	}
@@ -364,7 +364,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		return finish_client_login(client);
 
 	auth = cf_auth_type;
-	if (auth == AUTH_HBA) {
+	if (auth == AUTH_TYPE_HBA) {
 		rule = hba_eval(
 			parsed_hba,
 			&client->remote_addr,
@@ -383,34 +383,34 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		auth = rule->rule_method;
 	}
 
-	if (auth == AUTH_MD5) {
+	if (auth == AUTH_TYPE_MD5) {
 		if (get_password_type(client->login_user_credentials->passwd) == PASSWORD_TYPE_SCRAM_SHA_256)
-			auth = AUTH_SCRAM_SHA_256;
+			auth = AUTH_TYPE_SCRAM_SHA_256;
 	}
 
 	/* remember method */
 	client->client_auth_type = auth;
 
 	switch (auth) {
-	case AUTH_ANY:
+	case AUTH_TYPE_ANY:
 		ok = finish_client_login(client);
 		break;
-	case AUTH_TRUST:
+	case AUTH_TYPE_TRUST:
 		if (client->login_user_credentials->mock_auth)
 			disconnect_client(client, true, "\"trust\" authentication failed");
 		else
 			ok = finish_client_login(client);
 		break;
-	case AUTH_PLAIN:
-	case AUTH_MD5:
-	case AUTH_PAM:
-	case AUTH_SCRAM_SHA_256:
+	case AUTH_TYPE_PLAIN:
+	case AUTH_TYPE_MD5:
+	case AUTH_TYPE_PAM:
+	case AUTH_TYPE_SCRAM_SHA_256:
 		ok = send_client_authreq(client);
 		break;
-	case AUTH_CERT:
+	case AUTH_TYPE_CERT:
 		ok = login_via_cert(client, rule);
 		break;
-	case AUTH_PEER:
+	case AUTH_TYPE_PEER:
 		ok = login_as_unix_peer(client, rule);
 		break;
 	default:
@@ -488,7 +488,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	}
 
 	/* find user */
-	if (cf_auth_type == AUTH_ANY) {
+	if (cf_auth_type == AUTH_TYPE_ANY) {
 		/* ignore requested user */
 		if (client->db->forced_user_credentials == NULL) {
 			slog_error(client, "auth_type=any requires forced user");
@@ -499,7 +499,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		if (!check_user_connection_count(client)) {
 			return false;
 		}
-	} else if (cf_auth_type == AUTH_PAM) {
+	} else if (cf_auth_type == AUTH_TYPE_PAM) {
 		if (client->db->auth_user_credentials) {
 			slog_error(client, "PAM can't be used together with database authentication");
 			disconnect_client(client, true, "bouncer config error");
@@ -1007,7 +1007,7 @@ static bool scram_client_first(PgSocket *client, uint32_t datalen, const uint8_t
 	slog_debug(client, "SCRAM server-first-message = \"%s\"", client->scram_state.server_first_message);
 
 	SEND_generic(res, client, PqMsg_AuthenticationRequest, "ib",
-		     AUTH_SASL_CONT,
+		     AUTH_REQ_SASL_CONT,
 		     client->scram_state.server_first_message,
 		     strlen(client->scram_state.server_first_message));
 
@@ -1059,7 +1059,7 @@ static bool scram_client_final(PgSocket *client, uint32_t datalen, const uint8_t
 	slog_debug(client, "SCRAM server-final-message = \"%s\"", server_final_message);
 
 	SEND_generic(res, client, PqMsg_AuthenticationRequest, "ib",
-		     AUTH_SASL_FIN,
+		     AUTH_REQ_SASL_FIN,
 		     server_final_message,
 		     strlen(server_final_message));
 
@@ -1187,7 +1187,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 
-		if (client->client_auth_type == AUTH_SCRAM_SHA_256) {
+		if (client->client_auth_type == AUTH_TYPE_SCRAM_SHA_256) {
 			const char *mech;
 			uint32_t length;
 			const uint8_t *data;
@@ -1248,7 +1248,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 					return false;
 				}
 
-				if (client->client_auth_type == AUTH_PAM) {
+				if (client->client_auth_type == AUTH_TYPE_PAM) {
 					if (!sbuf_pause(&client->sbuf)) {
 						disconnect_client(client, true, "pause failed");
 						return false;

--- a/src/hba.c
+++ b/src/hba.c
@@ -744,19 +744,19 @@ static bool parse_line(struct HBA *hba, struct Ident *ident, struct TokParser *t
 	}
 
 	if (eat_kw(tp, "trust")) {
-		rule->rule_method = AUTH_TRUST;
+		rule->rule_method = AUTH_TYPE_TRUST;
 	} else if (eat_kw(tp, "reject")) {
-		rule->rule_method = AUTH_REJECT;
+		rule->rule_method = AUTH_TYPE_REJECT;
 	} else if (eat_kw(tp, "md5")) {
-		rule->rule_method = AUTH_MD5;
+		rule->rule_method = AUTH_TYPE_MD5;
 	} else if (eat_kw(tp, "password")) {
-		rule->rule_method = AUTH_PLAIN;
+		rule->rule_method = AUTH_TYPE_PLAIN;
 	} else if (eat_kw(tp, "peer")) {
-		rule->rule_method = AUTH_PEER;
+		rule->rule_method = AUTH_TYPE_PEER;
 	} else if (eat_kw(tp, "cert")) {
-		rule->rule_method = AUTH_CERT;
+		rule->rule_method = AUTH_TYPE_CERT;
 	} else if (eat_kw(tp, "scram-sha-256")) {
-		rule->rule_method = AUTH_SCRAM_SHA_256;
+		rule->rule_method = AUTH_TYPE_SCRAM_SHA_256;
 	} else {
 		log_warning("hba line %d: unsupported method: buf=%s", linenr, tp->buf);
 		goto failed;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -158,7 +158,7 @@ static void launch_recheck(PgPool *pool)
 		/* send test query, wait for result */
 		slog_debug(server, "P: checking: %s", q);
 		change_server_state(server, SV_TESTED);
-		SEND_generic(res, server, 'Q', "s", q);
+		SEND_generic(res, server, PqMsg_Query, "s", q);
 		if (!res)
 			disconnect_server(server, false, "test query failed");
 	} else {

--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,7 @@ int cf_tcp_keepidle;
 int cf_tcp_keepintvl;
 int cf_tcp_user_timeout;
 
-int cf_auth_type = AUTH_MD5;
+int cf_auth_type = AUTH_TYPE_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_ident_file;
@@ -201,16 +201,16 @@ static bool set_defer_accept(struct CfValue *cv, const char *val);
 #define DEFER_OPS {set_defer_accept, cf_get_int}
 
 static const struct CfLookup auth_type_map[] = {
-	{ "any", AUTH_ANY },
-	{ "trust", AUTH_TRUST },
-	{ "plain", AUTH_PLAIN },
-	{ "md5", AUTH_MD5 },
-	{ "cert", AUTH_CERT },
-	{ "hba", AUTH_HBA },
+	{ "any", AUTH_TYPE_ANY },
+	{ "trust", AUTH_TYPE_TRUST },
+	{ "plain", AUTH_TYPE_PLAIN },
+	{ "md5", AUTH_TYPE_MD5 },
+	{ "cert", AUTH_TYPE_CERT },
+	{ "hba", AUTH_TYPE_HBA },
 #ifdef HAVE_PAM
-	{ "pam", AUTH_PAM },
+	{ "pam", AUTH_TYPE_PAM },
 #endif
-	{ "scram-sha-256", AUTH_SCRAM_SHA_256 },
+	{ "scram-sha-256", AUTH_TYPE_SCRAM_SHA_256 },
 	{ NULL }
 };
 
@@ -419,9 +419,9 @@ static void set_peers_dead(bool flag)
 static bool requires_auth_file(int auth_type)
 {
 	/* For PAM authentication auth file is not used */
-	if (auth_type == AUTH_PAM)
+	if (auth_type == AUTH_TYPE_PAM)
 		return false;
-	return auth_type >= AUTH_TRUST;
+	return auth_type >= AUTH_TYPE_TRUST;
 }
 
 /* config loading, tries to be tolerant to errors */
@@ -448,7 +448,7 @@ void load_config(void)
 		set_dbs_dead(false);
 	}
 
-	if (cf_auth_type == AUTH_HBA) {
+	if (cf_auth_type == AUTH_TYPE_HBA) {
 		struct Ident *ident;
 		struct HBA *hba;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -2263,7 +2263,7 @@ bool use_client_socket(int fd, PgAddr *addr,
 			log_error("SCRAM key data received for forced user");
 			return false;
 		}
-		if (cf_auth_type == AUTH_PAM) {
+		if (cf_auth_type == AUTH_TYPE_PAM) {
 			log_error("SCRAM key data received for PAM user");
 			return false;
 		}
@@ -2330,7 +2330,7 @@ bool use_server_socket(int fd, PgAddr *addr,
 
 	if (db->forced_user_credentials) {
 		credentials = db->forced_user_credentials;
-	} else if (cf_auth_type == AUTH_PAM) {
+	} else if (cf_auth_type == AUTH_TYPE_PAM) {
 		credentials = add_pam_credentials(username, password);
 	} else {
 		credentials = find_global_credentials(username);

--- a/src/objects.c
+++ b/src/objects.c
@@ -999,10 +999,10 @@ bool queue_fake_response(PgSocket *client, char request_type)
 	PgSocket *server = client->link;
 	Assert(server);
 
-	if (request_type == 'P') {
+	if (request_type == PqMsg_Parse) {
 		slog_debug(client, "Queuing fake ParseComplete packet");
 		QUEUE_ParseComplete(res, server, client);
-	} else if (request_type == 'C') {
+	} else if (request_type == PqMsg_Close) {
 		slog_debug(client, "Queuing fake CloseComplete packet");
 		QUEUE_CloseComplete(res, server, client);
 	} else {
@@ -1055,7 +1055,7 @@ bool add_outstanding_request(PgSocket *client, char type, ResponseAction action)
  *
  * returns true if one of the given types was popped of off the queue.
  */
-bool pop_outstanding_request(PgSocket *server, char *types, bool *skip)
+bool pop_outstanding_request(PgSocket *server, const char types[], bool *skip)
 {
 	OutstandingRequest *request;
 	struct List *item = statlist_first(&server->outstanding_requests);
@@ -1092,19 +1092,19 @@ bool pop_outstanding_request(PgSocket *server, char *types, bool *skip)
  * types in "types". Any Parse or Close statement requests that were still
  * outstanding will be unregistered or re-registered from the server its cache.
  */
-bool clear_outstanding_requests_until(PgSocket *server, char *types)
+bool clear_outstanding_requests_until(PgSocket *server, const char types[])
 {
 	struct List *item, *tmp;
 	statlist_for_each_safe(item, &server->outstanding_requests, tmp) {
 		OutstandingRequest *request = container_of(item, OutstandingRequest, node);
 		char type = request->type;
-		if (type == 'P' && request->server_ps_query_id > 0) {
+		if (type == PqMsg_Parse && request->server_ps_query_id > 0) {
 			unregister_prepared_statement(server, request->server_ps_query_id);
 			slog_noise(server,
 				   "failed prepared statement '" PREPARED_STMT_NAME_FORMAT "' removed from server cache, %d cached items",
 				   request->server_ps_query_id,
 				   HASH_COUNT(server->server_prepared_statements));
-		} else if (type == 'C' && request->server_ps != NULL) {
+		} else if (type == PqMsg_Close && request->server_ps != NULL) {
 			if (!add_prepared_statement(server, request->server_ps)) {
 				if (server->link)
 					disconnect_client(server->link, true, "out of memory");
@@ -1134,7 +1134,7 @@ static bool reset_on_release(PgSocket *server)
 	Assert(server->state == SV_TESTED);
 
 	slog_debug(server, "resetting: %s", cf_server_reset_query);
-	SEND_generic(res, server, 'Q', "s", cf_server_reset_query);
+	SEND_generic(res, server, PqMsg_Query, "s", cf_server_reset_query);
 	if (!res)
 		disconnect_server(server, false, "reset query failed");
 	return res;
@@ -1373,7 +1373,7 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 
 	/* notify server and close connection */
 	if (send_term) {
-		static const uint8_t pkt_term[] = {'X', 0, 0, 0, 4};
+		static const uint8_t pkt_term[] = {PqMsg_Terminate, 0, 0, 0, 4};
 		bool _ignore = sbuf_answer(&server->sbuf, pkt_term, sizeof(pkt_term));
 		(void) _ignore;
 	}

--- a/src/pktbuf.c
+++ b/src/pktbuf.c
@@ -377,7 +377,7 @@ void pktbuf_write_RowDescription(PktBuf *buf, const char *tupdesc, ...)
 
 	log_noise("write RowDescription");
 
-	pktbuf_start_packet(buf, 'T');
+	pktbuf_start_packet(buf, PqMsg_RowDescription);
 
 	pktbuf_put_uint16(buf, ncol);
 
@@ -435,7 +435,7 @@ void pktbuf_write_DataRow(PktBuf *buf, const char *tupdesc, ...)
 	int ncol = strlen(tupdesc);
 	va_list ap;
 
-	pktbuf_start_packet(buf, 'D');
+	pktbuf_start_packet(buf, PqMsg_DataRow);
 	pktbuf_put_uint16(buf, ncol);
 
 	va_start(ap, tupdesc);
@@ -497,11 +497,9 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...)
 	const char *val;
 	int len, i;
 
-	/* Parse */
-	pktbuf_write_generic(buf, 'P', "csh", 0, query, 0);
+	pktbuf_write_generic(buf, PqMsg_Parse, "csh", 0, query, 0);
 
-	/* Bind */
-	pktbuf_start_packet(buf, 'B');
+	pktbuf_start_packet(buf, PqMsg_Bind);
 	pktbuf_put_char(buf, 0);	/* portal name */
 	pktbuf_put_char(buf, 0);	/* query name */
 	pktbuf_put_uint16(buf, 0);	/* number of parameter format codes */
@@ -519,12 +517,7 @@ void pktbuf_write_ExtQuery(PktBuf *buf, const char *query, int nargs, ...)
 	pktbuf_put_uint16(buf, 0);	/* number of result-column format codes */
 	pktbuf_finish_packet(buf);
 
-	/* Describe */
-	pktbuf_write_generic(buf, 'D', "cc", 'P', 0);
-
-	/* Execute */
-	pktbuf_write_generic(buf, 'E', "ci", 0, 0);
-
-	/* Sync */
-	pktbuf_write_generic(buf, 'S', "");
+	pktbuf_write_generic(buf, PqMsg_Describe, "cc", 'P', 0);
+	pktbuf_write_generic(buf, PqMsg_Execute, "ci", 0, 0);
+	pktbuf_write_generic(buf, PqMsg_Sync, "");
 }

--- a/src/proto.c
+++ b/src/proto.c
@@ -524,21 +524,21 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt)
 	if (!mbuf_get_uint32be(&pkt->data, &cmd))
 		return false;
 	switch (cmd) {
-	case AUTH_OK:
+	case AUTH_REQ_OK:
 		slog_debug(server, "S: auth ok");
 		res = true;
 		break;
-	case AUTH_PLAIN:
+	case AUTH_REQ_PASSWORD:
 		slog_debug(server, "S: req cleartext password");
 		res = login_clear_psw(server);
 		break;
-	case AUTH_MD5:
+	case AUTH_REQ_MD5:
 		slog_debug(server, "S: req md5-crypted psw");
 		if (!mbuf_get_bytes(&pkt->data, 4, &salt))
 			return false;
 		res = login_md5_psw(server, salt);
 		break;
-	case AUTH_SASL:
+	case AUTH_REQ_SASL:
 	{
 		bool selected_mechanism = false;
 
@@ -564,7 +564,7 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt)
 		}
 		break;
 	}
-	case AUTH_SASL_CONT:
+	case AUTH_REQ_SASL_CONT:
 	{
 		unsigned len;
 		const uint8_t *data;
@@ -576,7 +576,7 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt)
 		res = login_scram_sha_256_cont(server, len, data);
 		break;
 	}
-	case AUTH_SASL_FIN:
+	case AUTH_REQ_SASL_FIN:
 	{
 		unsigned len;
 		const uint8_t *data;

--- a/src/proto.c
+++ b/src/proto.c
@@ -158,7 +158,7 @@ bool send_pooler_error(PgSocket *client, bool send_ready, const char *sqlstate, 
 		slog_warning(client, "pooler error: %s", msg);
 
 	pktbuf_static(&buf, tmpbuf, sizeof(tmpbuf));
-	pktbuf_write_generic(&buf, 'E', "cscscsc",
+	pktbuf_write_generic(&buf, PqMsg_ErrorResponse, "cscscsc",
 			     'S', level_fatal ? "FATAL" : "ERROR",
 			     'C', sqlstate ? sqlstate : "08P01", 'M', msg, 0);
 	if (send_ready)

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1272,7 +1272,7 @@ bool sbuf_tls_setup(void)
 			return false;
 		}
 	}
-	if (cf_auth_type == AUTH_CERT) {
+	if (cf_auth_type == AUTH_TYPE_CERT) {
 		if (cf_client_tls_sslmode != SSLMODE_VERIFY_FULL) {
 			log_error("auth_type=cert requires client_tls_sslmode=SSLMODE_VERIFY_FULL");
 			return false;

--- a/src/server.c
+++ b/src/server.c
@@ -129,11 +129,13 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 	/* ignore most that happens during connect_query */
 	if (server->exec_on_connect) {
 		switch (pkt->type) {
-		case 'Z':
-		case 'S':	/* handle them below */
+		case PqMsg_ReadyForQuery:
+		case PqMsg_ParameterStatus:
+			/* handle them below */
 			break;
 
-		case 'E':	/* log & ignore errors */
+		case PqMsg_ErrorResponse:
+			/* log & ignore errors */
 			log_server_error("S: error while executing exec_on_query", pkt);
 		/* fallthrough */
 		default:	/* ignore rest */
@@ -148,7 +150,7 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 		disconnect_server(server, true, "unknown pkt from server");
 		break;
 
-	case 'E':		/* ErrorResponse */
+	case PqMsg_ErrorResponse:
 		/*
 		 * If we cannot log into the server, then we drop all clients
 		 * that are currently trying to log in because they will almost
@@ -173,25 +175,26 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 		break;
 
 	/* packets that need closer look */
-	case 'R':		/* AuthenticationXXX */
+
+	case PqMsg_AuthenticationRequest:
 		slog_debug(server, "calling login_answer");
 		res = answer_authreq(server, pkt);
 		if (!res)
 			disconnect_server(server, false, "failed to answer authreq");
 		break;
 
-	case 'S':		/* ParameterStatus */
+	case PqMsg_ParameterStatus:
 		res = load_parameter(server, pkt, true);
 		break;
 
-	case 'Z':		/* ReadyForQuery */
+	case PqMsg_ReadyForQuery:
 		if (server->exec_on_connect) {
 			server->exec_on_connect = false;
 			/* deliberately ignore transaction status */
 		} else if (server->pool->db->connect_query) {
 			server->exec_on_connect = true;
 			slog_debug(server, "server connect ok, send exec_on_connect");
-			SEND_generic(res, server, 'Q', "s", server->pool->db->connect_query);
+			SEND_generic(res, server, PqMsg_Query, "s", server->pool->db->connect_query);
 			if (!res)
 				disconnect_server(server, false, "exec_on_connect query failed");
 			break;
@@ -213,7 +216,8 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 		break;
 
 	/* ignorable packets */
-	case 'K':		/* BackendKeyData */
+
+	case PqMsg_BackendKeyData:
 		if (!mbuf_get_bytes(&pkt->data, BACKENDKEY_LEN, &ckey)) {
 			disconnect_server(server, true, "bad cancel key");
 			return false;
@@ -222,7 +226,7 @@ static bool handle_server_startup(PgSocket *server, PktHdr *pkt)
 		res = true;
 		break;
 
-	case 'N':		/* NoticeResponse */
+	case PqMsg_NoticeResponse:
 		slog_noise(server, "skipping pkt: %c", pkt_desc(pkt));
 		res = true;
 		break;
@@ -354,15 +358,15 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 		return false;
 
 	/* pooling decisions will be based on this packet */
-	case 'Z':		/* ReadyForQuery */
+	case PqMsg_ReadyForQuery:
 
 		/* if partial pkt, wait */
 		if (!mbuf_get_char(&pkt->data, &state))
 			return false;
 
-		if (!pop_outstanding_request(server, "SQF", &ignore_packet)
+		if (!pop_outstanding_request(server, (char[]) {PqMsg_Sync, PqMsg_Query, PqMsg_FunctionCall, '\0'}, &ignore_packet)
 		    && server->query_failed) {
-			if (!clear_outstanding_requests_until(server, "S"))
+			if (!clear_outstanding_requests_until(server, (char[]) {PqMsg_Sync, '\0'}))
 				return false;
 		}
 		server->query_failed = false;
@@ -378,22 +382,22 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 		}
 		break;
 
-	case 'S':		/* ParameterStatus */
+	case PqMsg_ParameterStatus:
 		if (!load_parameter(server, pkt, false))
 			return false;
 		break;
 
 	/*
-	 * 'E' and 'N' packets currently set ->ready to false.  Correct would
+	 * ErrorResponse and NoticeResponse packets currently set ->ready to false.  Correct would
 	 * be to leave ->ready as-is, because overall TX state stays same.
 	 * It matters for connections in IDLE or USED state which get dirty
 	 * suddenly but should not as they are still usable.
 	 *
-	 * But the 'E' or 'N' packet between transactions signifies probably
+	 * But the ErrorResponse or NoticeResponse packet between transactions signifies probably
 	 * dying backend.  It is better to tag server as dirty and drop
 	 * it later.
 	 */
-	case 'E':		/* ErrorResponse */
+	case PqMsg_ErrorResponse:
 		if (server->setting_vars) {
 			/*
 			 * the SET and user query will be different TX
@@ -434,14 +438,14 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			 * COPY for some reason unknown to the client (e.g. a
 			 * unique constraint violation).
 			 */
-			if (!clear_outstanding_requests_until(server, "cf"))
+			if (!clear_outstanding_requests_until(server, (char[]) {PqMsg_CopyDone, PqMsg_CopyFail, '\0'}))
 				return false;
 		}
 
 		server->query_failed = true;
 		break;
-	case 'C':		/* CommandComplete */
 
+	case PqMsg_CommandComplete:
 		/* ErrorResponse and CommandComplete show end of copy mode */
 		if (server->copy_mode) {
 			slog_debug(server, "COPY finished");
@@ -453,7 +457,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			 * outstanding requests queue, for which we don't
 			 * expect a response from the server.
 			 */
-			if (!clear_outstanding_requests_until(server, "c"))
+			if (!clear_outstanding_requests_until(server, (char[]) {PqMsg_CopyDone, '\0'}))
 				return false;
 		}
 		/*
@@ -477,55 +481,55 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 				return false;
 			}
 		}
-		pop_outstanding_request(server, "E", &ignore_packet);
+		pop_outstanding_request(server, (char[]) {PqMsg_Execute, '\0'}, &ignore_packet);
 
 		break;
 
-	case 'N':		/* NoticeResponse */
+	case PqMsg_NoticeResponse:
 		break;
 
 	/* reply to LISTEN, don't change connection state */
-	case 'A':		/* NotificationResponse */
+	case PqMsg_NotificationResponse:
 		idle_tx = server->idle_tx;
 		ready = server->ready;
 		async_response = true;
 		break;
 
 	/* copy mode */
-	case 'G':		/* CopyInResponse */
-	case 'W':		/* CopyBothResponse */
+	case PqMsg_CopyInResponse:
+	case PqMsg_CopyBothResponse:
 		slog_debug(server, "COPY started");
 		server->copy_mode = true;
 		break;
-	case 'H':		/* CopyOutResponse */
+	case PqMsg_CopyOutResponse:
 		break;
 	/* chat packets */
-	case '1':		/* ParseComplete */
-		pop_outstanding_request(server, "P", &ignore_packet);
+	case PqMsg_ParseComplete:
+		pop_outstanding_request(server, (char[]) {PqMsg_Parse, '\0'}, &ignore_packet);
 		break;
-	case '2':		/* BindComplete */
-		pop_outstanding_request(server, "B", &ignore_packet);
+	case PqMsg_BindComplete:
+		pop_outstanding_request(server, (char[]) {PqMsg_Bind, '\0'}, &ignore_packet);
 		break;
-	case '3':		/* CloseComplete */
-		pop_outstanding_request(server, "C", &ignore_packet);
+	case PqMsg_CloseComplete:
+		pop_outstanding_request(server, (char[]) {PqMsg_Close, '\0'}, &ignore_packet);
 		break;
-	case 'n':		/* NoData */
-	case 'T':		/* RowDescription */
-		pop_outstanding_request(server, "D", &ignore_packet);
+	case PqMsg_NoData:
+	case PqMsg_RowDescription:
+		pop_outstanding_request(server, (char[]) {PqMsg_Describe, '\0'}, &ignore_packet);
 		break;
-	case 't':		/* ParameterDescription */
-	case 'c':		/* CopyDone(F/B) */
-	case 'f':		/* CopyFail(F/B) */
-	case 'V':		/* FunctionCallResponse */
+	case PqMsg_ParameterDescription:
+	case PqMsg_CopyDone:
+	case PqMsg_CopyFail:
+	case PqMsg_FunctionCallResponse:
 		break;
-	case 'I':		/* EmptyQueryResponse == CommandComplete */
-	case 's':		/* PortalSuspended */
-		pop_outstanding_request(server, "E", &ignore_packet);
+	case PqMsg_EmptyQueryResponse:	/* EmptyQueryResponse is similar to CommandComplete, which is handled above */
+	case PqMsg_PortalSuspended:
+		pop_outstanding_request(server, (char[]) {PqMsg_Execute, '\0'}, &ignore_packet);
 		break;
 
 	/* data packets, there will be more coming */
-	case 'd':		/* CopyData(F/B) */
-	case 'D':		/* DataRow */
+	case PqMsg_CopyData:
+	case PqMsg_DataRow:
 		break;
 	}
 	server->idle_tx = idle_tx;

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -210,7 +210,7 @@ bool varcache_apply(PgSocket *server, PgSocket *client, bool *changes_p)
 	int sql_ofs;
 	struct PktBuf *pkt = pktbuf_temp();
 
-	pktbuf_start_packet(pkt, 'Q');
+	pktbuf_start_packet(pkt, PqMsg_Query);
 
 	/* grab query position inside pkt */
 	sql_ofs = pktbuf_written(pkt);

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -21,25 +21,23 @@ int cf_listen_port;
 static const char *method2string(int method)
 {
 	switch (method) {
-	case AUTH_TRUST:
+	case AUTH_TYPE_TRUST:
 		return "trust";
-	case AUTH_PLAIN:
+	case AUTH_TYPE_PLAIN:
 		return "password";
-	case AUTH_CRYPT:
-		return "crypt";
-	case AUTH_MD5:
+	case AUTH_TYPE_MD5:
 		return "md5";
-	case AUTH_CERT:
+	case AUTH_TYPE_CERT:
 		return "cert";
-	case AUTH_PEER:
+	case AUTH_TYPE_PEER:
 		return "peer";
-	case AUTH_HBA:
+	case AUTH_TYPE_HBA:
 		return "hba";
-	case AUTH_REJECT:
+	case AUTH_TYPE_REJECT:
 		return "reject";
-	case AUTH_PAM:
+	case AUTH_TYPE_PAM:
 		return "pam";
-	case AUTH_SCRAM_SHA_256:
+	case AUTH_TYPE_SCRAM_SHA_256:
 		return "scram-sha-256";
 	default:
 		return "???";


### PR DESCRIPTION
Use the descriptively-named macros for identifiers used in wire protocol messages, introduced in PostgreSQL 17.  The header file `protocol.h` is copied from PostgreSQL.

---

Separate AUTH_* symbols for protocol and configuration purposes

PgBouncer has used the same set of AUTH_* symbols for handling the authentication protocol (AuthenticationRequest message) and for storing configuration settings (auth_type, hba).  The two sets have diverged significantly over time, and it's gotten quite confusing and cumbersome.

This creates two separate sets of symbols.  For the protocol, we use the AUTH_REQ_* symbols imported from PostgreSQL in protocol.h.  For the configuration settings, we make a separate enum with AUTH_TYPE_* symbols.
