### PR TITLE
Fix tests for new psycopg version

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -341,12 +341,10 @@ class QueryRunner:
         """
         with self.cur(**kwargs) as cur:
             cur.execute(query, params=params)
-            try:
-                return cur.fetchall()
-            except psycopg.ProgrammingError as e:
-                if "the last operation didn't produce a result" == str(e):
-                    return None
-                raise
+            if cur.pgresult and cur.pgresult.status == psycopg.pq.ExecStatus.COMMAND_OK:
+                return None
+
+            return cur.fetchall()
 
     def sql_value(self, query, params=None, **kwargs):
         """Run an SQL query that returns a single cell and return this value
@@ -373,12 +371,10 @@ class QueryRunner:
     ) -> typing.Optional[typing.List[typing.Any]]:
         async with self.acur(**kwargs) as cur:
             await cur.execute(query, params=params)
-            try:
-                return await cur.fetchall()
-            except psycopg.ProgrammingError as e:
-                if "the last operation didn't produce a result" == str(e):
-                    return None
-                raise
+            if cur.pgresult and cur.pgresult.status == psycopg.pq.ExecStatus.COMMAND_OK:
+                return None
+
+            return await cur.fetchall()
 
     def psql(self, query, **kwargs):
         """Run an SQL query using psql instead of psycopg


### PR DESCRIPTION
All tests started failing due to a change in error message in psycopg.
This stops relying on the text of that error message and instead makes
sure the error isn't thrown in the first place.

Closes #1315
