### PR TITLE
ci: FreeBSD fix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-1
+    image_family: freebsd-14-2
   env:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true


### PR DESCRIPTION
The FreeBSD 14.1 image is no longer available according to the list of images and documentation [1].

$ gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images | grep 14
freebsd-14-2-release-amd64-ufs           freebsd-org-cloud-dev  freebsd-14-2                   READY
freebsd-14-2-release-amd64-ufs-gce       freebsd-org-cloud-dev  freebsd-14-2                   READY
freebsd-14-2-stable-amd64-ufs-20250102   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250109   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250116   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250124   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250130   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250206   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250213   freebsd-org-cloud-dev  freebsd-14-2-snap              READY
freebsd-14-2-stable-amd64-ufs-20250221   freebsd-org-cloud-dev  freebsd-14-2-snap              READY

[1] https://cirrus-ci.org/guide/FreeBSD/