### PR TITLE
Add transaction timeout

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -991,6 +991,13 @@ it will be disconnected.  [seconds]
 
 Default: 0.0 (disabled)
 
+### transaction_timeout
+
+If a client has been in "in transaction" state longer,
+it will be disconnected.  [seconds]
+
+Default: 0.0 (disabled)
+
 ### suspend_timeout
 
 How long to wait for buffer flush during `SUSPEND` or reboot (`-R`).

--- a/doc/config.md
+++ b/doc/config.md
@@ -1371,6 +1371,12 @@ Set the maximum number of seconds that a user can have an idle transaction open.
 If set this timeout overides the server level idle_transaction_timeout
 described above.
 
+### transaction_timeout
+
+Set the maximum number of seconds that a user can have a transaction open.
+If set this timeout overides the server level transaction_timeout
+described above.
+
 ### client_idle_timeout
 
 Set the maximum amount of time in seconds that a client is allowed to idly connect to

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -794,6 +794,7 @@ extern usec_t cf_cancel_wait_timeout;
 extern usec_t cf_client_idle_timeout;
 extern usec_t cf_client_login_timeout;
 extern usec_t cf_idle_transaction_timeout;
+extern usec_t cf_transaction_timeout;
 extern bool any_user_level_timeout_set;
 extern bool any_user_level_client_timeout_set;
 extern int cf_server_round_robin;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -529,6 +529,7 @@ struct PgGlobalUser {
 	int pool_size;	/* max server connections in one pool */
 	int res_pool_size;	/* max additional server connections in one pool */
 
+	usec_t transaction_timeout;	/* how long a user is allowed to stay in transaction before being killed */
 	usec_t idle_transaction_timeout;	/* how long a user is allowed to stay idle in transaction before being killed */
 	usec_t query_timeout;	/* how long a users query is allowed to run before beign killed */
 	usec_t client_idle_timeout;	/* how long is user allowed to idly connect to pgbouncer */

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -586,6 +586,8 @@ static void pool_server_maint(PgPool *pool)
 			usec_t effective_idle_transaction_timeout;
 			usec_t user_query_timeout;
 			usec_t user_idle_transaction_timeout;
+			usec_t user_transaction_timeout;
+			usec_t effective_transaction_timeout;
 
 			server = container_of(item, PgSocket, head);
 			Assert(server->state == SV_ACTIVE);
@@ -605,10 +607,12 @@ static void pool_server_maint(PgPool *pool)
 			age_transaction = now - server->xact_start;
 
 			user_idle_transaction_timeout = server->login_user_credentials->global_user->idle_transaction_timeout;
+			user_transaction_timeout = server->login_user_credentials->global_user->transaction_timeout;
 			user_query_timeout = server->login_user_credentials->global_user->query_timeout;
 
 			effective_idle_transaction_timeout = cf_idle_transaction_timeout;
 			effective_query_timeout = cf_query_timeout;
+			effective_transaction_timeout = cf_transaction_timeout;
 
 			if (user_idle_transaction_timeout > 0)
 				effective_idle_transaction_timeout = user_idle_transaction_timeout;
@@ -616,14 +620,17 @@ static void pool_server_maint(PgPool *pool)
 			if (user_query_timeout > 0)
 				effective_query_timeout = user_query_timeout;
 
+			if (user_transaction_timeout > 0)
+				effective_transaction_timeout = user_transaction_timeout;
+
 			if (effective_query_timeout > 0 && age_client > effective_query_timeout) {
 				disconnect_server(server, true, "query timeout");
 			} else if (effective_idle_transaction_timeout > 0 &&
 				   server->idle_tx &&
 				   age_server > effective_idle_transaction_timeout) {
 				disconnect_server(server, true, "idle transaction timeout");
-			} else if (cf_transaction_timeout > 0 &&
-				   age_transaction > cf_transaction_timeout) {
+			} else if (effective_transaction_timeout > 0 &&
+				   age_transaction > effective_transaction_timeout) {
 				disconnect_server(server, true, "transaction timeout");
 			}
 		}

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -604,7 +604,7 @@ static void pool_server_maint(PgPool *pool)
 			 */
 			age_client = now - server->link->request_time;
 			age_server = now - server->request_time;
