### PR TITLE
Have pytest report skipped tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,13 +156,14 @@ $(PACKAGE_TARNAME)-$(PACKAGE_VERSION).tar.gz:
 PYTEST = $(shell command -v pytest || echo '$(PYTHON) -m pytest')
 
 CONCURRENCY = auto
+PYTEST_FLAGS = -r s
 
 check: all
 	etc/optscan.sh
 	if [ $(CONCURRENCY) = 1 ]; then \
-		PYTHONIOENCODING=utf8 $(PYTEST); \
+		PYTHONIOENCODING=utf8 $(PYTEST) $(PYTEST_FLAGS); \
 	else \
-		PYTHONIOENCODING=utf8 $(PYTEST) -n $(CONCURRENCY); \
+		PYTHONIOENCODING=utf8 $(PYTEST) -n $(CONCURRENCY) $(PYTEST_FLAGS); \
 	fi
 	$(MAKE) -C test check
 


### PR DESCRIPTION
What do you think about having pytest report skipped tests by default at the end of the run, like in the attached patch. I have found this useful to analyze exactly what certain CI tasks test and don't test. So we could enable it on CI only. But I imagine it could also be useful for local development, if you don't realize that there are certain tests that you haven't activated.