### PR TITLE
Fix inaccurate display of pool_size in SHOW USERS issue #1323

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -603,8 +603,6 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	struct List *item;
 	PktBuf *buf = pktbuf_dynamic(256);
 	struct CfValue cv;
-	char pool_size_str[12] = "";
-	char res_pool_size_str[12] = "";
 	const char *pool_mode_str;
 
 	if (!buf) {
@@ -618,6 +616,8 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		"max_user_client_connections", "current_client_connections");
 	statlist_for_each(item, &user_list) {
 		PgGlobalUser *user = container_of(item, PgGlobalUser, head);
+		char pool_size_str[12] = "";
+		char res_pool_size_str[12] = "";
 		if (user->pool_size >= 0)
 			snprintf(pool_size_str, sizeof(pool_size_str), "%9d", user->pool_size);
 		if (user->res_pool_size >= 0)

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -39,6 +39,34 @@ def test_reload_error(bouncer):
         ):
             bouncer.admin("RELOAD")
 
+def test_show_user(bouncer):
+    """
+    Test that admin console correctly raises error during RELOAD
+    when invalid value set for auth_type.
+    """
+    config = f"""
+    [databases]
+    p1 = host={bouncer.pg.host} port={bouncer.pg.port}
+ 
+    [pgbouncer]
+    auth_file = {bouncer.auth_path}
+    auth_type = trust
+    auth_user = postgres
+    listen_addr = {bouncer.host}
+    listen_port = {bouncer.port}
+    admin_users = pgbouncer
+    pool_mode = session
+ 
+    [users]
+    test1 = pool_size=1 reserve_pool_size=1
+    test2 =
+    """
+
+    with bouncer.run_with_config(config):
+        users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
+        users = [user for user in users if user["name"] in ["test1", "test2"]]
+        assert [1, None] == [int(user["pool_size"].strip()) for user in users]
+        assert [1, None] == [int(user["res_pool_size"].strip()) for user in users]
 
 def test_show(bouncer):
     show_items = [


### PR DESCRIPTION
Resolve [issue  #1323](https://github.com/pgbouncer/pgbouncer/issues/1323)
Declare pool_size_str and res_pool_size_str inside the loop to reset them per iteration.
These changes fix a bug with pool_size display in SHOW_USERS; for users who do not have a pool_size limit.
```
pgbouncer=# SHOW USERS;
   name    | pool_size | reserve_pool_size | pool_mode | max_user_connections | current_connections | max_user_client_connections | current_client_connections 
-----------+-----------+-------------------+-----------+----------------------+---------------------+-----------------------------+----------------------------
 pgbouncer |           |                   |           |                    0 |                   0 |                           0 |                          0
 postgres  |           |                   |           |                    0 |                   1 |                           0 |                          1
 test1     |         1 |                   |           |                    0 |                   2 |                           0 |                          8
 test2     |           |                   |           |                    0 |                   7 |                           0 |                          7
(4 rows)
```

before 
```
pgbouncer=# SHOW USERS;
   name    | pool_size | reserve_pool_size | pool_mode | max_user_connections | current_connections | max_user_client_connections | current_client_connections 
-----------+-----------+-------------------+-----------+----------------------+---------------------+-----------------------------+----------------------------
 pgbouncer |           |                   |           |                    0 |                   0 |                           0 |                          0
 postgres  |           |                   |           |                    0 |                   4 |                           0 |                          1
 test1     |         1 |                   |           |                    0 |                   2 |                           0 |                          8
 test2     |         1 |                   |           |                    0 |                   4 |                           0 |                          0
 test3     |         1 |                   |           |                    0 |                   4 |                           0 |                          4
 zabbix    |         1 |                   |           |                    0 |                   0 |                           0 |                          1
(6 rows)
```