### PR TITLE
Simplify some attributes in postgres_compat.h

### DIFF
--- a/include/common/postgres_compat.h
+++ b/include/common/postgres_compat.h
@@ -26,8 +26,6 @@
 #define lengthof(array) (sizeof (array) / sizeof ((array)[0]))
 #define pg_hton32(x) htobe32(x)
 
-#define pg_attribute_noreturn() _NORETURN
-
 #define HIGHBIT					(0x80)
 #define IS_HIGHBIT_SET(ch)		((unsigned char)(ch) & HIGHBIT)
 
@@ -40,38 +38,8 @@ typedef unsigned int Oid;
 
 #define MaxAllocSize    ((Size) 0x3fffffff)
 
-/*
- * pg_nodiscard means the compiler should warn if the result of a function
- * call is ignored.  The name "nodiscard" is chosen in alignment with the C23
- * standard attribute with the same name.  For maximum forward compatibility,
- * place it before the declaration.
- */
-#ifdef __GNUC__
-#define pg_nodiscard __attribute__((warn_unused_result))
-#else
-#define pg_nodiscard
-#endif
-
-/*
- * pg_noreturn corresponds to the C11 noreturn/_Noreturn function specifier.
- * We can't use the standard name "noreturn" because some third-party code
- * uses __attribute__((noreturn)) in headers, which would get confused if
- * "noreturn" is defined to "_Noreturn", as is done by <stdnoreturn.h>.
- *
- * In a declaration, function specifiers go before the function name.  The
- * common style is to put them before the return type.  (The MSVC fallback has
- * the same requirement.  The GCC fallback is more flexible.)
- */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-#define pg_noreturn _Noreturn
-#elif defined(__GNUC__) || defined(__SUNPRO_C)
-#define pg_noreturn __attribute__((noreturn))
-#elif defined(_MSC_VER)
-#define pg_noreturn __declspec(noreturn)
-#else
-#define pg_noreturn
-#endif
-
+#define pg_nodiscard _MUSTCHECK
+#define pg_noreturn _NORETURN
 #define pg_restrict restrict
 
 /* define this to use non-server code paths */


### PR DESCRIPTION
PgBouncer already has portable definitions for the equivalent of `pg_nodiscard` and `pg_noreturn`, so we use them instead of reproducing the complicated definitions from PostgreSQL.

(Some of this will change in PostgreSQL 19 and beyond, as C11 and beyond gets adopted. Maybe in the long run, some of these things can be unified between PostgreSQL and PgBouncer. For now, this is just a simplification to use the existing facilities.)