### PR TITLE
Cache adhoc scram secrets

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -20,6 +20,7 @@
  * core structures
  */
 
+#include "common/scram-common.h"
 #include "system.h"
 
 #include <usual/cfparser.h>
@@ -516,6 +517,12 @@ struct PgCredentials {
 	 * settings and connection count tracking.
 	 */
 	PgGlobalUser *global_user;
+
+	int iterations;
+	char *salt;	/* base64-encoded */
+	uint8_t StoredKey[SCRAM_KEY_LEN];
+	uint8_t ServerKey[SCRAM_KEY_LEN];
+	bool adhoc_scram_secrets_cached;
 };
 
 /*

--- a/include/scram.h
+++ b/include/scram.h
@@ -65,7 +65,7 @@ bool read_client_final_message(PgSocket *client, const uint8_t *raw_input, char 
 			       char **proof_p);
 
 char *build_server_first_message(ScramState *scram_state,
-				 const char *username, const char *stored_secret);
+				 PgCredentials *user, const char *stored_secret);
 
 char *build_server_final_message(ScramState *scram_state);
 

--- a/src/client.c
+++ b/src/client.c
@@ -1127,7 +1127,7 @@ static bool scram_client_first(PgSocket *client, uint32_t datalen, const uint8_t
 		}
 	}
 
-	if (!build_server_first_message(&client->scram_state, user->name, user->mock_auth ? NULL : user->passwd))
+	if (!build_server_first_message(&client->scram_state, user, user->mock_auth ? NULL : user->passwd))
 		goto failed;
 	slog_debug(client, "SCRAM server-first-message = \"%s\"", client->scram_state.server_first_message);
 

--- a/src/scram.c
+++ b/src/scram.c
@@ -841,7 +841,7 @@ failed:
 	return false;
 }
 
-char *build_server_first_message(ScramState *scram_state, const char *username, const char *stored_secret)
+char *build_server_first_message(ScramState *scram_state, PgCredentials *user, const char *stored_secret)
 {
 	uint8_t raw_nonce[SCRAM_RAW_NONCE_LEN + 1];
 	int encoded_len;
@@ -849,7 +849,7 @@ char *build_server_first_message(ScramState *scram_state, const char *username, 
 	char *result;
 
 	if (!stored_secret) {
-		if (!build_mock_scram_secret(username, scram_state))
+		if (!build_mock_scram_secret(user->name, scram_state))
 			goto failed;
 	} else {
 		switch (get_password_type(stored_secret)) {
@@ -862,8 +862,21 @@ char *build_server_first_message(ScramState *scram_state, const char *username, 
 				goto failed;
 			break;
 		case PASSWORD_TYPE_PLAINTEXT:
-			if (!build_adhoc_scram_secret(stored_secret, scram_state))
-				goto failed;
+			if (user->adhoc_scram_secrets_cached) {
+				scram_state->iterations = user->iterations;
+				scram_state->salt = strdup(user->salt);
+				memcpy(scram_state->StoredKey, user->StoredKey, sizeof(user->StoredKey));
+				memcpy(scram_state->ServerKey, user->ServerKey, sizeof(user->ServerKey));
+			} else {
+				if (!build_adhoc_scram_secret(stored_secret, scram_state))
+					goto failed;
+
+				user->iterations = scram_state->iterations;
+				user->salt = strdup(scram_state->salt);
+				memcpy(user->StoredKey, scram_state->StoredKey, sizeof(scram_state->StoredKey));
+				memcpy(user->ServerKey, scram_state->ServerKey, sizeof(scram_state->ServerKey));
+				user->adhoc_scram_secrets_cached = true;
+			}
 			break;
 		default:
 			/* shouldn't get here */


### PR DESCRIPTION
This PR aims to cache adhoc scram secrets generated from build_adhoc_scram_secret() for cached users. We can have performance improvements by avoid recalculating the scram secrets every time that a cached user open a new connection.

Fixes #1335 

----
This PR is in early draft state, I've noted the following issues using the current approach:

- The PgCredentials struct already have the fields scram_ClientKey[32], scram_ServerKey[32], and  has_scram_keys which is currently used for [SCRAM pass-through ](https://github.com/pgbouncer/pgbouncer/commit/ba1abfe4d94c155a8db22d0b40d513b047c9bf06), so I don't think that we should just set the keys and has_scram_keys to true because we may trigger some code parts that works just for scram pass-through? Maybe another option would be to just include the adhoc_scram_secrets_cached and salt fields and reuse the scram_ClientKey and scram_ServerKey?
- We need to cache the scram_state->salt on PgCrendentials, but since it is a char * and I'm caching using user->salt = strdup(scram_state->salt), the VALGRIND is reporting a memory leak. I think that this is happening because we use the slab API to release the PgCrendential cache entry which just free the pointer and not the chield pointer (in this case the char *salt). Is this correct?

----

I've benchmark the changes using pgbench:
```
==========================> Master

[I] ~/d/pgbouncer  (cache-scram-256-state) ❯❯❯ PGPASSWORD=admin pgbench -h localhost -p 6432 -d postgres -c 1 -j 1 -T 60 -n --connect
pgbench (17.4 (Homebrew), server 18beta1)
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: simple
number of clients: 1
number of threads: 1
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 9347
number of failed transactions: 0 (0.000%)
latency average = 6.420 ms
average connection time = 5.138 ms
tps = 155.763798 (including reconnection times)

[N] ~/d/pgbouncer  ((ed7ecfb9)) ❯❯❯ PGPASSWORD=admin pgbench -h localhost -p 6432 -d postgres -c 2 -j 2 -T 60 -n --connect
pgbench (17.4 (Homebrew), server 18beta1)
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: simple
number of clients: 2
number of threads: 2
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 13806
number of failed transactions: 0 (0.000%)
latency average = 8.693 ms
average connection time = 6.161 ms
tps = 230.070256 (including reconnection times)

==========================> Patch

[I] ~/d/pgbouncer  (cache-scram-256-state) ❯❯❯ PGPASSWORD=admin pgbench -h localhost -p 6432 -d postgres -c 1 -j 1 -T 60 -n --connect
pgbench (17.4 (Homebrew), server 18beta1)
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: simple
number of clients: 1
number of threads: 1
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 12798
number of failed transactions: 0 (0.000%)
latency average = 4.689 ms
average connection time = 3.317 ms
tps = 213.273682 (including reconnection times)


[I] ~/d/pgbouncer  ((ed7ecfb9)) ❯❯❯ PGPASSWORD=admin pgbench -h localhost -p 6432 -d postgres -c 2 -j 2 -T 60 -n --connect
pgbench (17.4 (Homebrew), server 18beta1)
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 1
query mode: simple
number of clients: 2
number of threads: 2
maximum number of tries: 1
duration: 60 s
number of transactions actually processed: 24770
number of failed transactions: 0 (0.000%)
latency average = 4.845 ms
average connection time = 3.490 ms
tps = 412.782169 (including reconnection times)


```