### PR TITLE
ci: Add socat installation to Red Hat and Alpine tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,7 +60,7 @@ task:
     - curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     - echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main $PGVERSION" | tee /etc/apt/sources.list.d/pgdg.list
     - apt-get update
-    - pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc postgresql-$PGVERSION pkg-config python3 python3-pip python3-venv slapd socat sudo"
+    - pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
@@ -99,8 +99,7 @@ task:
       - image: rockylinux:9
       - image: rockylinux:8
   setup_script:
-    - yum -y install autoconf automake diffutils file libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib systemd-devel wget
-    - yum -y install python3 python3-pip sudo iptables
+    - yum -y install autoconf automake diffutils file iptables libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip sudo systemd-devel wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - pip3 install -r requirements.txt
@@ -128,7 +127,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake bash build-base libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip wget sudo iptables
+    - apk add autoconf automake bash build-base iptables libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip sudo wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - python3 -m venv /venv

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,7 +99,7 @@ task:
       - image: rockylinux:9
       - image: rockylinux:8
   setup_script:
-    - yum -y install autoconf automake diffutils file iptables libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip sudo systemd-devel wget
+    - yum -y install autoconf automake diffutils file iptables libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - pip3 install -r requirements.txt
@@ -127,7 +127,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake bash build-base iptables libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip sudo wget
+    - apk add autoconf automake bash build-base iptables libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - python3 -m venv /venv


### PR DESCRIPTION
This was forgotten in commit e0d58b5 for the manually triggered tasks. The new tests have been failing in the meantime.