### PR TITLE
Add git hash to version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([PgBouncer],
-        [1.23.1],
+         [m4_esyscmd([./version_script.sh])],
         [https://github.com/pgbouncer/pgbouncer/issues], [],
         [https://www.pgbouncer.org/])
 AC_CONFIG_SRCDIR(src/janitor.c)

--- a/version_script.sh
+++ b/version_script.sh
@@ -1,1 +1,7 @@
-echo 1.23.1-$(git describe --always --abbrev=5 --exclude "*" || echo "unknown" )
+git_hash=$(git describe --always --abbrev=5 --exclude "*" || echo unknown)
+numeric_version="1.23.1"
+if [[ $git_hash == "unknown" ]]; then
+  printf $numeric_version
+else
+  printf $numeric_version-$git_hash
+fi

--- a/version_script.sh
+++ b/version_script.sh
@@ -1,0 +1,1 @@
+echo 1.23.1-$(git describe --always --abbrev=5 --exclude "*" || echo "unknown" )


### PR DESCRIPTION
This PR adds a git hash to the pgbouncer version number. Currently if you build pgbouncer from source the only identifier available is the previous version number which is very misleading as you may be building a version based off of a totally different commit than the last release. This PR would decrease ambiguity around situations like these.