### PR TITLE
CI: Bump FreeBSD image to 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -152,7 +152,7 @@ task:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
   env:
     HAVE_IPV6_LOCALHOST: yes
     USE_SUDO: true


### PR DESCRIPTION
There are no 14.2 images on Cirrus anymore:

```
"code": 404,
"message": "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-2' was not found",
```

Source: https://cirrus-ci.com/task/5407469528154112
