### PR TITLE
Also check the second digit in the openssl version when creating certificates

### DIFF
--- a/test/ssl/newca.sh
+++ b/test/ssl/newca.sh
@@ -32,7 +32,7 @@ run openssl ecparam -name prime256v1 -genkey -out "$name/ca.key"
 # self-signed cert
 # the -addext option is not required for old OpenSSL versions
 openssl_version=`openssl version | awk '{print $2}'`
-if expr "X$openssl_version" : 'X1.0.*' >/dev/null; then
+if expr "X$openssl_version" : 'X1.*.*' >/dev/null; then
   run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -- "$@"
 else
   run_req -new -x509 -days $days -key "$name/ca.key" -out "$name/ca.crt" -addext basicConstraints=critical,CA:TRUE,pathlen:1 -- "$@"


### PR DESCRIPTION
Hello! Сommit #1221 introduced new changes needed to ensure that on systems with old openssl (v1.0.x) certificates are generated correctly by skipping the -addext option. But I found out that on the astra-leningrad-8.1 system, on which the openssl 1.1.f version, the check proposed in the above-mentioned commit will not work. I suggest adding a check for the second digit in the version number.
Examples:
```
test@astrassd:~/test/pgbouncer-1.24.0$ openssl_version=`openssl version | awk '{print $2}'`
test@astrassd:~/test/pgbouncer-1.24.0$ echo $openssl_version
1.1.0f
test@astrassd:~/test/pgbouncer-1.24.0$ expr "X$openssl_version" : 'X1.0.*'
0
test@astrassd:~/test/pgbouncer-1.24.0$ expr "X$openssl_version" : 'X1.*.*'
7
```
Test without patch:
```
test@astrassd:~/test/pgbouncer-1.24.0$ pytest --quiet test/test_ssl.py::test_server_ssl_verify
E                                                                                                                                                                                                                                                    [100%]
========================================================================================================================== ERRORS ==========================================================================================================================
_________________________________________________________________________________________________________ ERROR at setup of test_server_ssl_verify _________________________________________________________________________________________________________
/home/test/pgbouncer-1.24.0/test/conftest.py:77: in shared_setup
    create_certs(cert_dir)
        cert_dir   = PosixPath('/tmppg/pytest-of-postgres/pytest-4/certs')
        tmp_path_factory = TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0x1c20280>, _basetemp=PosixPath('/tmppg/pytest-of-postgres/pytest-4'))
        worker_id  = 'master'
/home/test/pgbouncer-1.24.0/test/conftest.py:45: in create_certs
    run(
        cert_dir   = PosixPath('/tmppg/pytest-of-postgres/pytest-4/certs')
/home/test/pgbouncer-1.24.0/test/utils.py:108: in run
    return subprocess.run(command, *args, check=check, shell=shell, **kwargs)
        args       = ()
        check      = True
        command    = 'sh create_certs.sh'
        kwargs     = {'cwd': PosixPath('/home/test/pgbouncer-1.24.0/test/ssl'), 'stdout': -3}
        shell      = True
        silent     = True
/home/test/rescue/lib/python3.11/subprocess.py:571: in run
    raise CalledProcessError(retcode, process.args,
E   subprocess.CalledProcessError: Command 'sh create_certs.sh' returned non-zero exit status 1.
        capture_output = False
        check      = True
        input      = None
        kwargs     = {'cwd': PosixPath('/home/test/pgbouncer-1.24.0/test/ssl'), 'shell': True, 'stdout': -3}
        popenargs  = ('sh create_certs.sh',)
        process    = <Popen: returncode: 1 args: 'sh create_certs.sh'>
        retcode    = 1
        stderr     = None
        stdout     = None
        timeout    = None
------------------------------------------------------------------------------------------------------------------ Captured stderr setup -------------------------------------------------------------------------------------------------------------------
cp: cannot stat 'TestCA1/certs/01.pem': No such file or directory
================================================================================================================= short test summary info ==================================================================================================================
ERROR test/test_ssl.py::test_server_ssl_verify - subprocess.CalledProcessError: Command 'sh create_certs.sh' returned non-zero exit status 1.
1 error in 0.89s
```
Test with patch:
```
test@astrassd:~/test/pgbouncer-1.24.0$ pytest --quiet test/test_ssl.py::test_server_ssl_verify
.                                                                                                                                                                                                                                                    [100%]
1 passed in 15.02s
```

Best regards,
Egor Chindyaskin
Postgres Professional: https://postgrespro.com