### PR TITLE
Change db param to reserve_pool_size

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1249,7 +1249,7 @@ Only enforced if at least one of the following is true:
 ### reserve_pool_size
 
 Set additional connections for this database. If not set, the global `reserve_pool_size`
-is used.
+is used. For backwards compatibilty reasons `reserve_pool` is an alias for this option.
 
 ### connect_query
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1246,7 +1246,7 @@ Only enforced if at least one of the following is true:
 * there is at least one client connected to the pool
 
 
-### reserve_pool
+### reserve_pool_size
 
 Set additional connections for this database. If not set, `reserve_pool_size` is
 used.

--- a/doc/config.md
+++ b/doc/config.md
@@ -1248,8 +1248,8 @@ Only enforced if at least one of the following is true:
 
 ### reserve_pool_size
 
-Set additional connections for this database. If not set, `reserve_pool_size` is
-used.
+Set additional connections for this database. If not set, the global `reserve_pool_size`
+is used.
 
 ### connect_query
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -595,7 +595,7 @@ pool_size
 min_pool_size
 :   Minimum number of server connections.
 
-reserve_pool
+reserve_pool_size
 :   Maximum number of additional connections for this database.
 
 server_lifetime

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -7,7 +7,7 @@
 ;; connect string params:
 ;;   dbname= host= port= user= password= auth_user=
 ;;   client_encoding= datestyle= timezone=
-;;   pool_size= reserve_pool= max_db_connections=
+;;   pool_size= reserve_pool_size= max_db_connections=
 ;;   pool_mode= connect_query= application_name=
 [databases]
 
@@ -21,7 +21,7 @@
 ;forcedb = host=localhost port=300 user=baz password=foo client_encoding=UNICODE datestyle=ISO connect_query='SELECT 1'
 
 ;; use custom pool sizes
-;nondefaultdb = pool_size=50 reserve_pool=10
+;nondefaultdb = pool_size=50 reserve_pool_size=10
 
 ;; use auth_user with auth_query if user not present in auth_file
 ;; auth_user must exist in auth_file

--- a/src/admin.c
+++ b/src/admin.c
@@ -499,7 +499,7 @@ static bool admin_show_databases(PgSocket *admin, const char *arg)
 
 	pktbuf_write_RowDescription(buf, "ssissiiiissiiiiii",
 				    "name", "host", "port",
-				    "database", "force_user", "pool_size", "min_pool_size", "reserve_pool",
+				    "database", "force_user", "pool_size", "min_pool_size", "reserve_pool_size",
 				    "server_lifetime", "pool_mode", "load_balance_hosts", "max_connections",
 				    "current_connections", "max_client_connections", "current_client_connections",
 				    "paused", "disabled");

--- a/src/loader.c
+++ b/src/loader.c
@@ -336,6 +336,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			pool_size = atoi(val);
 		} else if (strcmp("min_pool_size", key) == 0) {
 			min_pool_size = atoi(val);
+		/* We continue supporting this option for backwards compatibility */
 		} else if (strcmp("reserve_pool", key) == 0) {
 			res_pool_size = atoi(val);
 		} else if (strcmp("reserve_pool_size", key) == 0) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -336,8 +336,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			pool_size = atoi(val);
 		} else if (strcmp("min_pool_size", key) == 0) {
 			min_pool_size = atoi(val);
-			/* We continue supporting this option for backwards compatibility */
 		} else if (strcmp("reserve_pool", key) == 0) {
+			/* We continue supporting this option for backwards compatibility */
 			res_pool_size = atoi(val);
 		} else if (strcmp("reserve_pool_size", key) == 0) {
 			res_pool_size = atoi(val);

--- a/src/loader.c
+++ b/src/loader.c
@@ -336,7 +336,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			pool_size = atoi(val);
 		} else if (strcmp("min_pool_size", key) == 0) {
 			min_pool_size = atoi(val);
-		/* We continue supporting this option for backwards compatibility */
+			/* We continue supporting this option for backwards compatibility */
 		} else if (strcmp("reserve_pool", key) == 0) {
 			res_pool_size = atoi(val);
 		} else if (strcmp("reserve_pool_size", key) == 0) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -338,6 +338,8 @@ bool parse_database(void *base, const char *name, const char *connstr)
 			min_pool_size = atoi(val);
 		} else if (strcmp("reserve_pool", key) == 0) {
 			res_pool_size = atoi(val);
+		} else if (strcmp("reserve_pool_size", key) == 0) {
+			res_pool_size = atoi(val);
 		} else if (strcmp("max_db_connections", key) == 0) {
 			max_db_connections = atoi(val);
 		} else if (strcmp("max_db_client_connections", key) == 0) {

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,6 +1,6 @@
 [databases]
-p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2
-p0a= port=6666 host=127.0.0.1 dbname=p0 pool_size=2
+p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2 reserve_pool_size=2
+p0a= port=6666 host=127.0.0.1 dbname=p0 pool_size=2 reserve_pool=2
 p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
 p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=2
 ; for testing 'min_pool_size' with forced user


### PR DESCRIPTION
Based on discussion here: https://github.com/pgbouncer/pgbouncer/pull/1228

Updating the database parameter name from `reserve_pool` to `reserve_pool_size` to be consistent with everything else. 

Do you prefer to advertise the deprecation through the release notes only or also make a note in the parameter's documentation?