### PR TITLE
Fix bug when decrementing the user connection count

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -600,6 +600,8 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 
 			slog_info(client, "no such user: %s", username);
 			client->login_user_credentials = calloc(1, sizeof(*client->login_user_credentials));
+
+			client->login_user_credentials->global_user = find_or_add_new_global_user(username, NULL);
 			if (!check_db_connection_count(client))
 				return false;
 			client->login_user_credentials->mock_auth = true;

--- a/test/test.ini
+++ b/test/test.ini
@@ -61,6 +61,7 @@ client_limit_db_auth_passthrough = port=6666 host=127.0.0.1 dbname=p0 auth_user=
 maxedout = max_user_connections=3
 maxedout2 = max_user_connections=2 max_user_client_connections=2
 maxedout3 = max_user_client_connections=2
+maxedout6 = max_user_client_connections=2
 poolsize1 = pool_size=1
 respoolsize1 = pool_size=1 reserve_pool_size=2
 pswcheck_not_in_auth_file = max_user_client_connections=2

--- a/test/test.ini
+++ b/test/test.ini
@@ -61,7 +61,6 @@ client_limit_db_auth_passthrough = port=6666 host=127.0.0.1 dbname=p0 auth_user=
 maxedout = max_user_connections=3
 maxedout2 = max_user_connections=2 max_user_client_connections=2
 maxedout3 = max_user_client_connections=2
-maxedout6 = max_user_client_connections=2
 poolsize1 = pool_size=1
 respoolsize1 = pool_size=1 reserve_pool_size=2
 pswcheck_not_in_auth_file = max_user_client_connections=2

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -485,6 +485,9 @@ def test_user_client_count_db_connect_fail_3(bouncer) -> None:
         _ = bouncer.conn(**connect_args)
 
     users = bouncer.admin("SHOW USERS", row_factory=dict_row)
+    # We don't expect non-existent users which cannot authentiticate to show up
+    # in the stats at all. This would just pollute the output with people
+    # making typos or attackers trying random user accounts.
     assert len([user for user in users if user["name"] == test_user]) == 0
 
 

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -454,6 +454,23 @@ def test_user_client_count_db_connect_fail(pg, bouncer) -> None:
     assert user["current_client_connections"] == 0
 
 
+def test_user_client_count_db_connect_fail_2(pg, bouncer) -> None:
+    test_user = "maxedout6"
+    test_dbname = "user_passthrough"
+
+    users = bouncer.admin("SHOW USERS", row_factory=dict_row)
+    user = next(user for user in users if user["name"] == test_user)
+    assert user["current_client_connections"] == 0
+
+    connect_args = {"dbname": test_dbname, "user": test_user}
+    with pytest.raises(psycopg.OperationalError):
+        _ = bouncer.conn(**connect_args)
+
+    users = bouncer.admin("SHOW USERS", row_factory=dict_row)
+    user = next(user for user in users if user["name"] == test_user)
+    assert user["current_client_connections"] == 0
+
+
 def test_min_pool_size_with_lower_max_user_connections(bouncer):
     # The p0x in test.init has min_pool_size set to 5. This should make
     # the PgBouncer try to create a pool for maxedout2 user of size 5 after a

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -486,7 +486,7 @@ def test_user_client_count_db_connect_fail_3(bouncer) -> None:
 
     users = bouncer.admin("SHOW USERS", row_factory=dict_row)
     # We don't expect non-existent users which cannot authentiticate to show up
-    # in the stats at all. This would just pollute the output with people
+    # in the stats at all. This would just pollute the stats output with people
     # making typos or attackers trying random user accounts.
     assert len([user for user in users if user["name"] == test_user]) == 0
 


### PR DESCRIPTION
Fixes #1237

The user connection count was not being decremented correctly if the user did not exist in the auth file, but did exist in the pgbouncer config.

Relevant docs:

> Note that when auth_file is configured, if a user is defined in this section but not listed in auth_file, pgBouncer will attempt to use auth_query to find a password for that user if auth_user is set. If auth_user is not set, pgBouncer will pretend the user exists and fail to return "no such user" messages to the client, but neither will it accept any provided password.