### PR TITLE
option to disable default pool size

### DIFF
--- a/src/janitor.c
+++ b/src/janitor.c
@@ -522,15 +522,17 @@ static void check_pool_size(PgPool *pool)
 
 	Assert(pool_pool_size(pool) >= 0);
 
-	while (many > 0) {
-		server = first_socket(&pool->used_server_list);
-		if (!server)
-			server = first_socket(&pool->idle_server_list);
-		if (!server)
-			break;
-		disconnect_server(server, true, "too many servers in the pool");
-		many--;
-		cur--;
+	if (pool_pool_size(pool) > 0) {
+		while (many > 0) {
+			server = first_socket(&pool->used_server_list);
+			if (!server)
+				server = first_socket(&pool->idle_server_list);
+			if (!server)
+				break;
+			disconnect_server(server, true, "too many servers in the pool");
+			many--;
+			cur--;
+		}
 	}
 
 	/* launch extra connections to satisfy min_pool_size */


### PR DESCRIPTION
This PR implements the non default option of choosing zero as the default pool size and not having the restriction apply. This is useful in situations where you would rather limit connections by user or database instead of pool. Without this option it can be easy to forget to make sure that default pool size is larger than the limit you actually want to apply.