### PR TITLE
ci: Add more configure args to Red Hat and Alpine jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,12 +94,16 @@ task:
 task:
   name: Linux (Red Hat)
   trigger_type: manual
-  container:
-    matrix:
-      - image: rockylinux:9
-      - image: rockylinux:8
+  matrix:
+    - container:
+        image: rockylinux:9
+      env:
+        configure_args: '--with-cares'
+    - container:
+        image: rockylinux:8
   setup_script:
-    - yum -y install autoconf automake diffutils file iptables libevent-devel libpq-devel libtool make openssl-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+    - yum -y install autoconf automake diffutils file iptables libevent-devel libpq-devel libtool make openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+    - case $configure_args in *with-cares*) yum -y install c-ares-devel; esac
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - if grep -q -F 'release 9' /etc/redhat-release; then yum -y install python-unversioned-command; else yum -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
@@ -109,7 +113,7 @@ task:
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
   build_script:
     - su user -c "./autogen.sh"
-    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-systemd"
+    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-pam --with-systemd $configure_args"
     - su user -c "make -j4"
   test_script:
     - su user -c "make -j4 check CONCURRENCY=4"
@@ -128,7 +132,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake bash build-base iptables libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
+    - apk add autoconf automake bash build-base c-ares-dev iptables libevent-dev libtool openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - python3 -m venv /venv
@@ -138,7 +142,7 @@ task:
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
   build_script:
     - su user -c "./autogen.sh"
-    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror"
+    - su user -c "./configure --prefix=$HOME/install --enable-cassert --enable-werror --with-cares"
     - su user -c "make -j4"
   test_script:
     - source /venv/bin/activate && su user -c "make -j4 check CONCURRENCY=4"


### PR DESCRIPTION
The idea is to have these jobs test more features and have the configuration be similar to what the downstream packagers are using, so it's more realistic overall.

This adds --with-pam to the Red Hat jobs, and --with-cares to RHEL >=9.  Also --with-cares to Alpine.

The FreeBSD and macOS jobs appear to be in good shape in this respect already (no c-ares in either case in the downstream packages).