### PR TITLE
Fix application_name_add_host to handle SET application_name

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -23,3 +23,5 @@ bool check_db_connection_count(PgSocket *client);
 bool check_user_connection_count(PgSocket *client);
 bool sending_auth_query(PgSocket *client);
 PgDatabase *prepare_auth_database(PgSocket *client) _MUSTCHECK;
+void set_appname(PgSocket *client, const char *app_name);
+

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -25,3 +25,5 @@ void varcache_clean(VarCache *cache);
 void varcache_add_params(PktBuf *pkt, VarCache *vars);
 void varcache_deinit(void);
 void varcache_set_canonical(PgSocket *server, PgSocket *client);
+const char *varcache_get(VarCache *cache, const char *lk);
+

--- a/src/client.c
+++ b/src/client.c
@@ -872,15 +872,22 @@ fail:
 	return false;
 }
 
-static void set_appname(PgSocket *client, const char *app_name)
+void set_appname(PgSocket *client, const char *app_name)
 {
 	char buf[400], abuf[300];
 	const char *details;
 
 	if (cf_application_name_add_host) {
-		/* give app a name */
-		if (!app_name)
+		if (app_name) {
+			const char *current_appname = varcache_get(&client->vars, "application_name");
+			if (current_appname && (strcmp(current_appname, app_name) == 0)) {
+				slog_debug(client, "ignoring the set_appname, it's already set");
+				return;
+			}
+		} else {
+			/* give app a name */
 			app_name = "app";
+		}
 
 		/* add details */
 		details = pga_details(&client->remote_addr, abuf, sizeof(abuf));

--- a/src/server.c
+++ b/src/server.c
@@ -49,7 +49,11 @@ static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
 
 	if (client) {
 		slog_debug(client, "setting client var: %s='%s'", key, val);
-		varcache_set(&client->vars, key, val);
+		if (cf_application_name_add_host && (strcmp(key, "application_name") == 0)) {
+			set_appname(client, val);
+		} else {
+			varcache_set(&client->vars, key, val);
+		}
 	}
 
 	if (startup) {

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -106,6 +106,27 @@ void init_var_lookup(const char *cf_track_extra_parameters)
 	num_var_cached = idx;
 }
 
+const char *varcache_get(VarCache *cache, const char *key)
+{
+	struct var_lookup *lookup = NULL;
+	struct PStr *pstr;
+
+	if (!vpool) {
+		return NULL;
+	}
+	HASH_FIND_STR(lookup_map, key, lookup);
+
+	/* parameter not found */
+	if (lookup == NULL)
+		return NULL;
+
+	pstr = get_value(cache, lookup);
+	if (pstr)
+		return pstr->str;
+	else
+		return NULL;
+}
+
 bool varcache_set(VarCache *cache, const char *key, const char *value)
 {
 	const struct var_lookup *lk = NULL;


### PR DESCRIPTION
The PostgreSQL protocol sends us a message when the application_name is changed. It's thus possible to use this message to add back the host and port information in the session.


Old behaviour (transaction pooling):
```
test=> show application_name;
   application_name    
------------------------
psql - 127.0.0.1:52396
(1 row)
test=> set application_name to 'toto';
SET
test=> show application_name;
   application_name    
------------------------
toto
(1 row)
```

New behaviour:
```
test=> show application_name;
   application_name    
------------------------
psql - 127.0.0.1:52396
(1 row)
test=> set application_name to 'toto';
SET
test=> show application_name;
   application_name    
------------------------
toto - 127.0.0.1:52396
(1 row)
```


(This replaces PR #468)