### PR TITLE
Fix assertion failures introduced by psycopg 3.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pytest
 pytest-asyncio
 pytest-timeout
 pytest-xdist
-psycopg==3.2.3
+psycopg==3.2.4
 filelock
 contextlib2; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pytest
 pytest-asyncio
 pytest-timeout
 pytest-xdist
-psycopg==3.2.4
+psycopg
 filelock
 contextlib2; python_version < "3.7"

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -271,7 +271,8 @@ async def test_repeated_sigterm(bouncer):
         bouncer.sigterm()
         await bouncer.wait_for_exit()
         with pytest.raises(
-            psycopg.OperationalError, match="server closed the connection unexpectedly"
+            psycopg.OperationalError,
+            match="database removed|server closed the connection unexpectedly",
         ):
             cur.execute("SELECT 1")
         assert not bouncer.running()
@@ -298,7 +299,8 @@ async def test_repeated_sigint(bouncer):
         bouncer.sigint()
         await bouncer.wait_for_exit()
         with pytest.raises(
-            psycopg.OperationalError, match="server closed the connection unexpectedly"
+            psycopg.OperationalError,
+            match="database removed|server closed the connection unexpectedly",
         ):
             cur.execute("SELECT 1")
         assert not bouncer.running()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -28,7 +28,7 @@ def test_fast_close(bouncer):
 
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"database configuration changed|Software caused connection abort",
+                match=r"database configuration changed|server closed the connection unexpectedly|Software caused connection abort",
             ):
                 cur.execute("select 1")
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -28,7 +28,7 @@ def test_fast_close(bouncer):
 
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly|Software caused connection abort",
+                match=r"database configuration changed|Software caused connection abort",
             ):
                 cur.execute("select 1")
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -88,7 +88,7 @@ def test_user_idle_transaction_timeout_override_global(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"idle transaction timeout|Software caused connection abort",
                 ):
                     cur.execute("select 1")
 
@@ -118,7 +118,7 @@ def test_user_idle_transaction_timeout(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"idle transaction timeout|Software caused connection abort",
                 ):
                     cur.execute("select 1")
 
@@ -147,7 +147,7 @@ def test_user_query_timeout_override_global(bouncer):
         with bouncer.log_contains(r"query timeout"):
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly",
+                match=r"query timeout",
             ):
                 bouncer.sleep(5, user="puser1", dbname="postgres")
 
@@ -198,7 +198,7 @@ def test_user_query_timeout(bouncer):
         with bouncer.log_contains(r"query timeout"):
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly",
+                match=r"query timeout",
             ):
                 bouncer.sleep(5, user="puser1", dbname="postgres")
 
@@ -208,7 +208,7 @@ def test_query_timeout(bouncer):
 
     with bouncer.log_contains(r"query timeout"):
         with pytest.raises(
-            psycopg.OperationalError, match=r"server closed the connection unexpectedly"
+            psycopg.OperationalError, match=r"query timeout"
         ):
             bouncer.sleep(5)
 
@@ -242,7 +242,7 @@ def test_user_level_idle_client_timeout_negative(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"client_idle_timeout|Software caused connection abort",
                 ):
                     cur.execute("SELECT 1")
 
@@ -306,7 +306,7 @@ def test_user_level_idle_client_timeout_override(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"server closed the connection unexpectedly|Software caused connection abort",
+                    match=r"client_idle_timeout|Software caused connection abort",
                 ):
                     cur.execute("SELECT 1")
 
@@ -320,7 +320,7 @@ def test_idle_transaction_timeout(bouncer):
             time.sleep(3)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly|Software caused connection abort",
+                match=r"idle transaction timeout|Software caused connection abort",
             ):
                 cur.execute("select 1")
 
@@ -340,7 +340,7 @@ def test_client_idle_timeout(bouncer):
             time.sleep(3)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly|Software caused connection abort",
+                match=r"client_idle_timeout",
             ):
                 cur.execute("select 1")
 
@@ -405,7 +405,7 @@ def test_tcp_user_timeout(pg, bouncer):
         with pg.reject_traffic():
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"server closed the connection unexpectedly|Software caused connection abort",
+                match=r"query timeout|Software caused connection abort",
             ):
                 bouncer.test(connect_timeout=10)
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -340,7 +340,7 @@ def test_client_idle_timeout(bouncer):
             time.sleep(3)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"client_idle_timeout",
+                match=r"client_idle_timeout|Software caused connection abort",
             ):
                 cur.execute("select 1")
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -207,9 +207,7 @@ def test_query_timeout(bouncer):
     bouncer.admin(f"set query_timeout=1")
 
     with bouncer.log_contains(r"query timeout"):
