### PR TITLE
Fix kill_client help

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1568,7 +1568,7 @@ static bool admin_show_help(PgSocket *admin, const char *arg)
 		     "\tENABLE <db>\n"
 		     "\tRECONNECT [<db>]\n"
 		     "\tKILL <db>\n"
-		     "\tKILL_CLIENT <client_ptr>\n"
+		     "\tKILL_CLIENT <client_id>\n"
 		     "\tSUSPEND\n"
 		     "\tSHUTDOWN\n"
 		     "\tSHUTDOWN WAIT_FOR_SERVERS|WAIT_FOR_CLIENTS\n"


### PR DESCRIPTION
A previous version of kill_client used ptr. This is no longer the case. Updating help to reflect this change.