### PR TITLE
Match the MAX_PASSWORD value in bouncer.h

### DIFF
--- a/src/common/saslprep.c
+++ b/src/common/saslprep.c
@@ -35,7 +35,7 @@
  * Limit on how large password's we will try to process.  A password
  * larger than this will be treated the same as out-of-memory.
  */
-#define MAX_PASSWORD_LENGTH		1024
+#define MAX_PASSWORD_LENGTH		2048
 
 /*
  * In backend, we will use palloc/pfree.  In frontend, use malloc, and


### PR DESCRIPTION
Doing a bit of testing in AWS I discovered that the token (which is over 1024 bytes) would cause pg_bouncer to segfault when the server requests SASL auth. With some digging I found that the MAX_PASSWORD_LENGTH in `saslprep.c` didn't match what was defined in bouncer.h. 

This small patch just ensures the value matches. There is probably a better way to have this defined in one place instead of two. Alas this is a quick fix for those who may run into this issue.