### PR TITLE
Check the correct salt length for negative values

### DIFF
--- a/src/scram.c
+++ b/src/scram.c
@@ -401,7 +401,7 @@ bool read_server_first_message(PgSocket *server, char *input)
 	state->saltlen = pg_b64_decode(encoded_salt,
 				       strlen(encoded_salt),
 				       state->salt, decoded_salt_len);
-	if (decoded_salt_len < 0) {
+	if (state->saltlen < 0) {
 		slog_error(server, "malformed SCRAM message (invalid salt)");
 		return false;
 	}


### PR DESCRIPTION
While updating the SCRAM logic to the latest version that Postgres uses
a mistake snuck in where the wrong salt length was checked for problems.
This aligns in back to the logic that's present in Postgres.

Resolves #1424
