### PR TITLE
Whitespace checks and fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -262,7 +262,7 @@ task:
     image: ubuntu:22.04
   setup_script:
     - apt-get update
-    - apt-get install -y python3 python3-pip cmake curl
+    - apt-get install -y python3 python3-pip cmake curl git
     - pip install -r dev_requirements.txt
   build_script:
     - touch config.mak # Fake that configure has run

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ format-check: uncrustify
 	git diff-tree --check `git hash-object -t tree /dev/null` HEAD
 	black --check --diff .
 	isort --check --diff .
-	./uncrustify -c uncrustify.cfg --check include/*.h src/*.c -L WARN
+	./uncrustify -c uncrustify.cfg --check include/*.h src/*.c test/*.c -L WARN
 
 format: uncrustify
 	$(MAKE) format-c
@@ -210,7 +210,7 @@ format-python: uncrustify
 	isort .
 
 format-c: uncrustify
-	./uncrustify -c uncrustify.cfg --replace --no-backup include/*.h src/*.c -L WARN
+	./uncrustify -c uncrustify.cfg --replace --no-backup include/*.h src/*.c test/*.c -L WARN
 
 UNCRUSTIFY_VERSION=0.77.1
 

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ lint:
 	flake8
 
 format-check: uncrustify
+	git diff-tree --check `git hash-object -t tree /dev/null` HEAD
 	black --check --diff .
 	isort --check --diff .
 	./uncrustify -c uncrustify.cfg --check include/*.h src/*.c -L WARN

--- a/doc/config.md
+++ b/doc/config.md
@@ -481,14 +481,15 @@ Otherwise, you can set `auth_type` directly to `ldap`. If `auth_type` is set to 
 `auth_ldap_parameter` has also to be set.
 
 ### auth_ldap_parameter
-This value is the global ldap parameter if `auth_type` is set to `ldap`. The value would be 
-similar to the ldap line in pg_hba.conf. If no `auth_ldap_parameter` is set, then ldap 
-authentication will fail. However, the value only contains the parameter after the 'ldap' 
+
+This value is the global ldap parameter if `auth_type` is set to `ldap`. The value would be
+similar to the ldap line in pg_hba.conf. If no `auth_ldap_parameter` is set, then ldap
+authentication will fail. However, the value only contains the parameter after the 'ldap'
 keyword in the hba line. For example, if the hba line looks like this:
 ```conf
-host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`. 
+host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`.
 ```
-The corresponding value of `auth_ldap_parameter` would be 
+The corresponding value of `auth_ldap_parameter` would be
 `ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
 
 ### auth_hba_file

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -133,7 +133,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ; auth_ident_file =
 
 ;; Parameter ldap authentication would use when "auth_type = ldap"
-; auth_ldap_parameter = 
+; auth_ldap_parameter =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -13,7 +13,6 @@
 
 #include <usual/logging.h>
 #include <usual/getopt.h>
-#include <usual/logging.h>
 #include <usual/list.h>
 #include <usual/statlist.h>
 #include <usual/time.h>
@@ -28,14 +27,14 @@ static char *simple_query = "select 1";
 static struct event_base *evbase;
 
 typedef struct DbConn {
-	struct List	head;
-	const char	*connstr;
-	struct event	ev;
-	PGconn		*con;
-	bool		logged_in;
+	struct List head;
+	const char *connstr;
+	struct event ev;
+	PGconn *con;
+	bool logged_in;
 
 	/* time_t		connect_time; */
-	int	query_count;
+	int query_count;
 	/* const char	*query; */
 	int _arglen;
 } DbConn;
@@ -50,7 +49,7 @@ static uint64_t SqlErrorCount = 0;
 static uint64_t QueryCount = 0;
 
 static char *bulk_data;
-static int bulk_data_max = 128*1024;  /* power of 2 */
+static int bulk_data_max = 128*1024;	/* power of 2 */
 static int verbose = 0;
 static int throttle_connects = 0;
 static int throttle_queries = 0;
@@ -169,7 +168,7 @@ static bool another_result(DbConn *db)
 				       db->_arglen, curlen);
 			}
 		}
-		/* fallthrough */
+	/* fallthrough */
 	case PGRES_COMMAND_OK:
 		PQclear(res);
 		break;
@@ -221,8 +220,9 @@ static void send_cb(int sock, short flags, void *arg)
 		wait_event(db, EV_WRITE, send_cb);
 	} else if (res == 0) {
 		wait_event(db, EV_READ, result_cb);
-	} else
+	} else {
 		conn_error(db, "PQflush");
+	}
 }
 
 static int send_query_bigdata(DbConn *db)
@@ -284,8 +284,9 @@ static void send_query(DbConn *db)
 		wait_event(db, EV_WRITE, send_cb);
 	} else if (res == 0) {
 		wait_event(db, EV_READ, result_cb);
-	} else
+	} else {
 		conn_error(db, "PQflush");
+	}
 }
 
 static void connect_cb(int sock, short flags, void *arg)
@@ -426,19 +427,19 @@ static void run_stats(int fd, short ev, void *arg)
 }
 
 static const char usage_str [] =
