### PR TITLE
Add stat field to track client connections

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -186,6 +186,9 @@ total_xact_count
 total_query_count
 :   Total number of SQL commands pooled by **pgbouncer**.
 
+total_client_connect_count
+:   Total times that a client connected to a pool
+
 total_server_assignment_count
 :   Total times a server was assigned to a client
 
@@ -226,6 +229,10 @@ avg_xact_count
 
 avg_query_count
 :   Average queries per second in last stat period.
+
+avg_client_connect_count
+:   Average number of times a client connected to a pol per second in the
+    last stat period.
 
 avg_server_assignment_count
 :   Average number of times a server as assigned to a client per second in the

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -318,6 +318,7 @@ int pga_cmp_addr(const PgAddr *a, const PgAddr *b);
  * Stats, kept per-pool.
  */
 struct PgStats {
+	uint64_t client_connect_count;
 	uint64_t server_assignment_count;
 	uint64_t xact_count;
 	uint64_t query_count;

--- a/src/client.c
+++ b/src/client.c
@@ -188,6 +188,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 		disconnect_client(client, true, "no memory for authentication pool");
 		return;
 	}
+	client->pool->stats.client_connect_count += 1;
 	client->wait_for_user_conn = true;
 	if (!find_server(client)) {
 		return;
@@ -343,6 +344,7 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 			disconnect_client(client, true, "no memory for pool");
 			return false;
 		}
+		client->pool->stats.client_connect_count += 1;
 	}
 
 	if (cf_log_connections) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -122,7 +122,7 @@ static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
 			     avg.wait_time, avg.ps_client_parse_count,
 			     avg.ps_server_parse_count, avg.ps_bind_count,
 			     avg.client_connect_count
-);
+			     );
 }
 
 bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
@@ -157,7 +157,7 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 				    "avg_wait_time", "avg_client_parse_count",
 				    "avg_server_parse_count", "avg_bind_count",
 				    "avg_client_connect_count"
-);
+				    );
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -409,9 +409,11 @@ def test_show_stats(bouncer):
     p3_stats = next(s for s in stats if s["database"] == "p3")
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
+    assert p3_stats["total_client_connect_count"] == 5
     assert p3_stats["total_server_assignment_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["total_xact_count"] == 6
+
     # 11 SELECT 1 + 2 times COMMIT and ROLLBACK
     assert p3_stats["total_query_count"] == 15
 
@@ -419,6 +421,7 @@ def test_show_stats(bouncer):
     p3_stats = next(s for s in stats if s["database"] == "p3")
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
+    assert p3_stats["client_connect_count"] == 5
     assert p3_stats["server_assignment_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["xact_count"] == 6

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -405,11 +405,15 @@ def test_show_stats(bouncer):
             cur.execute("SELECT 1")
             cur.execute("SELECT 1")
 
+    # Make 3 connections so client and server connections differ
+    for _ in range(3):
+        _ = bouncer.conn()
+
     stats = bouncer.admin("SHOW STATS", row_factory=dict_row)
     p3_stats = next(s for s in stats if s["database"] == "p3")
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
-    assert p3_stats["total_client_connect_count"] == 5
+    assert p3_stats["total_client_connect_count"] == 8
     assert p3_stats["total_server_assignment_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["total_xact_count"] == 6
@@ -421,7 +425,7 @@ def test_show_stats(bouncer):
     p3_stats = next(s for s in stats if s["database"] == "p3")
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
-    assert p3_stats["client_connect_count"] == 5
+    assert p3_stats["client_connect_count"] == 8
     assert p3_stats["server_assignment_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["xact_count"] == 6


### PR DESCRIPTION
This PR adds the ability to track client connection counts from the admin console. 

While pgbouncer allows clients much greater performance in workloads that make fast connections/disconnects I have seen extreme instances where this clients will overuse this performance and cause issues in other areas of the network stack. For example a client will run an ETL that loops through a list of data to insert in a multiprocessed manner, create and close a connection for each row to be inserted. While the performance looks a lot better using pgbouncer than native postgres, it would still be better to find instances of clients doing this and be able to nudge them onto better practices (COPY from STDIN in this instance). It also exposes the clients to nondeteriministic network stack errors from the OS/libc, at least from what I have seen.