### PR TITLE
Rename ldap_options to auth_ldap_options

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -486,7 +486,7 @@ ldap
 :   Users are authenticated against an LDAP server, like in PostgreSQL
     (see <https://www.postgresql.org/docs/current/auth-ldap.html> for
     details).  The LDAP connection options are configured using the
-    setting `ldap_options`, or alternatively in the `auth_hba_file`.
+    setting `auth_ldap_options`, or alternatively in the `auth_hba_file`.
 
 pam
 :   PAM is used to authenticate users, `auth_file` is ignored. This method is not
@@ -548,12 +548,12 @@ Database name in the `[database]` section to be used for authentication purposes
 option can be either global or overridden in the connection string if this parameter is
 specified.
 
-### ldap_options
+### auth_ldap_options
 
 LDAP connection options to use if `auth_type` is `ldap`.  (Not used if
 authentication is configured via `auth_hba_file`.)  Example:
 
-    ldap_options = ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"
+    auth_ldap_options = ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"
 
 ## Log settings
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -140,7 +140,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;auth_ident_file =
 
 ;; LDAP connection options when "auth_type = ldap"
-;ldap_options =
+;auth_ldap_options =
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -854,7 +854,7 @@ extern char *cf_auth_query;
 extern char *cf_auth_user;
 extern char *cf_auth_hba_file;
 extern char *cf_auth_dbname;
-extern char *cf_ldap_options;
+extern char *cf_auth_ldap_options;
 
 extern char *cf_pidfile;
 

--- a/src/client.c
+++ b/src/client.c
@@ -375,12 +375,12 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	auth = cf_auth_type;
 #ifdef HAVE_LDAP
 	if (auth == AUTH_TYPE_LDAP) {
-		if (cf_ldap_options == NULL) {
-			disconnect_client(client, true, "ldap_options is null");
+		if (cf_auth_ldap_options == NULL) {
+			disconnect_client(client, true, "auth_ldap_options is null");
 			return false;
 		} else {
-			snprintf(client->ldap_options, MAX_LDAP_CONFIG, "%s", cf_ldap_options);
-			slog_noise(client, "The value of cf_ldap_options is %s", cf_ldap_options);
+			snprintf(client->ldap_options, MAX_LDAP_CONFIG, "%s", cf_auth_ldap_options);
+			slog_noise(client, "The value of cf_auth_ldap_options is %s", cf_auth_ldap_options);
 		}
 	} else
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,7 @@ int cf_auth_type = AUTH_TYPE_MD5;
 char *cf_auth_file;
 char *cf_auth_hba_file;
 char *cf_auth_ident_file;
-char *cf_ldap_options;
+char *cf_auth_ldap_options;
 char *cf_auth_user;
 char *cf_auth_query;
 char *cf_auth_dbname;
@@ -265,6 +265,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
+	CF_ABS("auth_ldap_options", CF_STR, cf_auth_ldap_options, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
@@ -290,7 +291,6 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 	CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),
 	CF_ABS("job_name", CF_STR, cf_jobname, CF_NO_RELOAD, "pgbouncer"),
-	CF_ABS("ldap_options", CF_STR, cf_ldap_options, 0, NULL),
 	CF_ABS("listen_addr", CF_STR, cf_listen_addr, CF_NO_RELOAD, ""),
 	CF_ABS("listen_backlog", CF_INT, cf_listen_backlog, CF_NO_RELOAD, "128"),
 	CF_ABS("listen_port", CF_INT, cf_listen_port, CF_NO_RELOAD, "6432"),
@@ -988,6 +988,7 @@ static void cleanup(void)
 	xfree(&cf_auth_ident_file);
 	xfree(&cf_auth_dbname);
 	xfree(&cf_auth_hba_file);
+	xfree(&cf_auth_ldap_options);
 	xfree(&cf_auth_query);
 	xfree(&cf_auth_user);
 	xfree(&cf_server_reset_query);
@@ -995,7 +996,6 @@ static void cleanup(void)
 	xfree(&cf_ignore_startup_params);
 	xfree(&cf_autodb_connstr);
 	xfree(&cf_jobname);
-	xfree(&cf_ldap_options);
 	xfree(&cf_admin_users);
 	xfree(&cf_stats_users);
 	xfree(&cf_client_tls_protocols);

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1277,7 +1277,7 @@ def test_ldap_auth(bouncer_with_openldap):
     # 10 test ldap auth_type
     bouncer_with_openldap.write_ini(f"auth_type = ldap")
     bouncer_with_openldap.write_ini(
-        f'ldap_options = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
+        f'auth_ldap_options = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
     )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")


### PR DESCRIPTION
The argument in commit 1a95d51 that the "auth" prefix is unnecessary is flawed.  There are also other ways in which LDAP could be used in a PostgreSQL stack, and they would use different LDAP options.  Explicit is better.  Also, PgBouncer groups all related settings under common prefixes, and they sort close together, so it seems good to maintain that.