### PR TITLE
ci: Use apt-get install with --no-install-recommends

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,14 +56,14 @@ task:
       trigger_type: manual
   setup_script:
     - apt-get update
-    - apt-get -y install gnupg postgresql-common
+    - apt-get -y --no-install-recommends install gnupg postgresql-common
     - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
     - apt-get update
     - pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
-    - apt-get -y install $pkgs
+    - apt-get -y --no-install-recommends install $pkgs
     - python3 -m venv /venv
     - /venv/bin/pip install -r requirements.txt
     - useradd user
@@ -261,7 +261,7 @@ task:
     image: ubuntu:22.04
   setup_script:
     - apt-get update
-    - apt-get install -y python3 python3-pip cmake curl git
+    - apt-get install -y --no-install-recommends python3 python3-pip cmake curl gcc g++ git make
     - pip install -r dev_requirements.txt
   build_script:
     - touch config.mak # Fake that configure has run


### PR DESCRIPTION
This saves installing a bunch of extra packages, thus saving download bandwidth and CPU time.

The "Formatting checks & linting" task needs a few more packages installed that were previously pulled in indirectly.

---

Examples:

before:
```
0 upgraded, 40 newly installed, 0 to remove and 0 not upgraded.
Need to get 13.4 MB of archives.

2 upgraded, 186 newly installed, 0 to remove and 0 not upgraded.
Need to get 192 MB of archives.

0 upgraded, 160 newly installed, 0 to remove and 0 not upgraded.
Need to get 127 MB of archives.
```

after:
```
0 upgraded, 32 newly installed, 0 to remove and 0 not upgraded.
Need to get 13.0 MB of archives.

2 upgraded, 123 newly installed, 0 to remove and 0 not upgraded.
Need to get 159 MB of archives.

0 upgraded, 85 newly installed, 0 to remove and 0 not upgraded.
Need to get 106 MB of archives.
```