### PR TITLE
Handle test flakiness in test_servers_disconnect_when_changing_tls_config

### DIFF
--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -4,7 +4,15 @@ import time
 import psycopg
 import pytest
 
-from .utils import MACOS, PG_MAJOR_VERSION, TEST_DIR, TLS_SUPPORT, WINDOWS, Bouncer
+from .utils import (
+    MACOS,
+    PG_MAJOR_VERSION,
+    TEST_DIR,
+    TLS_SUPPORT,
+    WINDOWS,
+    Bouncer,
+    wait_until,
+)
 
 if not TLS_SUPPORT:
     pytest.skip(allow_module_level=True)
@@ -403,8 +411,9 @@ def test_servers_disconnect_when_changing_tls_config(bouncer, pg, cert_dir):
             r"pTxnPool.*database configuration changed|pTxnPool.*obsolete connection", 1
         ):
             bouncer.admin("RELOAD")
-            time.sleep(0.5)
-            assert pg.connection_count(dbname="p0") == 0
+            for _ in wait_until("Did not close connection"):
+                if pg.connection_count(dbname="p0") == 0:
+                    break
             cur.execute("SELECT 1")
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -132,6 +132,24 @@ def capture(command, *args, stdout=subprocess.PIPE, encoding="utf-8", **kwargs):
     return run(command, *args, stdout=stdout, encoding=encoding, **kwargs).stdout
 
 
+def wait_until(error_message="Did not complete", timeout=5, interval=0.1):
+    """
+    Loop until the timeout is reached. If the timeout is reached, raise an
+    exception with the given error message.
+    """
+    start = time.time()
+    end = start + timeout
+    last_printed_progress = start
+    while time.time() < end:
+        if timeout > 5 and time.time() - last_printed_progress > 5:
+            last_printed_progress = time.time()
+            print(f"{error_message} in {time.time() - start} seconds - will retry")
+        yield
+        time.sleep(interval)
+
+    raise TimeoutError(error_message + " in time")
+
+
 def get_pg_major_version():
     full_version_string = capture("initdb --version", silent=True)
     major_version_string = re.search("[0-9]+", full_version_string)


### PR DESCRIPTION
The problem in the test that's solved here as an example was that half a
second wasn't always enough for PgBouncer to close the connection as
expected. This adds a wait_until method, to allow for easy polling until
the required condition is true.

This does a similar fix to #1320, but by introducing this new method
similar test failures can be fixed with a lot less code.

Reported in #1283
Closes #1320
