### PR TITLE
Windows UCRT support

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -403,7 +403,7 @@ jobs:
     runs-on: windows-2022
     env:
       HAVE_IPV6_LOCALHOST: "yes"
-      MSYSTEM: MINGW64
+      MSYSTEM: UCRT64
       BUILD_SYSTEM: meson
       # Without this the MSYS2 login shell starts in the home directory; we want
       # it to stay in the checkout directory.

--- a/lib/m4/usual.m4
+++ b/lib/m4/usual.m4
@@ -48,6 +48,7 @@ AC_SUBST(PORTNAME)
 AC_MSG_RESULT([$PORTNAME])
 dnl Set the flags before any feature tests.
 if test "$PORTNAME" = "win32"; then
+  AC_DEFINE([_POSIX_C_SOURCE], [1], [Define before including <time.h> for getting localtime_r() etc. on MinGW.])
   AC_DEFINE([WIN32_LEAN_AND_MEAN], [1], [Define to request cleaner win32 headers.])
   AC_DEFINE([WINVER], [0x0600], [Define to max win32 API version (0x0600=Vista).])
 fi
@@ -267,7 +268,7 @@ AC_CHECK_FUNCS(fls flsl flsll ffs ffsl ffsll)
 AC_CHECK_FUNCS(fnmatch mbsnrtowcs nl_langinfo strtod_l strtonum)
 AC_CHECK_FUNCS(asprintf vasprintf timegm)
 ### Functions provided only on win32
-AC_CHECK_FUNCS(localtime_r gettimeofday recvmsg sendmsg usleep getrusage)
+AC_CHECK_FUNCS(gettimeofday recvmsg sendmsg usleep getrusage)
 ### Functions used by libusual itself
 AC_CHECK_FUNCS(syslog mmap getpeerucred arc4random_buf getentropy getrandom)
 ### win32: link with ws2_32

--- a/lib/usual/time.c
+++ b/lib/usual/time.c
@@ -27,6 +27,7 @@ char *format_time_ms(usec_t time, char *dest, unsigned destlen)
 	struct tm *tm, tmbuf;
 	struct timeval tv;
 	time_t sec;
+	char msbuf[13];
 
 	if (!time) {
 		gettimeofday(&tv, NULL);
@@ -37,11 +38,12 @@ char *format_time_ms(usec_t time, char *dest, unsigned destlen)
 
 	sec = tv.tv_sec;
 	tm = localtime_r(&sec, &tmbuf);
-	snprintf(dest, destlen, "%04d-%02d-%02d %02d:%02d:%02d.%03d %s",
-		 tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-		 tm->tm_hour, tm->tm_min, tm->tm_sec,
-		 (int)(tv.tv_usec / 1000),
-		 tzname[tm->tm_isdst > 0 ? 1 : 0]);
+	strftime(dest, destlen, "%Y-%m-%d %H:%M:%S     %Z", tm);
+
+	/* 'paste' milliseconds into place... */
+	sprintf(msbuf, ".%03d", (int) (tv.tv_usec / 1000));
+	memcpy(dest + 19, msbuf, 4);
+
 	return dest;
 }
 
@@ -57,10 +59,7 @@ char *format_time_s(usec_t time, char *dest, unsigned destlen)
 		s = time / USEC;
 	}
 	tm = localtime_r(&s, &tbuf);
-	snprintf(dest, destlen, "%04d-%02d-%02d %02d:%02d:%02d %s",
-		 tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
-		 tm->tm_hour, tm->tm_min, tm->tm_sec,
-		 tzname[tm->tm_isdst > 0 ? 1 : 0]);
+	strftime(dest, destlen, "%Y-%m-%d %H:%M:%S %Z", tm);
 	return dest;
 }
 

--- a/lib/usual/time.c
+++ b/lib/usual/time.c
@@ -129,40 +129,6 @@ int gettimeofday(struct timeval *tp, void *tzp)
 
 #endif /* !HAVE_GETTIMEOFDAY */
 
-#ifndef HAVE_LOCALTIME_R
-
-struct tm *localtime_r(const time_t *tp, struct tm *result)
-{
-	ULARGE_INTEGER utc;
-	FILETIME ft_utc;
-	SYSTEMTIME st_utc, st_local;
-
-	/* convert time_t to FILETIME */
-	utc.QuadPart = (*tp + UNIX_EPOCH) * FT_SEC;
-	ft_utc.dwLowDateTime = utc.LowPart;
-	ft_utc.dwHighDateTime = utc.HighPart;
-
-	/* split to parts and get local time */
-	if (!FileTimeToSystemTime(&ft_utc, &st_utc))
-		return NULL;
-	if (!SystemTimeToTzSpecificLocalTime(NULL, &st_utc, &st_local))
-		return NULL;
-
-	/* fill struct tm */
-	result->tm_sec = st_local.wSecond;
-	result->tm_min = st_local.wMinute;
-	result->tm_hour = st_local.wHour;
-	result->tm_mday = st_local.wDay;
-	result->tm_mon = st_local.wMonth - 1;
-	result->tm_year = st_local.wYear - 1900;
-	result->tm_wday = st_local.wDayOfWeek;
-	result->tm_yday = 0;
-	result->tm_isdst = -1;
-	return result;
-}
-
-#endif /* !HAVE_LOCALTIME_R */
-
 #ifndef HAVE_GETRUSAGE
 
 int getrusage(int who, struct rusage *r_usage)

--- a/lib/usual/time.h
+++ b/lib/usual/time.h
@@ -67,15 +67,6 @@ int gettimeofday(struct timeval *tp, void *tzp);
 #endif
 
 
-#ifndef HAVE_LOCALTIME_R
-#define localtime_r(t, r) usual_localtime_r(t, r)
-
-/** Compat: localtime_r() */
-struct tm *localtime_r(const time_t *tp, struct tm *result);
-
-#endif
-
-
 #ifndef HAVE_USLEEP
 #define usleep(x) usual_usleep(x)
 

--- a/meson.build
+++ b/meson.build
@@ -105,6 +105,10 @@ cdata.set('_GNU_SOURCE', 1,
 cdata.set('_FILE_OFFSET_BITS', 64)
 
 if windows
+  if cc.get_id() != 'msvc'
+    cdata.set('_POSIX_C_SOURCE', 1,
+              description: 'Define before including <time.h> for getting localtime_r() etc. on MinGW.')
+  endif
   cdata.set('WIN32_LEAN_AND_MEAN', 1,
             description: 'Define to request cleaner win32 headers.')
   cdata.set('WINVER', '0x0600',
@@ -213,7 +217,6 @@ check_funcs = [
   'gettimeofday',
   'inet_ntop',
   'inet_pton',
-  'localtime_r',
   'lstat',
   'mbsnrtowcs',
   'memalign',


### PR DESCRIPTION
This patch set prepares the code to compile cleanly with the Windows UCRT library (instead of MSVCRT). A bit of code needed to be cleaned up, and then I switched the CI build to the newer environment.

Note that PostgreSQL has recently removed support for MSVCRT under MinGW, so this is to keep up with that, but it's also useful in general.
