### PR TITLE
Fix include order hygiene

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -20,7 +20,6 @@
  * core structures
  */
 
-#include "common/scram-common.h"
 #include "system.h"
 
 #include <usual/cfparser.h>
@@ -518,7 +517,7 @@ struct PgCredentials {
 	/* scram keys used for pass-though and adhoc auth caching */
 	uint8_t scram_ClientKey[32];
 	uint8_t scram_ServerKey[32];
-	uint8_t scram_StoredKey[SCRAM_KEY_LEN];
+	uint8_t scram_StoredKey[32];
 	int scram_Iiterations;
 	char *scram_SaltKey;	/* base64-encoded */
 


### PR DESCRIPTION
Commit 8765458 added another #include before "system.h" in bouncer.h. This is not good, because we need system.h and ultimately config.h to be included before all system header files.

A particular outcome is that the getaddrinfo_a()-based adns not longer compiled, because that requires _GNU_SOURCE to be defined before including system headers.

The #include was added to get SCRAM_KEY_LEN, but as can be seen in nearby field definitions, we already chose to hardcode 32 instead of using the symbol, for this and related reasons.  So do this here, too.