### PR TITLE
Handle query cancellation for waiting clients

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -665,7 +665,7 @@ struct PgSocket {
 	bool wait_for_user_conn : 1;	/* client: waiting for auth_conn server connection */
 	bool wait_for_user : 1;		/* client: waiting for auth_conn query results */
 	bool wait_for_auth : 1;		/* client: waiting for external auth (PAM) to be completed */
-	bool wait_for_cancel : 1; 	/* client: waiting for cancel action(Cancel requests on waiting clients) to be completed */
+	bool wait_for_cancel : 1;	/* client: waiting for cancel action(Cancel requests on waiting clients) to be completed */
 
 	bool suspended : 1;		/* client/server: if the socket is suspended */
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -665,6 +665,7 @@ struct PgSocket {
 	bool wait_for_user_conn : 1;	/* client: waiting for auth_conn server connection */
 	bool wait_for_user : 1;		/* client: waiting for auth_conn query results */
 	bool wait_for_auth : 1;		/* client: waiting for external auth (PAM) to be completed */
+	bool wait_for_cancel : 1; 	/* client: waiting for cancel action(Cancel requests on waiting clients) to be completed */
 
 	bool suspended : 1;		/* client/server: if the socket is suspended */
 

--- a/src/client.c
+++ b/src/client.c
@@ -1368,28 +1368,27 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	PgClosePacket close_packet;
 
 
-	if(client->wait_for_cancel){
-		
-		switch(pkt->type){
-			case PqMsg_Query:
-			case PqMsg_FunctionCall:
-			case PqMsg_Sync:
-				client->query_start = 0;
-				client->xact_start  = 0;
-				client->wait_for_cancel = false;
-				break;
-			default:
-				return false;
-				break;
+	if (client->wait_for_cancel) {
+		switch (pkt->type) {
+		case PqMsg_Query:
+		case PqMsg_FunctionCall:
+		case PqMsg_Sync:
+			client->query_start = 0;
+			client->xact_start = 0;
+			client->wait_for_cancel = false;
+			break;
+		default:
+			return false;
+			break;
 		}
-		
+
 		sbuf_prepare_skip(sbuf, pkt->len);
-		
-		if (!send_pooler_error(client,true,NULL,false,"Cancelled waiting query")){
-			disconnect_client(client,false,"Failed to cancel waiting query");
+
+		if (!send_pooler_error(client, true, NULL, false, "Cancelled waiting query")) {
+			disconnect_client(client, false, "Failed to cancel waiting query");
 			return false;
 		}
-		
+
 		return true;
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -1367,6 +1367,33 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	PreparedStatementAction ps_action = PS_IGNORE;
 	PgClosePacket close_packet;
 
+
+	if(client->wait_for_cancel){
+		
+		switch(pkt->type){
+			case PqMsg_Query:
+			case PqMsg_FunctionCall:
+			case PqMsg_Sync:
+				client->query_start = 0;
+				client->xact_start  = 0;
+				client->wait_for_cancel = false;
+				break;
+			default:
+				return false;
+				break;
+		}
+		
+		sbuf_prepare_skip(sbuf, pkt->len);
+		
+		if (!send_pooler_error(client,true,NULL,false,"Cancelled waiting query")){
+			disconnect_client(client,false,"Failed to cancel waiting query");
+			return false;
+		}
+		
+		return true;
+	}
+
+
 	switch (pkt->type) {
 	/* one-packet queries */
 	case PqMsg_Query:

--- a/src/objects.c
+++ b/src/objects.c
@@ -2193,8 +2193,7 @@ found:
 	 * itself before the cancel request arived to pgbouncer or it is for a waiting client.
 	 */
 	if (!main_client->link) {
-		
-		if (waiting_client){
+		if (waiting_client) {
 			main_client->wait_for_cancel = true;
 			activate_client(main_client);
 		}

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -129,6 +129,7 @@ def test_cancel_on_wait(bouncer):
     try:
         with ThreadPoolExecutor(max_workers=3) as pool:
             q1 = pool.submit(cur1.execute, "select pg_sleep(5)")
+            time.sleep(1)
             q2 = pool.submit(cur2.execute, "select pg_sleep(5)")
             time.sleep(1)
 

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -118,7 +118,7 @@ def test_cancel_race(bouncer):
         conn2.close()
 
 
-
+# Checks that pgbouncer handles cancel requests for waiting client
 def test_cancel_on_wait(bouncer):
     bouncer.admin("set default_pool_size=1")
     bouncer.admin("set log_pooler_errors=1")
@@ -136,16 +136,15 @@ def test_cancel_on_wait(bouncer):
             cancel.result()
             bouncer.print_logs()
 
-            with pytest.raises(
-                Exception, match="Cancelled waiting query"
-            ):
+            with pytest.raises(Exception, match="Cancelled waiting query"):
                 q2.result()
             q1.result()
     finally:
         conn1.close()
         conn2.close()
-        
-        
+
+
+# Checks that pgbouncer handles cancel requests for waiting client due to pause
 def test_cancel_on_wait_with_pause(bouncer):
     conn = bouncer.conn(dbname="p1")
     cur = conn.cursor()
@@ -159,11 +158,8 @@ def test_cancel_on_wait_with_pause(bouncer):
             cancel.result()
             bouncer.print_logs()
 
-            with pytest.raises(
-                Exception, match="Cancelled waiting query"
-            ):
+            with pytest.raises(Exception, match="Cancelled waiting query"):
                 q.result()
     finally:
         conn.close()
         bouncer.admin("resume p1")
-        


### PR DESCRIPTION
This fix enables the cancellation of waiting clients. Previously, if a cancel request arrived for a waiting client, it was ignored, causing the client to hang. With this fix, the behavior now aligns with how cancel requests are handled on a PostgreSQL server