### PR TITLE
Fix Client Connection Count Decrementing

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1428,14 +1428,6 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
  */
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 {
-	if (client->db && client->contributes_db_client_count)
-		client->db->client_connection_count--;
-
-	if (client->login_user_credentials) {
-		if (client->login_user_credentials->global_user && client->user_connection_counted) {
-			client->login_user_credentials->global_user->client_connection_count--;
-		}
-	}
 	if (reason) {
 		char buf[128];
 		va_list ap;
@@ -1461,6 +1453,15 @@ void disconnect_client(PgSocket *client, bool notify, const char *reason, ...)
 void disconnect_client_sqlstate(PgSocket *client, bool notify, const char *sqlstate, const char *reason)
 {
 	usec_t now = get_cached_time();
+
+	if (client->db && client->contributes_db_client_count)
+		client->db->client_connection_count--;
+
+	if (client->login_user_credentials) {
+		if (client->login_user_credentials->global_user && client->user_connection_counted) {
+			client->login_user_credentials->global_user->client_connection_count--;
+		}
+	}
 
 	if (cf_log_disconnections && reason) {
 		slog_info(client, "closing because: %s (age=%" PRIu64 "s)", reason,


### PR DESCRIPTION
Fix for [#1225](https://github.com/pgbouncer/pgbouncer/issues/1225). 

It seems that sometimes when a connection is closed pgbouncer does not make a call to `disconnect_client`. Instead it goes through `disconnect_client_sqlstate`. This PR moves the count decrementing from `disconnect_client` and to `disconnect_client_sqlstate` so that it gets counted more often.

Added a test case that proves this out which fails when running against the current state of pgbouncer.