### PR TITLE
Pin psycopg version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pytest
 pytest-asyncio
 pytest-timeout
 pytest-xdist
-psycopg
+psycopg==3.2.3
 filelock
 contextlib2; python_version < "3.7"


### PR DESCRIPTION
This PR attempts to fix CI by pinning the psycopg version. This will make it  a manual process to upgrade psycopg but at least it will not cause CI failures on the master branch anytime psycopg does a release that changes its behaviour in unit tests.