### PR TITLE
Disable error message test on Windows

### DIFF
--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -23,6 +23,7 @@ def test_message_fixture(bouncer, pg):
 
 
 @pytest.mark.skipif("FREEBSD", reason="FreeBSD error reporting broken")
+@pytest.mark.skipif("WINDOWS", reason="Windows error reporting broken")
 def test_message(test_message_fixture):
     bouncer, pg = test_message_fixture
     test_user = "test_error_message_user"


### PR DESCRIPTION
The new error message test introduced by #1152 is failing on Windows.
This slipped past CI, because Windows CI was broken completely
before #1216.

For now this disables the test on Windows to make CI green, but it might
be nice to actually fix the behaviour.
