### PR TITLE
Add /configure~ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /config.status
 /config.sub
 /configure
+/configure~
 /doc/pgbouncer_1.md
 /doc/pgbouncer_5.md
 /install-sh


### PR DESCRIPTION
This PR adds the file /configure~ to .gitignore. Not sure why this file gets created sometimes but it is very easy to miss when adding stuff to a commit.