-"usage: asynctest [-d connstr][-n numconn][-s seed][-t <types>][-C maxconn][-Q maxquery][-q perconnq]\n"
-"  -d connstr		libpq connect string\n"
-"  -n num		number of connections\n"
-"  -s seed		random number seed\n"
-"  -t type of queries	query type, see below\n"
-"  -C maxcps		max number of connects per sec\n"
-"  -Q maxqps		max number of queries per sec\n"
-"  -q num		queries per connection (default 1)\n"
-"  -S sql		set simple query\n"
-"accepted query types:\n"
-"  B - bigdata\n"
-"  S - sleep occasionally\n"
-"  1 - simple 'select 1'\n";
+	"usage: asynctest [-d connstr][-n numconn][-s seed][-t <types>][-C maxconn][-Q maxquery][-q perconnq]\n"
+	"  -d connstr		libpq connect string\n"
+	"  -n num		number of connections\n"
+	"  -s seed		random number seed\n"
+	"  -t type of queries	query type, see below\n"
+	"  -C maxcps		max number of connects per sec\n"
+	"  -Q maxqps		max number of queries per sec\n"
+	"  -q num		queries per connection (default 1)\n"
+	"  -S sql		set simple query\n"
+	"accepted query types:\n"
+	"  B - bigdata\n"
+	"  S - sleep occasionally\n"
+	"  1 - simple 'select 1'\n";
 
 int main(int argc, char *argv[])
 {
@@ -495,7 +496,7 @@ int main(int argc, char *argv[])
 	}
 
 #ifdef WIN32
-	wsresult = WSAStartup(MAKEWORD(2,0),&wsaData);
+	wsresult = WSAStartup(MAKEWORD(2, 0), &wsaData);
 	if (wsresult != 0)
 		fatal("cannot start the network subsystem: -%d", wsresult);
 #endif

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -63,7 +63,7 @@ static char *get_token(char **ln_p)
 
 static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 {
-	const char *addr=NULL, *user=NULL, *db=NULL, *modifier=NULL, *exp=NULL;
+	const char *addr = NULL, *user = NULL, *db = NULL, *modifier = NULL, *exp = NULL;
 	PgAddr pgaddr;
 	struct HBARule *rule;
 	int res = 0;
@@ -78,7 +78,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	addr = get_token(&ln);
 	modifier = get_token(&ln);
 	tls = strcmpeq(modifier, "tls");
-	replication = strcmpeq(modifier, "replication") ?  REPLICATION_PHYSICAL : REPLICATION_NONE;
+	replication = strcmpeq(modifier, "replication") ? REPLICATION_PHYSICAL : REPLICATION_NONE;
 	if (!exp)
 		return 0;
 	if (!db || !user)
@@ -102,7 +102,7 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 			res = 0;
 		} else {
 			log_warning("FAIL on line %d: expected '%s' got '%s' - user=%s db=%s addr=%s",
-			    linenr, exp, method2string(rule->rule_method), user, db, addr);
+				    linenr, exp, method2string(rule->rule_method), user, db, addr);
 			res = 1;
 		}
 	}
@@ -132,8 +132,8 @@ static void hba_test(void)
 		len = getline(&ln, &lnbuf, f);
 		if (len < 0)
 			break;
-		if (len && ln[len-1] == '\n')
-			ln[len-1] = 0;
+		if (len && ln[len - 1] == '\n')
+			ln[len - 1] = 0;
 		nfailed += hba_test_eval(hba, ln, linenr);
 	}
 	free(ln);

--- a/test/hba_test.c
+++ b/test/hba_test.c
@@ -90,14 +90,13 @@ static int hba_test_eval(struct HBA *hba, char *ln, int linenr)
 	rule = hba_eval(hba, &pgaddr, !!tls, replication, db, user);
 
 	if (!rule) {
-	       if (strcmp("reject", exp) == 0) {
-		       	res = 0;
-	       } else {
+		if (strcmp("reject", exp) == 0) {
+			res = 0;
+		} else {
 			log_warning("FAIL on line %d: No rule for user=%s db=%s addr=%s",
-                            linenr, user, db, addr);
+				    linenr, user, db, addr);
 			res = 1;
-	       }
-
+		}
 	} else {
 		if (strcmp(method2string(rule->rule_method), exp) == 0) {
 			res = 0;

--- a/test/pgbouncer_hba.conf
+++ b/test/pgbouncer_hba.conf
@@ -11,4 +11,3 @@ hostssl p0x             all             0.0.0.0/0               cert    map=test
 hostssl p0              bouncer         0.0.0.0/0               cert
 
 hostssl all             all		192.168.1.1/0		md5
-

--- a/test/pgident.conf
+++ b/test/pgident.conf
@@ -6,4 +6,3 @@ test		pgbouncer.acme.org	someuser
 test		pgbouncer.acme.org	anotheruser
 test2		"bouncer"		all
 test2		pgbouncer.acme.org	"anotheruser"
-


### PR DESCRIPTION
I noticed some files weren't following the .gitattributes whitespace rules, so I fixed those and also added an automatic check for it. (One possible problem is that this check only works in a git checkout. Do we need to support other cases?)

Also, some of that would have been caught by the uncrustify check, but that wasn't run on some files, so I added that as well.
