### PR TITLE
Remove warning log on socket EOF reading first byte

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1580,7 +1580,6 @@ static void sbuf_possible_direct_tls_startup_cb(evutil_socket_t fd, short flags,
 	got = sbuf_op_peek(sbuf, peek_byte, 1);
 	if (got <= 0) {
 		/* eof from socket */
-		log_warning("TLS startup peek received EOF.");
 		sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
 		return;
 	}


### PR DESCRIPTION
This log was added in a49dc8ddaf1b67c080d2e39746401fa3ab7c6c97 but a lot of monitoring tools close the connection before sending anything causing log spam.