### PR TITLE
Add missing typedefs for architectures with SIMD support

### DIFF
--- a/include/common/postgres_compat.h
+++ b/include/common/postgres_compat.h
@@ -17,6 +17,9 @@
 #endif
 
 #define int8 int8_t
+#define int16 int16_t
+#define int32 int32_t
+#define int64 int64_t
 #define uint8 uint8_t
 #define uint16 uint16_t
 #define uint32 uint32_t


### PR DESCRIPTION
For architectures without SIMD support some additional typedefs from Postgres are needed. Since our CI only runs ARM and AMD64 these codepaths were not compiled in CI.

Fixes #1413