-        with pytest.raises(
-            psycopg.OperationalError, match=r"query timeout"
-        ):
+        with pytest.raises(psycopg.OperationalError, match=r"query timeout"):
             bouncer.sleep(5)
 
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -88,7 +88,7 @@ def test_user_idle_transaction_timeout_override_global(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"idle transaction timeout|Software caused connection abort",
+                    match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
                 ):
                     cur.execute("select 1")
 
@@ -118,7 +118,7 @@ def test_user_idle_transaction_timeout(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"idle transaction timeout|Software caused connection abort",
+                    match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
                 ):
                     cur.execute("select 1")
 
@@ -147,7 +147,7 @@ def test_user_query_timeout_override_global(bouncer):
         with bouncer.log_contains(r"query timeout"):
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"query timeout",
+                match=r"query timeout|server closed the connection unexpectedly",
             ):
                 bouncer.sleep(5, user="puser1", dbname="postgres")
 
@@ -198,7 +198,7 @@ def test_user_query_timeout(bouncer):
         with bouncer.log_contains(r"query timeout"):
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"query timeout",
+                match=r"query timeout|server closed the connection unexpectedly",
             ):
                 bouncer.sleep(5, user="puser1", dbname="postgres")
 
@@ -207,7 +207,10 @@ def test_query_timeout(bouncer):
     bouncer.admin(f"set query_timeout=1")
 
     with bouncer.log_contains(r"query timeout"):
-        with pytest.raises(psycopg.OperationalError, match=r"query timeout"):
+        with pytest.raises(
+            psycopg.OperationalError,
+            match=r"query timeout|server closed the connection unexpectedly",
+        ):
             bouncer.sleep(5)
 
 
@@ -240,7 +243,7 @@ def test_user_level_idle_client_timeout_negative(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"client_idle_timeout|Software caused connection abort",
+                    match=r"client_idle_timeout|Software caused connection abort|server closed the connection unexpectedly",
                 ):
                     cur.execute("SELECT 1")
 
@@ -304,7 +307,7 @@ def test_user_level_idle_client_timeout_override(bouncer):
                 time.sleep(3)
                 with pytest.raises(
                     psycopg.OperationalError,
-                    match=r"client_idle_timeout|Software caused connection abort",
+                    match=r"client_idle_timeout|Software caused connection abort|server closed the connection unexpectedly",
                 ):
                     cur.execute("SELECT 1")
 
@@ -318,7 +321,7 @@ def test_idle_transaction_timeout(bouncer):
             time.sleep(3)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"idle transaction timeout|Software caused connection abort",
+                match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
             ):
                 cur.execute("select 1")
 
@@ -338,7 +341,7 @@ def test_client_idle_timeout(bouncer):
             time.sleep(3)
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"client_idle_timeout|Software caused connection abort",
+                match=r"client_idle_timeout|Software caused connection abort|server closed the connection unexpectedly",
             ):
                 cur.execute("select 1")
 
@@ -403,7 +406,7 @@ def test_tcp_user_timeout(pg, bouncer):
         with pg.reject_traffic():
             with pytest.raises(
                 psycopg.OperationalError,
-                match=r"query timeout|Software caused connection abort",
+                match=r"query timeout|Software caused connection abort|server closed the connection unexpectedly",
             ):
                 bouncer.test(connect_timeout=10)
 


### PR DESCRIPTION
These failures were previously addressed by @AndrewJackson2020
in #1249 by pinning psycopg to 3.2.3. I became aware of this because I
just re-enabled the python test suite in Debian[1] [2].

This is a good change in psycopg[3]. Let's update the assertions and bump
the version.

Open question around whether or not we should pin here? It would be good if
we can sort these issues out before they block the upload of new
pgbouncer packages to downstream distros (although most folks probably
care more about pgdg?) No worries either way.

[1]: https://www.postgresql.org/message-id/CAOMoQbROhu7WG9LnyjHb1RXJrax_HKKMBbwaou%2Bjps0uZgqHFw%40mail.gmail.com
[2]: https://www.postgresql.org/message-id/CAGKCzNAQKMKJ_BQcF%3DuzcfcM%3Dvx8QYnT%2Bjtzuv_yp%3D76zbhn7g%40mail.gmail.com
[3]: https://github.com/psycopg/psycopg/compare/3.2.3...3.2.4#diff-87f7a7bb7fe8dbed76e16b67b87f27bda7b779b56e7d93ed3350d77ee4a3f217R20-R23
