### PR TITLE
Harden decide_startup_pool packet parsing

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1050,6 +1050,13 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 	}
+
+	/* ran out of bytes before seeing a terminator, or got a double \0 before the end */
+	if (!ok || mbuf_avail_for_read(&pkt->data) != 0) {
+		disconnect_client(client, true, "invalid startup packet layout: expected terminator as last byte");
+		return false;
+	}
+
 	if (!username || !username[0]) {
 		disconnect_client(client, true, "no username supplied");
 		return false;


### PR DESCRIPTION
The start-up packet contains a series of 0-terminated key-value strings. After the last value, exactly at the end of the packet, there should be an additional \0 (an empty key).

Both Postgres and pgbouncer check for the \0 to break from look, but postgres additionally checks whether this byte was indeed at the end.
https://github.com/postgres/postgres/blob/master/src/backend/tcop/backend_startup.c#L814

Pgbouncer continues processing if the empty key appears earlier or there is no terminator, ignoring that the start-up packet was invalid.

There don't seem to be any immediate consequences, mostly that some bytes are ignored, but it seems preferable to terminate early when receiving garbage and be consistent with postgres.