### PR TITLE
Enable Admin Console Access During Safe Shutdown

### DIFF
--- a/include/pooler.h
+++ b/include/pooler.h
@@ -23,6 +23,7 @@ void suspend_pooler(void);
 void per_loop_pooler_maint(void);
 void pooler_tune_accept(bool on);
 void cleanup_sockets(void);
+void cleanup_sockets_unix(void);
 
 typedef bool (*pooler_cb)(void *arg, int fd, const PgAddr *addr);
 bool for_each_pooler_fd(pooler_cb cb, void *arg);

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -789,6 +789,7 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 	if (cf_shutdown == SHUTDOWN_WAIT_FOR_SERVERS && get_active_server_count() == 0) {
 		log_info("server connections dropped, exiting");
 		cf_shutdown = SHUTDOWN_IMMEDIATE;
+		cleanup_sockets_unix();
 		event_base_loopbreak(pgb_event_base);
 		return;
 	}
@@ -796,6 +797,7 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 	if (cf_shutdown == SHUTDOWN_WAIT_FOR_CLIENTS && get_active_client_count() == 0) {
 		log_info("client connections dropped, exiting");
 		cf_shutdown = SHUTDOWN_IMMEDIATE;
+		cleanup_sockets_unix();
 		event_base_loopbreak(pgb_event_base);
 		return;
 	}

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -35,6 +35,7 @@ struct ListenSocket {
 };
 
 static STATLIST(sock_list);
+static STATLIST(sock_list_shutdown);
 
 /* hints for getaddrinfo(listen_addr) */
 static const struct addrinfo hints = {
@@ -69,6 +70,29 @@ void cleanup_sockets(void)
 
 	while ((el = statlist_pop(&sock_list)) != NULL) {
 		ls = container_of(el, struct ListenSocket, node);
+		if (pga_is_unix(&ls->addr) && cf_unix_socket_dir[0] != '@') {
+			statlist_append(&sock_list_shutdown, &ls->node);
+			// statlist_remove(&sock_list, &ls->node);
+			continue;
+		}
+		if (event_del(&ls->ev) < 0) {
+			log_warning("cleanup_sockets, event_del: %s", strerror(errno));
+		}
+		if (ls->fd > 0) {
+			safe_close(ls->fd);
+			ls->fd = 0;
+		}
+		statlist_remove(&sock_list, &ls->node);
+		free(ls);
+	}
+}
+
+void cleanup_sockets_unix(void)
+{
+	struct ListenSocket *ls;
+	struct List *el;
+	while ((el = statlist_pop(&sock_list_shutdown)) != NULL) {
+		ls = container_of(el, struct ListenSocket, node);
 		if (event_del(&ls->ev) < 0) {
 			log_warning("cleanup_sockets, event_del: %s", strerror(errno));
 		}
@@ -80,8 +104,9 @@ void cleanup_sockets(void)
 			char buf[sizeof(struct sockaddr_un) + 20];
 			snprintf(buf, sizeof(buf), "%s/.s.PGSQL.%d", cf_unix_socket_dir, cf_listen_port);
 			unlink(buf);
+			statlist_remove(&sock_list_shutdown, &ls->node);
 		}
-		statlist_remove(&sock_list, &ls->node);
+		statlist_remove(&sock_list_shutdown, &ls->node);
 		free(ls);
 	}
 }
@@ -575,6 +600,12 @@ bool for_each_pooler_fd(pooler_cb cbfunc, void *arg)
 	bool ok;
 
 	statlist_for_each(el, &sock_list) {
+		ls = container_of(el, struct ListenSocket, node);
+		ok = cbfunc(arg, ls->fd, &ls->addr);
+		if (!ok)
+			return false;
+	}
+	statlist_for_each(el, &sock_list_shutdown) {
 		ls = container_of(el, struct ListenSocket, node);
 		ok = cbfunc(arg, ls->fd, &ls->addr);
 		if (!ok)


### PR DESCRIPTION
In it's current implementation, during safe shutdowns there is no way to access the admin console. This is problematic if you want to log in, see who is on, alert tenants to restart their apps, etc. Currently the only way to gain visibility about who is connected to your app is via `lsof` and other cli tools but even here you lose visibility as to what database they are connected to, what user, etc.

This PR attempts to provide a way for admin users to continue to access the admin console by keeping the Unix Socket open during the safe shutdown period.

Another approach to accomplish this goal would be to create separate sockets/ports that only admins users can log in through. Happy to consider this as an alternate approach is the method currently implemented does not work.