### PR TITLE
Revert "Enable "pam" authentication support via HBA (#326)"

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -470,7 +470,7 @@ hba
 pam
 :   PAM is used to authenticate users, `auth_file` is ignored. This method is not
     compatible with databases using the `auth_user` option. The service name reported to
-    PAM is "pgbouncer".
+    PAM is "pgbouncer". `pam` is not supported in the HBA configuration file.
 
 ### auth_hba_file
 
@@ -1569,7 +1569,7 @@ The file follows the format of the PostgreSQL `pg_hba.conf` file
 * User name field: Supports `all`, `@file`, multiple names.  Not supported: `+groupname`.
 * Address field: Supports `all`, IPv4, IPv6.  Not supported: `samehost`, `samenet`, DNS names, domain prefixes.
 * Auth-method field: Only methods supported by PgBouncer's `auth_type`
-  are supported, plus `peer` and `reject`, but except `any`, which only works globally.
+  are supported, plus `peer` and `reject`, but except `any` and `pam`, which only work globally.
 * User name map (`map=`) parameter is supported when `auth_type` is `cert` or `peer`.
 
 ## Ident map file format

--- a/src/client.c
+++ b/src/client.c
@@ -535,7 +535,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 
 		if (!check_user_connection_count(client))
 			return false;
-	} else if (client->client_auth_type == AUTH_TYPE_PAM) {
+	} else if (cf_auth_type == AUTH_TYPE_PAM) {
 		if (client->db->auth_user_credentials) {
 			slog_error(client, "PAM can't be used together with database authentication");
 			disconnect_client(client, true, "bouncer config error");

--- a/src/hba.c
+++ b/src/hba.c
@@ -755,10 +755,6 @@ static bool parse_line(struct HBA *hba, struct Ident *ident, struct TokParser *t
 		rule->rule_method = AUTH_TYPE_PEER;
 	} else if (eat_kw(tp, "cert")) {
 		rule->rule_method = AUTH_TYPE_CERT;
-#ifdef HAVE_PAM
-	} else if (eat_kw(tp, "pam")) {
-		rule->rule_method = AUTH_TYPE_PAM;
-#endif
 	} else if (eat_kw(tp, "scram-sha-256")) {
 		rule->rule_method = AUTH_TYPE_SCRAM_SHA_256;
 	} else {


### PR DESCRIPTION
This reverts commit f856951fa6d7fc670e74b1dfeb301fcb949c3caf.

As reported in #1261 this broke PAM authentication completely, so I'm
reverting this. I won't be touching PAM code anymore until someone adds
some automated tests.

Fixes #1261
