### PR TITLE
Fix LDAP tests on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,7 +163,7 @@ task:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true
   setup_script:
-    - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool pkgconf postgresql${PGVERSION}-server postgresql${PGVERSION}-contrib python devel/py-pip sudo
+    - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool openldap25-client openldap25-server pkgconf postgresql${PGVERSION}-server postgresql${PGVERSION}-contrib python devel/py-pip sudo
     - pip install -r requirements.txt
     - kldload pf
     - echo 'anchor "pgbouncer_test/*"' >> /etc/pf.conf
@@ -178,7 +178,7 @@ task:
     M4: /usr/local/bin/gm4
   build_script:
     - su user -c "./autogen.sh"
-    - su user -c "./configure --prefix=$HOME/install --enable-werror"
+    - su user -c "./configure --prefix=$HOME/install --enable-werror --with-ldap"
     - su user -c "gmake -j4"
   test_script:
     - su user -c "gmake -j4 check CONCURRENCY=4"

--- a/test/start_openldap_server.sh
+++ b/test/start_openldap_server.sh
@@ -1,14 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-slapd=/usr/sbin/slapd
-if [ -d '/etc/ldap/schema' ]
-then
-	ldap_schema_dir='/etc/ldap/schema'
-else
-	ldap_schema_dir='/etc/openldap/schema'
+for file in '/usr/sbin/slapd' '/usr/local/libexec/slapd'; do
+	if [ -e "$file" ]; then
+		slapd=$file
+	fi
+done
+if [ -z "$slapd" ]; then
+	exit 77
 fi
-if [ ! -e $slapd ];then
+
+for dir in '/etc/ldap/schema' '/etc/openldap/schema' '/usr/local/etc/openldap/schema'; do
+	if [ -d "$dir" ]; then
+		ldap_schema_dir=$dir
+	fi
+done
+if [ -z "$ldap_schema_dir" ]; then
 	exit 77
 fi
 


### PR DESCRIPTION
The script start_openldap_server.sh hardcoded /bin/bash, which does not exist on FreeBSD.  The script works just fine with /bin/sh, so use that instead.

Also, generalize the search for various openldap-related paths to handle the FreeBSD installation location.

With that fixed, we can enable LDAP on the CI FreeBSD task.  We need to install openldap client and server packages for that.

toward fixing #1375