### PR TITLE
Output diff of linter failures in 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,10 @@ lint:
 	flake8
 
 format-check: uncrustify
-	black --check .
-	isort --check .
+	black --check --diff .
+	isort --check --diff .
+
+Co-authored-by: Brian Cosgrove <bcosgrove@paypal.com>
 	./uncrustify -c uncrustify.cfg --check include/*.h src/*.c -L WARN
 
 format: uncrustify

--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,6 @@ lint:
 format-check: uncrustify
 	black --check --diff .
 	isort --check --diff .
-
-Co-authored-by: Brian Cosgrove <bcosgrove@paypal.com>
 	./uncrustify -c uncrustify.cfg --check include/*.h src/*.c -L WARN
 
 format: uncrustify


### PR DESCRIPTION
It would improve my workflow to see the diffs `black` and `isort` are
prescribing while running `format-check`
