### PR TITLE
Fix version  in configure.ac

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,18 @@ PgBouncer changelog
 
 PgBouncer 1.23.x
 ----------------
+**2024-08-02 - PgBouncer 1.23.1 - "Everything is put back in order"**
+
+- Fixes
+  * Fix a possible segmentation fault after PgBouncer reloads its configuration.
+    (#1105) (bug introduced in 1.23.0)
+  * Fix all known put_in_order crashes. (#1120) (new crashes were introduced in
+    1.23.0)
+  * Add missing files to release tarball that are required for testing. (#1124)
+    (missing files were introduced in 1.23.0)
+[#1105]: https://github.com/pgbouncer/pgbouncer/pull/1105
+[#1120]: https://github.com/pgbouncer/pgbouncer/pull/1120
+[#1124]: https://github.com/pgbouncer/pgbouncer/pull/1124
 
 **2024-07-03  -  PgBouncer 1.23.0  -  "Into the new beginnings"**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,18 +3,6 @@ PgBouncer changelog
 
 PgBouncer 1.23.x
 ----------------
-**2024-08-02 - PgBouncer 1.23.1 - "Everything is put back in order"**
-
-- Fixes
-  * Fix a possible segmentation fault after PgBouncer reloads its configuration.
-    (#1105) (bug introduced in 1.23.0)
-  * Fix all known put_in_order crashes. (#1120) (new crashes were introduced in
-    1.23.0)
-  * Add missing files to release tarball that are required for testing. (#1124)
-    (missing files were introduced in 1.23.0)
-[#1105]: https://github.com/pgbouncer/pgbouncer/pull/1105
-[#1120]: https://github.com/pgbouncer/pgbouncer/pull/1120
-[#1124]: https://github.com/pgbouncer/pgbouncer/pull/1124
 
 **2024-07-03  -  PgBouncer 1.23.0  -  "Into the new beginnings"**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,20 @@ PgBouncer changelog
 PgBouncer 1.23.x
 ----------------
 
+**2024-08-02  -  PgBouncer 1.23.1  -  "Everything is put back in order"**
+
+- Fixes
+  * Fix a possible segmentation fault after PgBouncer reloads its
+    configuration. ([#1105]) (bug introduced in 1.23.0)
+  * Fix all known put_in_order crashes. ([#1120])
+    (new crashes were introduced in 1.23.0)
+  * Add missing files to release tarball that are required for testing.
+    ([#1124]) (missing files were introduced in 1.23.0)
+
+[#1120]: https://github.com/pgbouncer/pgbouncer/pull/1120
+[#1105]: https://github.com/pgbouncer/pgbouncer/pull/1105
+[#1124]: https://github.com/pgbouncer/pgbouncer/pull/1124
+
 **2024-07-03  -  PgBouncer 1.23.0  -  "Into the new beginnings"**
 
 - Features

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([PgBouncer],
-        [1.23.0],
+        [1.23.1],
         [https://github.com/pgbouncer/pgbouncer/issues], [],
         [https://www.pgbouncer.org/])
 AC_CONFIG_SRCDIR(src/janitor.c)

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([PgBouncer],
-        [1.23.1],
+        [1.23.0],
         [https://github.com/pgbouncer/pgbouncer/issues], [],
         [https://www.pgbouncer.org/])
 AC_CONFIG_SRCDIR(src/janitor.c)


### PR DESCRIPTION
I noticed that in the most recent build the version number still displays as v1.23.0. I believe that the below number should have been incremented with the last update.