### PR TITLE
Change PAM queue full debug message to warning

### DIFF
--- a/src/pam.c
+++ b/src/pam.c
@@ -154,7 +154,7 @@ void pam_auth_begin(PgSocket *client, const char *passwd)
 	 * then block until one is available.
 	 */
 	if (next_free_slot == pam_first_taken_slot)
-		slog_debug(client, "PAM queue is full, waiting");
+		slog_warning(client, "PAM queue is full, waiting");
 
 	while (next_free_slot == pam_first_taken_slot) {
 		if (pam_poll() == 0) {


### PR DESCRIPTION
Based on the discussion in #1054

Change "queue full" message in pam_auth_begin() from debug to warning. In current code (with sleep) this can easily become a bottleneck. Displaying the warning will save hours of debugging when users are trying to diagnose pgbouncer unresponsiveness.
