### PR TITLE
scram: add missed ctx deallocation

### DIFF
--- a/src/scram.c
+++ b/src/scram.c
@@ -485,7 +485,7 @@ static bool calculate_client_proof(PgSocket *server,
 	ctx = pg_hmac_create(state->hash_type);
 	if (ctx == NULL) {
 		slog_error(server, "HMAC context creation failed: %s", pg_hmac_error(NULL));
-		return false;
+		goto failed;
 	}
 
 	if (credentials->use_scram_keys) {


### PR DESCRIPTION
Found by PostgresPro with Svace static analyzer.
Fixes: 0c2e919 ("Update PgBouncer code to use new PG SCRAM code (#1356)")
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>