### PR TITLE
[postgres-proxy] log send buffer stalls

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -666,6 +666,8 @@ try_more:
 		io->done_pos += res;
 	} else if (res < 0) {
 		if (errno == EAGAIN) {
+			log_info("sbuf_send_pending_iobuf: send() is stalled on dst=%d avail=%d",
+				 sbuf->dst->sock, avail);
 			if (!sbuf_queue_send(sbuf)) {
 				/* drop if queue failed */
 				sbuf_call_proto(sbuf, SBUF_EV_SEND_FAILED);


### PR DESCRIPTION
Log whenever sends stall. We'll use this to see the effects of tuning send buffers.