### PR TITLE
Remove all remaining uses of bash

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,7 +133,7 @@ task:
       - image: alpine:latest
   setup_script:
     - apk update
-    - apk add autoconf automake bash build-base c-ares-dev iptables libevent-dev libtool openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
+    - apk add autoconf automake build-base c-ares-dev iptables libevent-dev libtool openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
     - wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
     - tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
     - python3 -m venv /venv
@@ -162,7 +162,7 @@ task:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true
   setup_script:
-    - pkg install -y autoconf automake bash gmake hs-pandoc libevent libtool openldap25-client openldap25-server pkgconf postgresql${PGVERSION}-server postgresql${PGVERSION}-contrib python devel/py-pip sudo
+    - pkg install -y autoconf automake gmake hs-pandoc libevent libtool openldap25-client openldap25-server pkgconf postgresql${PGVERSION}-server postgresql${PGVERSION}-contrib python devel/py-pip sudo
     - pip install -r requirements.txt
     - kldload pf
     - echo 'anchor "pgbouncer_test/*"' >> /etc/pf.conf
@@ -199,7 +199,7 @@ task:
     LDFLAGS: -L/opt/homebrew/opt/openldap/lib -L/opt/homebrew/opt/openssl@3/lib
     PATH: /opt/homebrew/opt/postgresql@${PGVERSION}/bin:$PATH
   setup_script:
-    - brew install autoconf automake bash libevent libtool openldap openssl pandoc pkg-config postgresql@${PGVERSION}
+    - brew install autoconf automake libevent libtool openldap openssl pandoc pkg-config postgresql@${PGVERSION}
     - python3 -m venv venv
     - venv/bin/pip install -r requirements.txt
     - echo 'anchor "pgbouncer_test/*"' | sudo tee -a /etc/pf.conf

--- a/test/README.md
+++ b/test/README.md
@@ -6,21 +6,21 @@ Tests
 To be able to run most of the tests you need to install a few python tools.  To
 do so, you should run the following from the root of the repository:
 
-```bash
+```sh
 pip3 install --user -r requirements.txt
 ```
 
 This will install the packages globally on your system, if you don't want to do
 that (or if tests are still not working after executing the above command) you can use a
 [virtual environment][1] instead:
-```bash
+```sh
 # create a virtual environment (only needed once)
 python3 -m venv env
 
 # activate the environment. You will need to activate this environment in
 # your shell every time you want to run the tests. (so it's needed once per
 # shell).
-source env/bin/activate
+. env/bin/activate
 
 # Install the dependencies (only needed once, or whenever extra dependencies
 # get added to requirements.txt)
@@ -55,7 +55,7 @@ This test is run by `make check`.
 You can review the pytest docs on how to run tests with pytest, but the most
 common commands that you'll want to use are:
 
-```bash
+```sh
 # Run all tests in parallel
 pytest -n auto
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -485,7 +485,7 @@ class QueryRunner:
                 assert match is not None
                 fw_token = match.group(1)
             sudo(
-                'bash -c "'
+                'sh -c "'
                 f"echo 'anchor \\\"port_{self.port}\\\"'"
                 f' | pfctl -a pgbouncer_test -f -"'
             )
@@ -509,7 +509,7 @@ class QueryRunner:
                 )
             elif BSD:
                 sudo(
-                    "bash -c '"
+                    "sh -c '"
                     f'echo "block drop out proto tcp from any to {self.host} port {self.port}"'
                     f"| pfctl -a pgbouncer_test/port_{self.port} -f -'"
                 )
@@ -544,7 +544,7 @@ class QueryRunner:
                 )
             elif BSD:
                 sudo(
-                    "bash -c '"
+                    "sh -c '"
                     f'echo "block return-rst out out proto tcp from any to {self.host} port {self.port}"'
                     f"| pfctl -a pgbouncer_test/port_{self.port} -f -'"
                 )


### PR DESCRIPTION
The few remaining uses can be done with normal sh.  The testing instructions can be modified slightly to not require bash.  We also don't need to install the bash package on ci anymore.