### PR TITLE
Rename auth_ldap_parameter

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -493,20 +493,7 @@ In order to use ldap, `auth_type` needs to be set to `hba`. The value of
 `auth_hba_file` has also to be set. And the content of the `auth_hba_file` could be
 the same format like `pg_hba.conf` in Postgres.
 Otherwise, you can set `auth_type` directly to `ldap`. If `auth_type` is set to `ldap`, the
-`auth_ldap_parameter` has also to be set.
-
-### auth_ldap_parameter
-
-This value is the global ldap parameter if `auth_type` is set to `ldap`. The
-value would be similar to the ldap line in pg_hba.conf. If no
-`auth_ldap_parameter` is set, then ldap authentication will fail. However, the
-value only contains the parameter after the 'ldap' keyword in the HBA line. For
-example, if the HBA line looks like this:
-```conf
-host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`.
-```
-The corresponding value of `auth_ldap_parameter` would be
-`ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
+`ldap_options` has also to be set.
 
 ### auth_hba_file
 
@@ -562,6 +549,19 @@ Default: `SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpass
 Database name in the `[database]` section to be used for authentication purposes. This
 option can be either global or overridden in the connection string if this parameter is
 specified.
+
+### ldap_options
+
+This value is the global ldap parameter if `auth_type` is set to `ldap`. The
+value would be similar to the ldap line in pg_hba.conf. If no `ldap_options` is
+set, then ldap authentication will fail. However, the value only contains the
+parameter after the 'ldap' keyword in the HBA line. For example, if the HBA
+line looks like this:
+```conf
+host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`.
+```
+The corresponding value of `ldap_options` would be
+`ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
 
 ## Log settings
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -140,7 +140,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ; auth_ident_file =
 
 ;; Parameter ldap authentication would use when "auth_type = ldap"
-; auth_ldap_parameter =
+; ldap_options =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -854,7 +854,7 @@ extern char *cf_auth_query;
 extern char *cf_auth_user;
 extern char *cf_auth_hba_file;
 extern char *cf_auth_dbname;
-extern char *cf_auth_ldap_parameter;
+extern char *cf_ldap_options;
 
 extern char *cf_pidfile;
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -754,7 +754,7 @@ struct PgSocket {
 		uint8_t ServerKey[32];
 	} scram_state;
 #ifdef HAVE_LDAP
-	char ldap_parameters[MAX_LDAP_CONFIG];
+	char ldap_options[MAX_LDAP_CONFIG];
 #endif
 
 	VarCache vars;		/* state of interesting server parameters */

--- a/src/client.c
+++ b/src/client.c
@@ -379,7 +379,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 			disconnect_client(client, true, "ldap_options is null");
 			return false;
 		} else {
-			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", cf_ldap_options);
+			snprintf(client->ldap_options, MAX_LDAP_CONFIG, "%s", cf_ldap_options);
 			slog_noise(client, "The value of cf_ldap_options is %s", cf_ldap_options);
 		}
 	} else
@@ -401,7 +401,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		auth = rule->rule_method;
 #ifdef HAVE_LDAP
 		if (auth == AUTH_TYPE_LDAP) {
-			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", rule->auth_options);
+			snprintf(client->ldap_options, MAX_LDAP_CONFIG, "%s", rule->auth_options);
 		}
 #endif
 		slog_noise(client, "HBA Line %d is matched", rule->hba_linenr);

--- a/src/client.c
+++ b/src/client.c
@@ -375,12 +375,12 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	auth = cf_auth_type;
 #ifdef HAVE_LDAP
 	if (auth == AUTH_TYPE_LDAP) {
-		if (cf_auth_ldap_parameter == NULL) {
-			disconnect_client(client, true, "auth_ldap_parameter is null");
+		if (cf_ldap_options == NULL) {
+			disconnect_client(client, true, "ldap_options is null");
 			return false;
 		} else {
-			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", cf_auth_ldap_parameter);
-			slog_noise(client, "The value of cf_auth_ldap_parameter is %s", cf_auth_ldap_parameter);
+			snprintf(client->ldap_parameters, MAX_LDAP_CONFIG, "%s", cf_ldap_options);
+			slog_noise(client, "The value of cf_ldap_options is %s", cf_ldap_options);
 		}
 	} else
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,7 @@ int cf_auth_type = AUTH_TYPE_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_ident_file;
-char *cf_auth_ldap_parameter;
+char *cf_ldap_options;
 char *cf_auth_user;
 char *cf_auth_query;
 char *cf_auth_dbname;
@@ -265,7 +265,6 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
-	CF_ABS("auth_ldap_parameter", CF_STR, cf_auth_ldap_parameter, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
@@ -291,6 +290,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 	CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 	CF_ABS("job_name", CF_STR, cf_jobname, CF_NO_RELOAD, "pgbouncer"),
+	CF_ABS("ldap_options", CF_STR, cf_ldap_options, 0, NULL),
 	CF_ABS("listen_addr", CF_STR, cf_listen_addr, CF_NO_RELOAD, ""),
 	CF_ABS("listen_backlog", CF_INT, cf_listen_backlog, CF_NO_RELOAD, "128"),
 	CF_ABS("listen_port", CF_INT, cf_listen_port, CF_NO_RELOAD, "6432"),
@@ -988,7 +988,6 @@ static void cleanup(void)
 	xfree(&cf_auth_ident_file);
 	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_hba_file);
-	xfree(&cf_auth_ldap_parameter);
 	xfree(&cf_auth_query);
 	xfree(&cf_auth_user);
 	xfree(&cf_server_reset_query);
@@ -996,6 +995,7 @@ static void cleanup(void)
 	xfree(&cf_ignore_startup_params);
 	xfree(&cf_autodb_connstr);
 	xfree(&cf_jobname);
+	xfree(&cf_ldap_options);
 	xfree(&cf_admin_users);
 	xfree(&cf_stats_users);
 	xfree(&cf_client_tls_protocols);

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1277,7 +1277,7 @@ def test_ldap_auth(bouncer_with_openldap):
     # 10 test ldap auth_type
     bouncer_with_openldap.write_ini(f"auth_type = ldap")
     bouncer_with_openldap.write_ini(
-        f'auth_ldap_parameter = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
+        f'ldap_options = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
     )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")


### PR DESCRIPTION
The commit cabe794 uses auth_ldap_parameter but this name is conceptually wrong. There isn't a single parameter but multiple ones (ldapserver, ldapport, ...). Postgres refers the LDAP elements as "options" [1] instead of "parameters".  Adopt the same terminology as Postgres. It also removes the "auth" prefix because "ldap" implies that this PgBouncer parameter is for authentication. The bonus is a shorter name. The new parameter name is ldap_options.

[1] https://www.postgresql.org/docs/current/auth-ldap.html