### PR TITLE
Enable LDAP tests on macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -196,18 +196,18 @@ task:
   env:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true
-    CPPFLAGS: -I/opt/homebrew/opt/openssl@3/include
-    LDFLAGS: -L/opt/homebrew/opt/openssl@3/lib
+    CPPFLAGS: -I/opt/homebrew/opt/openldap/include -I/opt/homebrew/opt/openssl@3/include
+    LDFLAGS: -L/opt/homebrew/opt/openldap/lib -L/opt/homebrew/opt/openssl@3/lib
     PATH: /opt/homebrew/opt/postgresql@${PGVERSION}/bin:$PATH
   setup_script:
-    - brew install autoconf automake bash libevent libtool openssl pandoc pkg-config postgresql@${PGVERSION}
+    - brew install autoconf automake bash libevent libtool openldap openssl pandoc pkg-config postgresql@${PGVERSION}
     - python3 -m venv venv
     - venv/bin/pip install -r requirements.txt
     - echo 'anchor "pgbouncer_test/*"' | sudo tee -a /etc/pf.conf
     - sudo pfctl -f /etc/pf.conf
   build_script:
     - ./autogen.sh
-    - ./configure --prefix=$HOME/install --enable-werror
+    - ./configure --prefix=$HOME/install --enable-werror --with-ldap
     - make -j4
   test_script:
     - source venv/bin/activate && make -j4 check CONCURRENCY=4

--- a/test/start_openldap_server.sh
+++ b/test/start_openldap_server.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-for file in '/usr/sbin/slapd' '/usr/local/libexec/slapd'; do
+for file in '/usr/sbin/slapd' '/usr/local/libexec/slapd' '/opt/homebrew/opt/openldap/libexec/slapd' '/usr/local/opt/openldap/libexec/slapd' '/opt/local/libexec/slapd'; do
 	if [ -e "$file" ]; then
 		slapd=$file
 	fi
@@ -10,7 +10,7 @@ if [ -z "$slapd" ]; then
 	exit 77
 fi
 
-for dir in '/etc/ldap/schema' '/etc/openldap/schema' '/usr/local/etc/openldap/schema'; do
+for dir in '/etc/ldap/schema' '/etc/openldap/schema' '/usr/local/etc/openldap/schema' '/opt/homebrew/etc/openldap/schema' '/opt/local/etc/openldap/schema'; do
 	if [ -d "$dir" ]; then
 		ldap_schema_dir=$dir
 	fi

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1128,7 +1128,6 @@ def test_auth_user_at_db_level_with_same_forced_user(bouncer):
                 cur.execute("select 1")
 
 
-@pytest.mark.skipif("MACOS", reason="OpenLDAP on OSX is difficult")
 @pytest.mark.skipif("WINDOWS", reason="We do not expect to support ldap on Windows")
 @pytest.mark.skipif(not LDAP_SUPPORT, reason="pgbouncer is built without LDAP support")
 def test_ldap_auth(bouncer_with_openldap):


### PR DESCRIPTION
We need to look for the LDAP files in various locations.  I copied the locations used by PostgreSQL for its LDAP tests; this supports both Homebrew and MacPorts locations.  (The macOS native LDAP libraries are not supported by neither PgBouncer nor PostgreSQL.)  Then we can un-skip the tests on macOS and enable them in CI.

toward fixing #1375