### PR TITLE
Use newer python on RHEL8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,7 +102,8 @@ task:
     - yum -y install autoconf automake diffutils file iptables libevent-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
-    - pip3 install -r requirements.txt
+    - if grep -q -F 'release 9' /etc/redhat-release; then yum -y install python-unversioned-command; else yum -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
+    - python -m pip install -r requirements.txt
     - useradd user
     - chown -R user .
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers


### PR DESCRIPTION
Per discussion in #1368, I have raised the Python version used for the tests on RHEL8. I have picked Python 3.9, which is the same version that RHEL9 uses. (Also, once you go to >=3.11, the virtual environment setup changes, so this might end up creating more work for now.)

With this change, the tests on the rockylinux:8 task pass green. There are still a bunch of warnings from the test run, but they seem at least equivalent to what I see on the rockylinux:9 task.

Thoughts?