### PR TITLE
Fixup longpass auth tests

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -143,9 +143,10 @@ PG_MAJOR_VERSION = get_pg_major_version()
 
 def get_max_password_length():
     with open("../include/bouncer.h", encoding="utf-8") as f:
-        match = re.search(r"#define MAX_PASSWORD\s+([0-9])", f.read())
+        match = re.search(r"#define MAX_PASSWORD\s+([0-9].*)", f.read())
         assert match is not None
         max_password_length = int(match.group(1))
+        assert max_password_length >= 996
 
     if max_password_length > 996 and PG_MAJOR_VERSION < 14:
         return 996
@@ -154,7 +155,7 @@ def get_max_password_length():
 
 PKT_BUF_SIZE = 4096
 MAX_PASSWORD_LENGTH = get_max_password_length()
-LONG_PASSWORD = "a" * MAX_PASSWORD_LENGTH
+LONG_PASSWORD = "a" * (MAX_PASSWORD_LENGTH - 1)
 
 PG_SUPPORTS_SCRAM = PG_MAJOR_VERSION >= 10
 


### PR DESCRIPTION
C-strings are `NULL` terminated and so `MAX_PASSWORD_LENGTH` =
`MAX_PASSWORD - 1`.

Additionally, the regex matcher for pulling out `MAX_PASSWORD` was wrong
and only got "2" when it should have been "2048".

This closes #1268 