### PR TITLE
Adding server_closed_count and server_lifetime metrics

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -187,7 +187,10 @@ total_query_count
 :   Total number of SQL commands pooled by **pgbouncer**.
 
 total_server_assignment_count
-:   Total times a server was assigned to a client
+:   Total times a server was assigned to a client.
+
+total_server_closed_count
+:   Total times a server connection was closed.
 
 total_received
 :   Total volume in bytes of network traffic received by **pgbouncer**.
@@ -207,6 +210,10 @@ total_query_time
 total_wait_time
 :   Time spent by clients waiting for a server, in microseconds. Updated
     when a client connection is assigned a backend connection.
+
+total_server_lifetime
+:   Total age of server connections, in microseconds. Updated when a
+    server connection is disconnected.
 
 total_client_parse_count
 :   Total number of prepared statements created by clients. Only applicable
@@ -247,6 +254,11 @@ avg_wait_time
 :   Time spent by clients waiting for a server, in microseconds (average
     of the wait times for clients assigned a backend during the current
     `stats_period`).
+
+avg_server_lifetime
+:   Average age of server connections, in microseconds (average
+    of the server lifetimes for servers disconnected during the current
+    `stats_period`).   
 
 avg_client_parse_count
 :   Average number of prepared statements created by clients. Only applicable

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -306,6 +306,7 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
  * Stats, kept per-pool.
  */
 struct PgStats {
+	uint64_t server_closed_count;
 	uint64_t server_assignment_count;
 	uint64_t xact_count;
 	uint64_t query_count;
@@ -314,6 +315,7 @@ struct PgStats {
 	usec_t xact_time;	/* total transaction time in us */
 	usec_t query_time;	/* total query time in us */
 	usec_t wait_time;	/* total time clients had to wait */
+	usec_t server_lifetime; /* total lifetime of servers */
 
 	/* stats for prepared statements */
 	uint64_t ps_server_parse_count;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -315,7 +315,7 @@ struct PgStats {
 	usec_t xact_time;	/* total transaction time in us */
 	usec_t query_time;	/* total query time in us */
 	usec_t wait_time;	/* total time clients had to wait */
-	usec_t server_lifetime; /* total lifetime of servers */
+	usec_t server_lifetime;	/* total lifetime of servers */
 
 	/* stats for prepared statements */
 	uint64_t ps_server_parse_count;

--- a/src/objects.c
+++ b/src/objects.c
@@ -1351,6 +1351,9 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 			  (now - server->connect_time) / USEC);
 	}
 
+	server->pool->stats.server_closed_count++;
+	server->pool->stats.server_lifetime += (now - server->connect_time);
+
 	switch (server->state) {
 	case SV_ACTIVE_CANCEL:
 	case SV_ACTIVE:

--- a/src/stats.c
+++ b/src/stats.c
@@ -160,7 +160,7 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 				    "avg_recv", "avg_sent",
 				    "avg_xact_time", "avg_query_time",
 				    "avg_wait_time", "avg_server_lifetime",
-					"avg_client_parse_count",
+				    "avg_client_parse_count",
 				    "avg_server_parse_count", "avg_bind_count");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
@@ -261,7 +261,7 @@ static void write_stats_averages(PktBuf *buf, PgStats *stat, PgStats *old, char 
 			     avg.client_bytes, avg.server_bytes,
 			     avg.xact_time, avg.query_time,
 			     avg.wait_time, avg.server_lifetime,
-				 avg.ps_client_parse_count,
+			     avg.ps_client_parse_count,
 			     avg.ps_server_parse_count, avg.ps_bind_count);
 }
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -268,3 +268,19 @@ def test_show_stats(bouncer):
     assert ("total_xact_count", 10) in totals
     # 11 SELECT 1 + 2 times COMMIT and ROLLBACK + 4 admin commands
     assert ("total_query_count", 19) in totals
+
+    bouncer.admin(f"set server_lifetime=0")
+    # wait for existing server connection to drop
+    time.sleep(3)
+    bouncer.test()
+    bouncer.test()
+    bouncer.test()
+    bouncer.test()
+
+    # Get updated stats
+    stats = bouncer.admin("SHOW STATS", row_factory=dict_row)
+    p3_stats = next((s for s in stats if s.get("database") == "p3"), None)
+    assert p3_stats is not None
+
+    # 1 server connection from previous commands and 4 after setting server_lifetime=0
+    assert p3_stats["total_server_closed_count"] == 5


### PR DESCRIPTION
This PR adds server_closed_count and server_lifetime metrics to track and analyze the age of server connections. These metrics provide insights into connection lifetimes and can help diagnose connection churn.

These metrics can be useful for understanding how long connections typically last before being closed, helping in fine-tuning idle_server_timeout and server_lifetime settings.

Do let me know if this would be useful, and if emitting any other similar metrics would add value—I’d be happy to take a stab at it!
