### PR TITLE
Install pkg-config in Windows CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -232,7 +232,7 @@ task:
     #     MSYSTEM: MINGW32
   setup_script:
     - choco install -y --no-progress msys2
-    - sh -l -c "pacman --noconfirm -S --needed base-devel ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-libevent ${MINGW_PACKAGE_PREFIX}-openssl ${MINGW_PACKAGE_PREFIX}-postgresql autoconf automake libtool ${MINGW_PACKAGE_PREFIX}-python ${MINGW_PACKAGE_PREFIX}-python-pip zip"
+    - sh -l -c "pacman --noconfirm -S --needed base-devel ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-libevent ${MINGW_PACKAGE_PREFIX}-openssl ${MINGW_PACKAGE_PREFIX}-postgresql autoconf automake libtool pkg-config ${MINGW_PACKAGE_PREFIX}-python ${MINGW_PACKAGE_PREFIX}-python-pip zip"
     - sh -l -c 'pip install -r requirements.txt'
     - echo 127.0.0.1 localhost >> c:\Windows\System32\Drivers\etc\hosts
     - sh -l -c 'echo "127.0.0.1   localhost" >> /etc/hosts'


### PR DESCRIPTION
This looks like it is solving the error that has been occurring in the recent Windows CI runs.

For reference, the errors are of this form:

```
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call sh -l -c "./autogen.sh" 
Using autoconf: 2.72
Using aclocal: 1.17
ac-wrapper: autoheader: warning: auto-detected versions not found ( ); falling back to latest available
ac-wrapper: autoconf: warning: auto-detected versions not found ( ); falling back to latest available
configure.ac:15: warning: The macro 'AC_PROG_CC_STDC' is obsolete.
configure.ac:15: You should run autoupdate.
../autoconf-2.72/lib/autoconf/c.m4:1669: AC_PROG_CC_STDC is expanded from...
lib/m4/usual.m4:69: AC_USUAL_PROGRAM_CHECK is expanded from...
configure.ac:15: the top level
configure.ac:17: error: possibly undefined macro: PKG_PROG_PKG_CONFIG
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:58: error: possibly undefined macro: PKG_CHECK_MODULES

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 1 NEQ 0 exit /b 1 
```