### PR TITLE
ci: Re-enable commented out Debian/Ubuntu tasks, with manual trigger

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,8 +6,9 @@ env:
 task:
   name: Linux (Debian/Ubuntu)
   matrix:
-    # - container:
-    #     image: ubuntu:20.04
+    - container:
+        image: ubuntu:22.04
+      trigger_type: manual
     - container:
         image: ubuntu:22.04
       env:
@@ -16,46 +17,43 @@ task:
         image: ubuntu:22.04
       env:
         configure_args: '--without-openssl'
-    # - container:
-    #     image: ubuntu:20.04
-    #   env:
-    #     configure_args: '--disable-evdns'
-    # - container:
-    #     image: ubuntu:20.04
-    #   env:
-    #     CC: clang
-    # - container:
-    #     image: ubuntu:20.04
-    #   env:
-    #     CFLAGS: -fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift
+    - container:
+        image: ubuntu:22.04
+      env:
+        configure_args: '--disable-evdns'
+      trigger_type: manual
+    - container:
+        image: ubuntu:22.04
+      env:
+        CFLAGS: -fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift
+      trigger_type: manual
     - container:
         image: ubuntu:22.04
       env:
         ENABLE_VALGRIND: yes
         CFLAGS: -O0 -g
         PGVERSION: 17
-    # - container:
-    #     image: ubuntu:20.04
-    #   env:
-    #     ENABLE_VALGRIND: yes
-    #     CFLAGS: -O0 -g
-    #     PGVERSION: 9.6
-    # - container:
-    #     image: ubuntu:20.04
-    #   env:
-    #     use_scan_build: yes
-    # - arm_container:
-    #     image: ubuntu:20.04
-    # - container:
-    #     image: ubuntu:22.04
-    # - container:
-    #     image: debian:stable
-    #   env:
-    #     PGVERSION: 13
-    # - container:
-    #     image: debian:oldstable
-    #   env:
-    #     PGVERSION: 11
+    - container:
+        image: ubuntu:22.04
+      env:
+        use_scan_build: yes
+      trigger_type: manual
+    - arm_container:
+        image: ubuntu:22.04
+      trigger_type: manual
+    - container:
+        image: ubuntu:24.04
+      trigger_type: manual
+    - container:
+        image: debian:bookworm
+      env:
+        PGVERSION: 15
+      trigger_type: manual
+    - container:
+        image: debian:bullseye
+      env:
+        PGVERSION: 13
+      trigger_type: manual
   setup_script:
     - apt-get update
     - apt-get -y install curl gnupg lsb-release


### PR DESCRIPTION
Reactivate the Debian/Ubuntu tasks that were commented out in 92b4645, setting them to trigger manually.  This was already done for the other tasks in commit 0738448.  There I wrote, "this does not appear to work for matrix elements inside a task", but this appears to work now (or it worked back then but I didn't do it correctly).

In the re-enabled tasks, raise the Ubuntu version from 20.04 to 22.04, like the change in commit ef611b5, and where it was already 22.04 to now 24.04.

The clang variant is removed.  This is already covered by the FreeBSD task now.

The variant that runs Valgrind against PostgreSQL 9.6 is removed. This was originally meant to handle the non-SCRAM code paths, but those PostgreSQL versions are long obsolete.

Also update the PGVERSIONs of the Debian tasks.  Those were supposed to be the versions that ship with upstream Debian, but in the meantime, the actual "stable" and "oldstable" releases have shifted, so this no longer matched.  To avoid these kinds of silent changes, write out the actual release names instead of "stable" and "oldstable".