-			age_transaction = now - server->xact_start;
+			age_transaction = now - server->link->xact_start;
 
 			user_idle_transaction_timeout = server->login_user_credentials->global_user->idle_transaction_timeout;
 			user_transaction_timeout = server->login_user_credentials->global_user->transaction_timeout;

--- a/src/loader.c
+++ b/src/loader.c
@@ -505,6 +505,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	int res_pool_size = -1;
 	int max_user_connections = -1;
 	usec_t idle_transaction_timeout = 0;
+	usec_t transaction_timeout = 0;
 	usec_t query_timeout = 0;
 	usec_t client_idle_timeout = 0;
 	int max_user_client_connections = -1;
@@ -539,6 +540,9 @@ bool parse_user(void *base, const char *name, const char *connstr)
 			res_pool_size = atoi(val);
 		} else if (strcmp("max_user_connections", key) == 0) {
 			max_user_connections = atoi(val);
+		} else if (strcmp("transaction_timeout", key) == 0) {
+			any_user_level_timeout_set = true;
+			transaction_timeout = atoi(val) * USEC;
 		} else if (strcmp("idle_transaction_timeout", key) == 0) {
 			any_user_level_timeout_set = true;
 			idle_transaction_timeout = atoi(val) * USEC;
@@ -567,6 +571,7 @@ bool parse_user(void *base, const char *name, const char *connstr)
 	user->res_pool_size = res_pool_size;
 	user->max_user_connections = max_user_connections;
 	user->idle_transaction_timeout = idle_transaction_timeout;
+	user->transaction_timeout = transaction_timeout;
 	user->query_timeout = query_timeout;
 	user->client_idle_timeout = client_idle_timeout;
 	user->max_user_client_connections = max_user_client_connections;

--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,7 @@ usec_t cf_cancel_wait_timeout;
 usec_t cf_client_idle_timeout;
 usec_t cf_client_login_timeout;
 usec_t cf_idle_transaction_timeout;
+usec_t cf_transaction_timeout;
 usec_t cf_suspend_timeout;
 
 usec_t g_suspend_start;
@@ -269,6 +270,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 	CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
 	CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
+	CF_ABS("transaction_timeout", CF_TIME_USEC, cf_transaction_timeout, 0, "0"),
 	CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 	CF_ABS("job_name", CF_STR, cf_jobname, CF_NO_RELOAD, "pgbouncer"),
 	CF_ABS("listen_addr", CF_STR, cf_listen_addr, CF_NO_RELOAD, ""),

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -366,13 +366,15 @@ def test_transaction_timeout(bouncer):
     values for valgrind pipeline.
 
     Procedure:
-        - Set transaction_timeout=6 in admin console.
+        - Set pool_mode=transaction in admin console (default is statement)
+        - Set transaction_timeout=6
         - start transaction.
         - Execute empty query. Test that no error is raised
         - Wait 7 seconds
         - Execute emtpty query. Test that psycopg.OperationalError is raised
     """
-    bouncer.admin("set transaction_timeout=6")
+    bouncer.admin("SET pool_mode=transaction")
+    bouncer.admin("SET transaction_timeout=6")
 
     with bouncer.transaction() as cur:
         with bouncer.log_contains(r"transaction timeout"):

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -311,6 +311,20 @@ def test_user_level_idle_client_timeout_override(bouncer):
                     cur.execute("SELECT 1")
 
 
+def test_transaction_timeout(bouncer):
+    bouncer.admin(f"set pool_mode=transaction")
+    bouncer.admin(f"set transaction_timeout=2")
+
+    with bouncer.transaction() as cur:
+        with bouncer.log_contains(r"transaction timeout"):
+            time.sleep(3)
+            with pytest.raises(
+                psycopg.OperationalError,
+                match=r"server closed the connection unexpectedly|Software caused connection abort",
+            ):
+                cur.execute("select 1")
+
+
 def test_idle_transaction_timeout(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     bouncer.admin(f"set idle_transaction_timeout=2")

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -352,7 +352,7 @@ def test_transaction_timeout_user_overide_global(bouncer):
                 time.sleep(2)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"transaction timeout",
                 ):
                     cur.execute("")
 
@@ -395,7 +395,7 @@ def test_transaction_timeout_user(bouncer):
                 time.sleep(2)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"transaction timeout",
                 ):
                     cur.execute("")
 
@@ -423,7 +423,7 @@ def test_transaction_timeout(bouncer):
             time.sleep(2)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly|Software caused connection abort",
+                match=r"transaction timeout",
             ):
                 cur.execute("")
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -347,8 +347,8 @@ def test_transaction_timeout_user(bouncer):
     # while configured to be in statement pooling mode
     with bouncer.run_with_config(config):
         with bouncer.transaction(dbname="postgres", user="puser1") as cur:
+            cur.execute("")
             with bouncer.log_contains(r"transaction timeout"):
-                cur.execute("")
                 time.sleep(7)
                 with pytest.raises(
                     psycopg.OperationalError,
@@ -377,8 +377,8 @@ def test_transaction_timeout(bouncer):
     bouncer.admin("SET transaction_timeout=6")
 
     with bouncer.transaction() as cur:
+        cur.execute("")
         with bouncer.log_contains(r"transaction timeout"):
-            cur.execute("")
             time.sleep(7)
             with pytest.raises(
                 psycopg.OperationalError,

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -326,33 +326,33 @@ def test_transaction_timeout_user(bouncer):
         pool_mode = session
 
         [users]
-        puser1 = pool_mode=transaction transaction_timeout=2
+        puser1 = pool_mode=transaction transaction_timeout=6
     """
 
     # while configured to be in statement pooling mode
     with bouncer.run_with_config(config):
         with bouncer.transaction(dbname="postgres", user="puser1") as cur:
             with bouncer.log_contains(r"transaction timeout"):
-                time.sleep(3)
+                time.sleep(7)
                 with pytest.raises(
                     psycopg.OperationalError,
                     match=r"server closed the connection unexpectedly|Software caused connection abort",
                 ):
-                    cur.execute("select 1")
+                    cur.execute("")
 
 
 def test_transaction_timeout(bouncer):
     bouncer.admin("set pool_mode=transaction")
-    bouncer.admin("set transaction_timeout=2")
+    bouncer.admin("set transaction_timeout=6")
 
     with bouncer.transaction() as cur:
         with bouncer.log_contains(r"transaction timeout"):
-            time.sleep(3)
+            time.sleep(7)
             with pytest.raises(
                 psycopg.OperationalError,
                 match=r"server closed the connection unexpectedly|Software caused connection abort",
             ):
-                cur.execute("select 1")
+                cur.execute("")
 
 
 def test_idle_transaction_timeout(bouncer):

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -352,7 +352,7 @@ def test_transaction_timeout_user_overide_global(bouncer):
                 time.sleep(2)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"transaction timeout",
+                    match=r"transaction timeout|Software caused connection abort",
                 ):
                     cur.execute("")
 
@@ -395,7 +395,7 @@ def test_transaction_timeout_user(bouncer):
                 time.sleep(2)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"transaction timeout",
+                    match=r"transaction timeout|Software caused connection abort",
                 ):
                     cur.execute("")
 
@@ -423,7 +423,7 @@ def test_transaction_timeout(bouncer):
             time.sleep(2)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"transaction timeout",
+                match=r"transaction timeout|Software caused connection abort",
             ):
                 cur.execute("")
 


### PR DESCRIPTION
This PR adds a transaction timeout global setting to pgbouncer. In the current state there is an idle_in_transaction_timeout and a query_timeout but no transaction_timeout. This is meant to combat issues where a user starts a transaction and then proceeds to wait and issue `SELECT 1;` repeatedly thus making the transaction not idle. There is an equivalent setting on the postgres side but it is easily overridden by any user.

Not looking to get this in before the next release but I believe that this functionality could be very useful and just want to put a PR out here for visibility.