### PR TITLE
Set Basic Constraints X.509 v3 extension

### DIFF
--- a/test/ssl/newca.sh
+++ b/test/ssl/newca.sh
@@ -30,7 +30,7 @@ days=10240
 run openssl ecparam -name prime256v1 -genkey -out "$name/ca.key"
 
 # self-signed cert
-run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -- "$@"
+run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -addext basicConstraints=critical,CA:TRUE,pathlen:1 -- "$@"
 
 
 cat > "$name"/config.ini <<EOF

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -9,11 +9,6 @@ from .utils import MACOS, PG_MAJOR_VERSION, TEST_DIR, TLS_SUPPORT, WINDOWS, Boun
 if not TLS_SUPPORT:
     pytest.skip(allow_module_level=True)
 
-# Windows and MacOS TLS tests are currently broken for some strange reason.
-# Make CI pass for now by ignoring these tests.
-if WINDOWS or MACOS:
-    pytest.skip(allow_module_level=True)
-
 # XXX: These test use psql to connect using sslmode=verify-full instead of
 # using psycopg. The reason for this is that psycopg has a bug on Apple
 # silicon when enabling SSL: https://github.com/psycopg/psycopg/discussions/270


### PR DESCRIPTION
It appears that recent versions of the OpenSSL library require the "Basic Constraints" X509 extension to be properly configured for CA certificates. The x509v3_config(5) man page states:
"A CA certificate must include the basicConstraints name with the CA parameter set to TRUE. An end-user certificate must either have CA:FALSE or omit the extension entirely."
Currently, the basic constraints are not set when generating CA certificates and SSL tests fail on distros with new OpenSSL libraries such as Rocky Linux 9. This PR fixes the issue.

For reference: https://docs.openssl.org/3.4/man5/x509v3_config/#basic-constraints

Fixes #1210 
Fixes #1031 