### PR TITLE
fix clang readability warning (inconsistent declarataion parameter name)

### DIFF
--- a/include/server.h
+++ b/include/server.h
@@ -19,7 +19,7 @@
 bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *pkt)  _MUSTCHECK;
 void kill_pool_logins(PgPool *pool, const char *sqlstate, const char *msg);
 const char * kill_pool_logins_server_error(PgPool *pool, PktHdr *errpkt);
-int connection_pool_mode(PgSocket *server) _MUSTCHECK;
+int connection_pool_mode(PgSocket *connection) _MUSTCHECK;
 int probably_wrong_pool_pool_mode(PgPool *pool) _MUSTCHECK;
 int pool_pool_size(PgPool *pool) _MUSTCHECK;
 int pool_min_pool_size(PgPool *pool) _MUSTCHECK;


### PR DESCRIPTION
clang-tidy identified a minor naming inconsistency between parameter naming in server.h/server.c

https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html