### PR TITLE
Optionally drain connections on client disconnection

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1300,6 +1300,12 @@ Query to be executed after a connection is established, but before
 allowing the connection to be used by any clients. If the query raises errors,
 they are logged but ignored otherwise.
 
+### drain_stale_connections
+
+Instead of disposing of the server connection if an active connection goes away and recreating it, instead try to drain the connection for reuse. Might be useful for highly transactional workloads.
+
+Default: `false`
+
 ### pool_mode
 
 Set the pool mode specific to this database. If not set,

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -156,6 +156,11 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;;; Pooler personality questions
 ;;;
 
+;; Defines the behavior for a server connection if a client connection drops
+;; in the middle of creating a connection. By default the behavior is to recreate the connection.
+;; For highly transactional workloads, attempting to drain the connection for reuse might be appropriate.
+;drain_stale_connections = 0
+
 ;; When server connection is released back to pool:
 ;;   session      - after client disconnects (default)
 ;;   transaction  - after transaction finishes

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -80,7 +80,8 @@ enum SocketState {
 	SV_ACTIVE,		/* pool->active_server_list */
 	SV_ACTIVE_CANCEL,	/* pool->active_cancel_server_list */
 	SV_USED,		/* pool->used_server_list */
-	SV_TESTED		/* pool->tested_server_list */
+	SV_TESTED,		/* pool->tested_server_list */
+	SV_DRAIN
 };
 
 enum PauseMode {
@@ -441,6 +442,13 @@ struct PgPool {
 	 * launch_new_connection spawns them.
 	 */
 	struct StatList new_server_list;
+
+	/* 
+	 * Servers that are in the process of being drained. This is a special
+	 * state that is used when the server connection is being closed due to
+	 * client disconnection and we want to try and reuse the connection.
+	 */
+	struct StatList drain_server_list;
 
 	PgStats stats;
 	PgStats newer_stats;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -780,6 +780,7 @@ extern int cf_listen_port;
 extern int cf_listen_backlog;
 extern int cf_peer_id;
 
+extern int cf_drain_stale_connections;
 extern int cf_pool_mode;
 extern int cf_max_client_conn;
 extern int cf_default_pool_size;

--- a/include/objects.h
+++ b/include/objects.h
@@ -58,6 +58,7 @@ bool finish_client_login(PgSocket *client)      _MUSTCHECK;
 bool check_fast_fail(PgSocket *client)          _MUSTCHECK;
 
 PgSocket *accept_client(int sock, bool is_unix) _MUSTCHECK;
+void drain_server(PgSocket *server, const char *reason, ...) _PRINTF(2, 3);
 void disconnect_server(PgSocket *server, bool notify, const char *reason, ...) _PRINTF(3, 4);
 void disconnect_client(PgSocket *client, bool notify, const char *reason, ...) _PRINTF(3, 4);
 void disconnect_client_sqlstate(PgSocket *client, bool notify, const char *sqlstate, const char *reason);

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -119,6 +119,7 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
 
 bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);
+void sbuf_drain(SBuf *sbuf);
 bool sbuf_close(SBuf *sbuf) _MUSTCHECK;
 
 bool sbuf_flush(SBuf *sbuf) _MUSTCHECK;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -119,7 +119,6 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
 
 bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);
-void sbuf_drain(SBuf *sbuf);
 bool sbuf_close(SBuf *sbuf) _MUSTCHECK;
 
 bool sbuf_flush(SBuf *sbuf) _MUSTCHECK;

--- a/src/main.c
+++ b/src/main.c
@@ -99,6 +99,7 @@ int cf_unix_socket_mode;
 char *cf_unix_socket_group;
 int cf_peer_id;
 
+int cf_drain_stale_connections;
 int cf_pool_mode = POOL_SESSION;
 
 /* sbuf config */
@@ -284,6 +285,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
 	CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
 	CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
+	CF_ABS("drain_stale_connections", CF_INT, cf_drain_stale_connections, 0, "0"),
 	CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 	CF_ABS("transaction_timeout", CF_TIME_USEC, cf_transaction_timeout, 0, "0"),
 	CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1351,7 +1351,7 @@ void drain_server(PgSocket *server, const char *reason, ...) {
 		disconnect_server(server, true, "drain failed to clear outstanding requests");
 		return;
 	}
-	release_server(server);
+	disconnect_server(server, false, "drain server successful");
 }
 
 /*

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -245,23 +245,6 @@ void sbuf_continue(SBuf *sbuf)
 	sbuf_main_loop(sbuf, do_recv);
 }
 
-void sbuf_drain(SBuf *sbuf) {
-	/*
-	 * This is used to drain the socket, so we can close it
-	 * without waiting for the next event loop.
-	 */
-	AssertActive(sbuf);
-	Assert(sbuf->wait_type == W_RECV);
-
-	if (event_del(&sbuf->ev) < 0) {
-		log_warning("event_del: %s", strerror(errno));
-		return;
-	}
-	sbuf->wait_type = W_NONE;
-
-	sbuf_main_loop(sbuf, SKIP_RECV);
-}
-
 /*
  * Resume from pause and give socket over to external
  * callback function.

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -245,6 +245,23 @@ void sbuf_continue(SBuf *sbuf)
 	sbuf_main_loop(sbuf, do_recv);
 }
 
+void sbuf_drain(SBuf *sbuf) {
+	/*
+	 * This is used to drain the socket, so we can close it
+	 * without waiting for the next event loop.
+	 */
+	AssertActive(sbuf);
+	Assert(sbuf->wait_type == W_RECV);
+
+	if (event_del(&sbuf->ev) < 0) {
+		log_warning("event_del: %s", strerror(errno));
+		return;
+	}
+	sbuf->wait_type = W_NONE;
+
+	sbuf_main_loop(sbuf, SKIP_RECV);
+}
+
 /*
  * Resume from pause and give socket over to external
  * callback function.

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -868,6 +868,7 @@ def test_drain_connection(pg, bouncer):
     listen_addr = {bouncer.host}
     auth_type = trust
     admin_users = pgbouncer
+    drain_stale_connections = 1
     auth_file = {bouncer.auth_path}
     listen_port = {bouncer.port}
     logfile = {bouncer.log_path}

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -873,7 +873,7 @@ def test_drain_connection(pg, bouncer):
     listen_port = {bouncer.port}
     logfile = {bouncer.log_path}
     auth_dbname = postgres
-    pool_mode = session
+    pool_mode = transaction
     server_check_delay = 0
     """
     pg.configure(config="log_statement = 'all'")


### PR DESCRIPTION
WIP on https://github.com/pgbouncer/pgbouncer/issues/1312

Ths current comment drains the server sbuf, but has run into three issues:
1. There may be more outstanding requests in which case releasing the server will just kill the connection instead
2. The amount of data to drain might be more than a single round of `sbuf_continue`
3. Even if this works, psycopg2 throws a cannot connect to socket error (which sounds more like a client issue?)

The [commit](https://github.com/pgbouncer/pgbouncer/commit/2bc74ac507cd31d3f56faff9e72fc555cfd296ec) before it clears outstanding requests. It works correctly some of the times - namely it works if the sbuf somehow gets cleared.

A hybrid approach might work, but you'd have to either drain the last request or drain the first request then clear the outstanding requests, or drain the buffer per outstanding request.