### PR TITLE
Remove obsolete third field from auth_file entries in mkauth.py

### DIFF
--- a/etc/mkauth.py
+++ b/etc/mkauth.py
@@ -29,7 +29,7 @@ for user, psw in curs.fetchall():
     if not psw:
         psw = ""
     psw = psw.replace('"', '""')
-    lines.append('"%s" "%s" ""\n' % (user, psw))
+    lines.append('"%s" "%s"\n' % (user, psw))
 db.commit()
 cur = "".join(lines)
 


### PR DESCRIPTION
The `mkauth.py` script previously generated auth_file entries with three quoted fields: `"user" "password" ""`.
The third field was a leftover from an old postgresql flat-file format (`pg_pwd`) that included a "valid until" field in addition to the username and password.

This format was originally used to allow pgbouncer to directly read the `pg_pwd` file, maintaining compatibility during a transition period.
However, the `pg_pwd` file has long been removed, and pgbouncer ignores all fields after the second one.

Removing this unused field simplifies the file format, aligns with pgbouncer documentation and common usage, and helps prevent confusion when managing auth_file contents.

Fixes: #1351