### PR TITLE
Make SCRAM Iterations Runtime Configurable

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -426,6 +426,11 @@ the error go away.
 
 Default: 200
 
+### scram_iterations
+
+The number of computational iterations to be performed when encrypting a password using SCRAM-SHA-256. A higher number of iterations provides additional protection against brute-force attacks on stored passwords, but makes authentication slower.
+
+Default: 4096
 
 ## Authentication settings
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -166,6 +166,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; disables support of prepared statements).
 ;max_prepared_statements = 0
 
+;; The number of computational iterations to be performed when
+;; encrypting a password using SCRAM-SHA-256.
+;scram_iterations = 4096
+
 ;; Query for cleaning connection immediately after releasing from
 ;; client.  No need to put ROLLBACK here, pgbouncer does not reuse
 ;; connections where transaction is left open.

--- a/include/common/scram-common.h
+++ b/include/common/scram-common.h
@@ -45,7 +45,7 @@
  * Default number of iterations when generating secret.  Should be at least
  * 4096 per RFC 7677.
  */
-#define SCRAM_DEFAULT_ITERATIONS	4096
+#define SCRAM_DEFAULT_ITERATIONS	256
 
 /*
  * Context data for HMAC used in SCRAM authentication.

--- a/include/common/scram-common.h
+++ b/include/common/scram-common.h
@@ -41,11 +41,8 @@
  */
 #define SCRAM_DEFAULT_SALT_LEN		16
 
-/*
- * Default number of iterations when generating secret.  Should be at least
- * 4096 per RFC 7677.
- */
-#define SCRAM_DEFAULT_ITERATIONS	256
+
+extern int cf_scram_iterations;
 
 /*
  * Context data for HMAC used in SCRAM authentication.

--- a/include/scram.h
+++ b/include/scram.h
@@ -22,6 +22,8 @@
 
 #include <usual/crypto/sha256.h>
 
+extern int cf_scram_iterations;
+
 void free_scram_state(ScramState *scram_state);
 
 typedef enum PasswordType {

--- a/src/common/scram-common.c
+++ b/src/common/scram-common.c
@@ -208,7 +208,7 @@ scram_build_secret(const char *salt, int saltlen, int iterations,
 	int			encoded_result;
 
 	if (iterations <= 0)
-		iterations = SCRAM_DEFAULT_ITERATIONS;
+		iterations = cf_scram_iterations;
 
 	/* Calculate StoredKey and ServerKey */
 	scram_SaltedPassword(password, salt, saltlen, iterations,

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,12 @@
 #include <sys/resource.h>
 #endif
 
+/*
+ * Default number of iterations when generating secret.  Should be at least
+ * 4096 per RFC 7677.
+ */
+#define SCRAM_DEFAULT_ITERATIONS	"4096"
+
 static void usage(const char *exe)
 {
 	printf("%s is a connection pooler for PostgreSQL.\n\n", exe);
@@ -198,6 +204,8 @@ char *cf_server_tls_ciphers;
 
 int cf_max_prepared_statements;
 
+int cf_scram_iterations;
+
 /*
  * config file description
  */
@@ -293,6 +301,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("max_db_client_connections", CF_INT, cf_max_db_client_connections, 0, "0"),
 	CF_ABS("max_packet_size", CF_UINT, cf_max_packet_size, 0, "2147483647"),
 	CF_ABS("max_prepared_statements", CF_INT, cf_max_prepared_statements, 0, "200"),
+	CF_ABS("scram_iterations", CF_INT, cf_scram_iterations, 0, SCRAM_DEFAULT_ITERATIONS),
 	CF_ABS("max_user_connections", CF_INT, cf_max_user_connections, 0, "0"),
 	CF_ABS("max_user_client_connections", CF_INT, cf_max_user_client_connections, 0, "0"),
 	CF_ABS("min_pool_size", CF_INT, cf_min_pool_size, 0, "0"),

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@
  * Default number of iterations when generating secret.  Should be at least
  * 4096 per RFC 7677.
  */
-#define SCRAM_DEFAULT_ITERATIONS	"4096"
+#define SCRAM_DEFAULT_ITERATIONS        "4096"
 
 static void usage(const char *exe)
 {

--- a/src/scram.c
+++ b/src/scram.c
@@ -760,7 +760,7 @@ static bool build_adhoc_scram_secret(const char *plain_password, ScramState *scr
 
 	scram_state->adhoc = true;
 
-	scram_state->iterations = SCRAM_DEFAULT_ITERATIONS;
+	scram_state->iterations = cf_scram_iterations;
 
 	encoded_len = pg_b64_enc_len(sizeof(saltbuf));
 	scram_state->salt = malloc(encoded_len + 1);
@@ -824,7 +824,7 @@ static bool build_mock_scram_secret(const char *username, ScramState *scram_stat
 	uint8_t saltbuf[SCRAM_DEFAULT_SALT_LEN];
 	int encoded_len;
 
-	scram_state->iterations = SCRAM_DEFAULT_ITERATIONS;
+	scram_state->iterations = cf_scram_iterations;
 
 	scram_mock_salt(username, saltbuf);
 	encoded_len = pg_b64_enc_len(sizeof(saltbuf));


### PR DESCRIPTION
This PR makes the number of scram iterations that are used to generate SCRAM keys configurable. This is an attempt to partially resolve #1335 by allowing people to use a lower iteration count to reduce the amount of computation that is needed for PgBouncer to process a client authentication request.