### PR TITLE
SSL verify-full mode is broken with multi-host configuration.

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -693,6 +693,8 @@ struct PgSocket {
 	PgAddr remote_addr;	/* ip:port for remote endpoint */
 	PgAddr local_addr;	/* ip:port for local endpoint */
 
+	char *host;
+
 	union {
 		struct DNSToken *dns_token;	/* ongoing request */
 		PgDatabase *db;			/* cache db while doing auth query */

--- a/src/objects.c
+++ b/src/objects.c
@@ -125,6 +125,7 @@ static void construct_server(void *obj)
 	server->vars.var_list = slab_alloc(var_list_cache);
 	server->state = SV_FREE;
 	server->server_prepared_statements = NULL;
+	server->host = NULL;
 	statlist_init(&server->outstanding_requests, "outstanding_requests");
 
 	server->id = ++last_pgsocket_id;
@@ -210,6 +211,7 @@ static void server_free(PgSocket *server)
 	}
 
 	free_server_prepared_statements(server);
+	free(server->host);
 	varcache_clean(&server->vars);
 	slab_free(var_list_cache, server->vars.var_list);
 	slab_free(server_cache, server);
@@ -1691,6 +1693,8 @@ static void dns_connect(struct PgSocket *server)
 	} else {
 		host = db->host;
 	}
+
+	server->host = xstrdup(host);
 
 	if (!host || host[0] == '/' || host[0] == '@') {
 		const char *unix_dir;

--- a/src/objects.c
+++ b/src/objects.c
@@ -1694,7 +1694,9 @@ static void dns_connect(struct PgSocket *server)
 		host = db->host;
 	}
 
-	server->host = xstrdup(host);
+	if (host) {
+		server->host = xstrdup(host);
+	}
 
 	if (!host || host[0] == '/' || host[0] == '@') {
 		const char *unix_dir;

--- a/src/server.c
+++ b/src/server.c
@@ -731,7 +731,7 @@ static bool handle_sslchar(PgSocket *server, struct MBuf *data)
 
 	if (schar == 'S') {
 		slog_noise(server, "launching tls");
-		ok = sbuf_tls_connect(&server->sbuf, server->pool->db->host);
+		ok = sbuf_tls_connect(&server->sbuf, server->host);
 	} else if (server_connect_sslmode >= SSLMODE_REQUIRE) {
 		disconnect_server(server, false, "server refused SSL");
 		return false;

--- a/test/ssl/test.ini
+++ b/test/ssl/test.ini
@@ -3,6 +3,7 @@ p0 = port=6666 host=localhost dbname=p0 user=bouncer pool_size=2
 p1 = port=6666 host=localhost dbname=p1 user=bouncer
 p7a= port=6666 host=localhost dbname=p7
 pTxnPool = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_mode=transaction
+hostlistsslverify = port=6666 host=localhost,127.0.0.1 dbname=p0 user=bouncer
 
 [pgbouncer]
 logfile = test.log

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -128,6 +128,7 @@ def test_server_ssl_verify(pg, bouncer, cert_dir):
     bouncer.admin(f"set server_tls_ca_file = '{root}'")
     bouncer.test()
 
+    bouncer.psql_test(dbname="hostlistsslverify")
 
 def test_server_ssl_auth(pg, bouncer, cert_dir):
     bouncer.admin("set server_tls_sslmode = 'verify-full'")

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -130,6 +130,7 @@ def test_server_ssl_verify(pg, bouncer, cert_dir):
 
     bouncer.psql_test(dbname="hostlistsslverify")
 
+
 def test_server_ssl_auth(pg, bouncer, cert_dir):
     bouncer.admin("set server_tls_sslmode = 'verify-full'")
     root = cert_dir / "TestCA1" / "ca.crt"


### PR DESCRIPTION
verify-full requires to compare hostname against the server certificate. Looks like we pass the entire multi-host string as the hostname which causes failure with connection establishment.

Fixes #1300 