### PR TITLE
LDAP documentation cleanup

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -482,18 +482,16 @@ hba
     over Unix socket use the `peer` authentication method, connections over TCP
     must use TLS.
 
+ldap
+:   Users are authenticated against an LDAP server, like in PostgreSQL
+    (see <https://www.postgresql.org/docs/current/auth-ldap.html> for
+    details).  The LDAP connection options are configured using the
+    setting `ldap_options`, or alternatively in the `auth_hba_file`.
+
 pam
 :   PAM is used to authenticate users, `auth_file` is ignored. This method is not
     compatible with databases using the `auth_user` option. The service name reported to
     PAM is "pgbouncer". `pam` is not supported in the HBA configuration file.
-
-ldap
-:   LDAP is used to authenticate users with ldap server (OpenLDAP on Linux or AD on Windows).
-In order to use ldap, `auth_type` needs to be set to `hba`. The value of
-`auth_hba_file` has also to be set. And the content of the `auth_hba_file` could be
-the same format like `pg_hba.conf` in Postgres.
-Otherwise, you can set `auth_type` directly to `ldap`. If `auth_type` is set to `ldap`, the
-`ldap_options` has also to be set.
 
 ### auth_hba_file
 
@@ -552,16 +550,10 @@ specified.
 
 ### ldap_options
 
-This value is the global ldap parameter if `auth_type` is set to `ldap`. The
-value would be similar to the ldap line in pg_hba.conf. If no `ldap_options` is
-set, then ldap authentication will fail. However, the value only contains the
-parameter after the 'ldap' keyword in the HBA line. For example, if the HBA
-line looks like this:
-```conf
-host all ldapuser1 0.0.0.0/0 ldap ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`.
-```
-The corresponding value of `ldap_options` would be
-`ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"`
+LDAP connection options to use if `auth_type` is `ldap`.  (Not used if
+authentication is configured via `auth_hba_file`.)  Example:
+
+    ldap_options = ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"
 
 ## Log settings
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -137,10 +137,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;auth_hba_file =
 
 ;; Path to Pg-ident-style map file
-; auth_ident_file =
+;auth_ident_file =
 
-;; Parameter ldap authentication would use when "auth_type = ldap"
-; ldap_options =
+;; LDAP connection options when "auth_type = ldap"
+;ldap_options =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -228,8 +228,7 @@ static bool validate_ldap_options(struct ldap_auth_request *request)
 		    request->ldapbindpasswd ||
 		    request->ldapsearchattribute ||
 		    request->ldapsearchfilter) {
-			log_warning("cannot use ldapbasedn, ldapbinddn, ldapbindpasswd, "
-				    "ldapsearchattribute, ldapsearchfilter, or ldapurl together with ldapprefix");
+			log_warning("cannot mix options for simple bind and search+bind modes");
 			return false;
 		}
 	} else if (!request->ldapbasedn) {


### PR DESCRIPTION
Clean up the documentation around the new LDAP authentication feature a bit.  Some of the text was poorly worded.

Also change one error message to be more consistent with a recent PostgreSQL change (PostgreSQL commit f68d85bf692).