### PR TITLE
make dist uses git archive

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,7 @@ task:
     - curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main $PGVERSION" | tee /etc/apt/sources.list.d/pgdg.list
     - apt-get update
-    - pkgs="autoconf automake ca-certificates cpio iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv slapd socat sudo"
+    - pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv slapd socat sudo"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
@@ -79,13 +79,11 @@ task:
   install_script:
     - make -j4 install
   dist_script:
-    - make -j4 dist
+    - su user -c "make dist"
     - PACKAGE_VERSION=$(sed -n 's/PACKAGE_VERSION = //p' config.mak)
-    - tar -x -v -f pgbouncer-${PACKAGE_VERSION}.tar.gz
-    - cd pgbouncer-${PACKAGE_VERSION}/
-    - ./configure --prefix=$HOME/install2 --enable-werror --without-cares $configure_args
-    - make -j4
-    - make -j4 install
+    - su user -c "tar -x -v -f pgbouncer-${PACKAGE_VERSION}.tar.gz"
+    - su user -c "cd pgbouncer-${PACKAGE_VERSION}/ && ./configure --prefix=$HOME/install2 --enable-werror --without-cares $configure_args && make -j4"
+    - cd pgbouncer-${PACKAGE_VERSION}/ && make -j4 install
   tarball_artifacts:
     path: "pgbouncer-*.tar.gz"
   always:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,10 +4,6 @@ manpages = pgbouncer.1 pgbouncer.5
 
 dist_man_MANS = $(manpages)
 
-EXTRA_DIST = config.md usage.md Makefile $(manpages) \
-	     frag-config-man.md frag-usage-man.md \
-	     filter.py
-
 CLEANFILES = pgbouncer_1.md pgbouncer_5.md
 
 # make maintainer-clean removes those

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,15 +8,6 @@ USUAL_DIR = ../lib
 SUBLOC = test
 DIST_SUBDIRS = ssl
 
-EXTRA_DIST = conntest.sh ctest6000.ini ctest7000.ini run-conntest.sh \
-	     hba_test.eval hba_test.rules Makefile pgident.conf \
-	     test.ini stress.py userlist.txt pgbouncer_hba.conf start_openldap_server.sh \
-	     __init__.py conftest.py utils.py \
-	     test_admin.py test_auth.py test_cancel.py test_copy.py test_limits.py \
-	     test_load_balance_hosts.py test_misc.py test_no_database.py \
-	     test_no_user.py test_operations.py test_peering.py test_prepared.py \
-	     test_ssl.py test_timeouts.py test_replication.py
-
 
 noinst_PROGRAMS = hba_test
 hba_test_CPPFLAGS = -I../include $(LIBEVENT_CFLAGS)

--- a/test/ssl/Makefile
+++ b/test/ssl/Makefile
@@ -1,5 +1,3 @@
-EXTRA_DIST = lib.sh newca.sh newsite.sh create_certs.sh test.ini Makefile
-
 SUBLOC = test/ssl
 
 include ../../config.mak


### PR DESCRIPTION
This changes `make dist` to directly use `git archive`, rather than the custom shell script it currently runs.

This is to make the creation of the distribution tarball more reliable, as this does not require manual maintenance of various `*_DIST` make variables.  Eventually, it will also make the distribution tarball more directly traceable to the git repository.  For the time being, we still include files produced by `autogen.sh` in the tarball, for ease of use. (This could go away when the meson build system (#1077) is ready.)

The techniques used are the same as in postgres/postgres@619bc23a1a2.

(This required getting rid of git submodules, since `git-archive` does not support submodules.)