### PR TITLE
ci: Combine some Ubuntu tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,12 +16,7 @@ task:
     - container:
         image: ubuntu:22.04
       env:
-        configure_args: '--without-openssl'
-    - container:
-        image: ubuntu:22.04
-      env:
-        configure_args: '--disable-evdns'
-      trigger_type: manual
+        configure_args: '--disable-evdns --without-openssl'
     - container:
         image: ubuntu:22.04
       env:


### PR DESCRIPTION
We can run --disable-evdns and --without-openssl in one job, because the code related to these two options is independent of each other.