### PR TITLE
Change types in `SHOW USERS` admin command

### DIFF
--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -40,6 +40,15 @@ def test_reload_error(bouncer):
             bouncer.admin("RELOAD")
 
 
+def test_show_users(bouncer):
+    """
+    Specific tests for show user command
+    """
+    users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
+    assert isinstance(users[0]["pool_size"], int)
+    assert isinstance(users[0]["reserve_pool_size"], int)
+
+
 def test_show(bouncer):
     show_items = [
         "clients",


### PR DESCRIPTION
In the `SHOW USERS` command, `pool_size` and `reserve_pool_size` are both sent to the client as strings instead of integers. There may be a reason for this that I'm not seeing but it seems like an oversight as these fields also show up in `SHOW DATABASES` and `SHOW PEERS` as integers. This probably constitutes a breaking change because there is probably a lot of downstream code that depends on these being strings and not integers. Maybe that precludes merging this, just figure I would raise a PR just in case.