### PR TITLE
ci: Add test for FIPS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,6 +45,12 @@ task:
         image: ubuntu:24.04
       trigger_type: manual
     - container:
+        image: debian:trixie
+      env:
+        PGVERSION: 13
+        use_fips: yes
+#      trigger_type: manual
+    - container:
         image: debian:bookworm
       env:
         PGVERSION: 15
@@ -56,12 +62,13 @@ task:
       trigger_type: manual
   setup_script:
     - apt-get update
-    - apt-get -y --no-install-recommends install gnupg postgresql-common
+    - apt-get -y --no-install-recommends install ca-certificates gnupg postgresql-common
     - /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
     - apt-get update
     - pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
     - case $CC in clang) pkgs="$pkgs clang";; esac
     - if [ x"$ENABLE_VALGRIND" = x"yes" ]; then pkgs="$pkgs valgrind"; fi
+    - if [ x"$use_fips" = x"yes" ]; then pkgs="$pkgs openssl-provider-fips"; fi
     - if [ x"$use_scan_build" = x"yes" ]; then pkgs="$pkgs clang-tools"; fi
     - apt-get -y --no-install-recommends install $pkgs
     - python3 -m venv /venv
@@ -69,6 +76,11 @@ task:
     - useradd user
     - chown -R user .
     - echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+    - |
+      if [ x"$use_fips" = x"yes" ]; then
+        openssl fipsinstall -out /etc/ssl/fipsmodule.cnf -module $(openssl version -m | sed 's/^MODULESDIR: "//;s/"$//')/fips.so
+        sed -i 's!^.*\.include.*fipsmodule.*$!.include /etc/ssl/fipsmodule.cnf!;s!^.*fips.*fips_sect.*$!fips = fips_sect\nbase = base_sect\n\n[base_sect]\nactivate = 1!' /etc/ssl/openssl.cnf
+      fi
   build_script:
     - su user -c "./autogen.sh"
     - su user -c "${use_scan_build:+scan-build} ./configure --prefix=$HOME/install --enable-cassert --enable-werror --without-cares --with-systemd $configure_args"


### PR DESCRIPTION
To test running the test suite of PgBouncer in FIPS mode, add a new task for Debian trixie (currently stable), which includes a FIPS provider package.

NOTE: Currently, this is all pretty broken.

We need to test against PostgreSQL 13, because newer versions will reject the

    pg.sql("set password_encryption = 'md5'; create user muser1 password 'foo';")

etc. calls in `test/conftest.py` (and perhaps more along those lines).

The actual PgBouncer tests are also failing at the moment.

Somewhat inspired by the issue #1384, although that one uses a different FIPS module.