### PR TITLE
Fix a scan-build warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -460,7 +460,7 @@ bool load_config(void)
 {
 	static bool loaded = false;
 	bool load_file_ok;
-	bool ok = true;
+	bool ok;
 	const char *q;
 
 	any_user_level_timeout_set = false;
@@ -477,8 +477,8 @@ bool load_config(void)
 		if (requires_auth_file(cf_auth_type))
 			loader_users_check();
 		loaded = true;
+		ok = true;
 	} else if (!loaded) {
-		ok = false;
 		die("cannot load config file");
 	} else {
 		log_warning("config file loading failed");


### PR DESCRIPTION
src/main.c:481:3: warning: Value stored to 'ok' is never read [deadcode.DeadStores]

The fix is trivial, but it also seems generally more robust to set the "ok" variable to true only after the steps have all succeeded, not before.