### PR TITLE
Fix test warnings

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -179,7 +179,6 @@ def pg(tmp_path_factory, cert_dir):
     pg.cleanup()
 
 
-@pytest.mark.asyncio
 @pytest.fixture
 async def proxy(pg, tmp_path):
     """Starts a new proxy process"""
@@ -192,7 +191,6 @@ async def proxy(pg, tmp_path):
     proxy.cleanup()
 
 
-@pytest.mark.asyncio
 @pytest.fixture
 async def bouncer(pg, tmp_path):
     """Starts a new PgBouncer process"""
@@ -205,7 +203,6 @@ async def bouncer(pg, tmp_path):
     await bouncer.cleanup()
 
 
-@pytest.mark.asyncio
 @pytest.fixture
 async def bouncer_with_openldap(pg, tmp_path, monkeypatch):
     """Starts a new PgBouncer process"""

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -23,7 +23,6 @@ if not TLS_SUPPORT:
 
 
 # replace regular bouncer fixture with one that uses the special SSL config
-@pytest.mark.asyncio
 @pytest.fixture
 async def bouncer_tls(pg, tmp_path):
     bouncer_tls = Bouncer(


### PR DESCRIPTION
```
test/conftest.py:182: 13 warnings
  .../test/conftest.py:182: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    @pytest.mark.asyncio
```

Remove the marks without effect, as suggested by the warning.