### PR TITLE
Teach KILL command to take an optional db argument

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -797,9 +797,10 @@ recommended instead.  To close server connections without waiting (for
 example, in emergency failover rather than gradual switchover
 scenarios), also consider **KILL**.
 
-#### KILL db
+#### KILL [db]
 
-Immediately drop all client and server connections on given database.
+Immediately drop all client and server connections on the given database or all
+databases, excluding the admin database.
 
 New client connections to a killed database will wait until **RESUME**
 is called.

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -287,6 +287,28 @@ def test_kill_db_nonexisting(bouncer: "Bouncer"):
     conn_1.close()
 
 
+def test_kill_all(bouncer: "Bouncer"):
+    # Connect to client as user A to first database
+    conn_1 = bouncer.conn(dbname="p0", user="maxedout")
+
+    # Connect to client as user B to second database
+    conn_2 = bouncer.conn(dbname="p1", user="maxedout")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
+    assert len(clients) == 3
+
+    # Issue kill command
+    bouncer.admin("KILL")
+
+    # Validate count
+    clients = bouncer.admin("SHOW CLIENTS")
+    assert len(clients) == 1
+
+    conn_1.close()
+    conn_2.close()
+
+
 def test_kill_client_nonexisting(bouncer):
     # Connect to client as user A
     conn_1 = bouncer.conn(dbname="p0", user="maxedout")


### PR DESCRIPTION
Allows KILL to operate on all databases similar to RECONNECT.