### PR TITLE
Use new cancel video link

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1390,7 +1390,10 @@ TCP load balancer.  Cancellation requests are sent over different TCP
 connections than the query they are cancelling, so a TCP load balancer might
 send the cancellation request connection to a different process than the one
 that it was meant for.  By peering them these cancellation requests eventually
-end up at the right process.
+end up at the right process. A more in-depth explanation is provided in this
+[recording of a conference talk][cancel-problem-video].
+
+[cancel-problem-video]: https://www.youtube.com/watch?v=M585FfbboNA
 
 The section contains key=value lines like
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1393,7 +1393,7 @@ that it was meant for.  By peering them these cancellation requests eventually
 end up at the right process. A more in-depth explanation is provided in this
 [recording of a conference talk][cancel-problem-video].
 
-[cancel-problem-video]: https://www.youtube.com/watch?v=M585FfbboNA
+[cancel-problem-video]: https://www.youtube.com/watch?v=X-nCHcZ6vQU
 
 The section contains key=value lines like
 


### PR DESCRIPTION
The videos from the Uptime conference were sadly all removed it seems. Luckily I gave this talk at another conference too where it was recorded.

Fixes #1270
Related to #1276
