### PR TITLE
Skip -addext option for OpenSSL 1.0.x

### DIFF
--- a/test/ssl/newca.sh
+++ b/test/ssl/newca.sh
@@ -30,7 +30,13 @@ days=10240
 run openssl ecparam -name prime256v1 -genkey -out "$name/ca.key"
 
 # self-signed cert
-run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -addext basicConstraints=critical,CA:TRUE,pathlen:1 -- "$@"
+# the -addext option is not required for old OpenSSL versions
+openssl_version=`openssl version | awk '{print $2}'`
+if expr "X$openssl_version" : 'X1.0.*' >/dev/null; then
+  run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -- "$@"
+else
+  run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -addext basicConstraints=critical,CA:TRUE,pathlen:1 -- "$@"
+fi
 
 
 cat > "$name"/config.ini <<EOF


### PR DESCRIPTION
The `-addext` option was introduced in OpenSSL 1.1.1. We need to skip it to support old OpenSSL versions (1.0.x).

See also #1210 