### PR TITLE
Allow client_tls_sslmode to be used without client_tls_ca_file

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1227,7 +1227,7 @@ static bool setup_tls(struct tls_config *conf, const char *pfx, int sslmode,
 			tls_config_verify_client(conf);
 		} else if (sslmode == SSLMODE_VERIFY_CA) {
 			tls_config_verify_client(conf);
-		} else {
+		} else if (*cafile) {
 			tls_config_verify_client_optional(conf);
 		}
 	}


### PR DESCRIPTION
This change allows `client_tls_sslmode` to be used without `client_tls_ca_file` when set to `require`, `prefer` or `allow`.

Fixes https://github.com/pgbouncer/pgbouncer/issues/1215