### PR TITLE
Avoid rare double call to disconnect_server for cancellations

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -79,7 +79,7 @@ PgCredentials * find_or_add_new_global_credentials(const char *name, const char 
 PgCredentials * add_pam_credentials(const char *name, const char *passwd) _MUSTCHECK;
 
 void accept_cancel_request(PgSocket *req);
-bool forward_cancel_request(PgSocket *server);
+void forward_cancel_request(PgSocket *server);
 
 void launch_new_connection(PgPool *pool, bool evict_if_needed);
 

--- a/src/server.c
+++ b/src/server.c
@@ -677,14 +677,7 @@ static bool handle_connect(PgSocket *server)
 	 */
 	if (!statlist_empty(&pool->waiting_cancel_req_list)) {
 		slog_debug(server, "use it for pending cancel req");
-		if (forward_cancel_request(server)) {
-			change_server_state(server, SV_ACTIVE_CANCEL);
-			sbuf_continue(&server->sbuf);
-		} else {
-			/* notify disconnect_server() that connect did not fail */
-			server->ready = true;
-			disconnect_server(server, false, "failed to send cancel req");
-		}
+		forward_cancel_request(server);
 	} else if (pool->db->peer_id) {
 		/* notify disconnect_server() that connect did not fail */
 		server->ready = true;


### PR DESCRIPTION
It was possible for disconnect_server to be called twice on a server that was used to forward a cancel request. This would happen when `SEND_CancelRequest` would fail. If that happened we would have already linked the client and server, so by calling `disconnect_client` it would

This simplifies the code by linking the server and client earlier in `forward_cancel_request`. This way we can relying on the `disconnect_client` calls in `forward_cancel_request` to also always disconnect the server, so we don't need the additional `disconnect_server` call in `handle_connect` anymore.

For easier understanding this also move the server state change that happens on success into that `forward_cancel_request`, so that all the related code is together.

Since the `disconnect_client` code can also close servers that are in the `SV_LOGIN` state, we also set `server->ready` for those cases. To avoid tracking this as a connection failure, like we did in `handle_connect` before.

Fixes #1376
