### PR TITLE
[#1442] New implementation for test_cancel_race

### DIFF
--- a/test/test.ini
+++ b/test/test.ini
@@ -3,7 +3,6 @@ p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2 reserve_pool_si
 p0a= port=6666 host=127.0.0.1 dbname=p0 pool_size=2 reserve_pool=2
 p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
 p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=2
-p0p= port=6666 host=127.0.0.1 dbname=p0 user=postgres pool_size=2 reserve_pool_size=2
 ; for testing 'min_pool_size' with forced user
 ;p0z= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=3 user=pswcheck
 p1 = port=6666 host=127.0.0.1 dbname=p1 user=bouncer

--- a/test/test.ini
+++ b/test/test.ini
@@ -3,6 +3,7 @@ p0 = port=6666 host=127.0.0.1 dbname=p0 user=bouncer pool_size=2 reserve_pool_si
 p0a= port=6666 host=127.0.0.1 dbname=p0 pool_size=2 reserve_pool=2
 p0x= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5
 p0y= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=5 pool_size=5 max_db_connections=2
+p0p= port=6666 host=127.0.0.1 dbname=p0 user=postgres pool_size=2 reserve_pool_size=2
 ; for testing 'min_pool_size' with forced user
 ;p0z= port=6666 host=127.0.0.1 dbname=p0 min_pool_size=3 user=pswcheck
 p1 = port=6666 host=127.0.0.1 dbname=p1 user=bouncer

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -183,13 +183,9 @@ END $$;""".format(
                     break
                 assert len(r) == 0
                 # Let's check our task
-                print("Check task1")
-                try:
-                    # Let's wait a bit
-                    q1.result(0.2)
-                except TimeoutError:
-                    continue
-                raise RuntimeError("The first query already finished!")
+                print("Sleep a bit")
+                time.sleep(0.2)
+                continue
 
             # It waits for conn1
             q2 = pool.submit(

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -188,21 +188,11 @@ END $$;""".format(
                     break
                 assert len(r) == 0
 
-                pyver = sys.version_info
-                assert pyver is not None
+                # There were attempts to check a state
+                # of task1 via "q1.result(0.2)"" but they
+                # had problems on GitHub CI. So it the most easier
+                # and stable variant.
 
-                # ATTENTION
-                # Py 3.9.6 does not respect timeout for Future.result(...)
-                if pyver >= (3, 10):
-                    print("Check task1")
-                    try:
-                        q1.result(0.2)
-                    except TimeoutError:
-                        continue
-                    raise RuntimeError("Task1 already finished!")
-
-                # It is OLD python.
-                # Future.result does not respect timeout
                 print("Sleep a bit")
                 time.sleep(0.2)
                 continue

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -179,7 +179,12 @@ END $$;""".format(
                     assert r[0][0] == 2
                     break
                 assert len(r) == 0
-                continue
+                # Let's check our task
+                try:
+                    q1.result(0)
+                except TimeoutError:
+                    continue
+                raise RuntimeError("The first query already finished!")
 
             # Will waits for conn1
             q2 = pool.submit(

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -1,9 +1,9 @@
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
 import psycopg
 import pytest
-import sys
 
 
 def test_cancel(bouncer):

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -140,6 +140,11 @@ def test_cancel_race_v2(bouncer):
             bouncer.default_user,
         )
 
+        if bouncer.default_password is not None:
+            cn0_str += "password={}".format(
+                bouncer.default_password
+            )
+
         conn0 = psycopg.connect(cn0_str, autocommit=True)
         conn1 = bouncer.conn()
         cur1 = conn1.cursor()

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -141,9 +141,7 @@ def test_cancel_race_v2(bouncer):
         )
 
         if bouncer.default_password is not None:
-            cn0_str += "password={}".format(
-                bouncer.default_password
-            )
+            cn0_str += "password={}".format(bouncer.default_password)
 
         conn0 = psycopg.connect(cn0_str, autocommit=True)
         conn1 = bouncer.conn()

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -1,4 +1,3 @@
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -160,7 +160,9 @@ END $$;""".format(
         with ThreadPoolExecutor(max_workers=100) as pool:
             conn1_dbuser = conn1.execute("SELECT CURRENT_USER;").fetchall()[0][0]
             conn1.execute(
-                "CREATE TABLE test_cancel_race_v2 (id INTEGER, data VARCHAR(32));"
+                "CREATE TABLE test_cancel_race_v2\n"
+                "(id INTEGER NOT NULL PRIMARY KEY,\n"
+                "data VARCHAR(32));"
             )
             conn1.execute("INSERT INTO test_cancel_race_v2 (id) VALUES (1);")
             conn0.execute("CREATE EXTENSION dblink SCHEMA public;")

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -191,12 +191,12 @@ END $$;""".format(
                 pyver = sys.version_info
                 assert pyver is not None
 
-                # ATTENTION.
+                # ATTENTION
                 # Py 3.9.6 does not respect timeout for Future.result(...)
                 if pyver >= (3, 10):
                     print("Check task1")
                     try:
-                        q1.result(timeout=0.2)
+                        q1.result(0.2)
                     except TimeoutError:
                         continue
                     raise RuntimeError("Task1 already finished!")
@@ -204,7 +204,7 @@ END $$;""".format(
                 # It is OLD python.
                 # Future.result does not respect timeout
                 print("Sleep a bit")
-                time.sleep(seconds=0.2)
+                time.sleep(0.2)
                 continue
 
             # It waits for conn1

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -183,6 +183,7 @@ END $$;""".format(
                     break
                 assert len(r) == 0
                 # Let's check our task
+                print("Check task1")
                 try:
                     # Let's wait a bit
                     q1.result(0.2)

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -183,6 +183,8 @@ END $$;""".format(
                 try:
                     q1.result(0)
                 except TimeoutError:
+                    # Let's wait a bit
+                    time.sleep(0.2)
                     continue
                 raise RuntimeError("The first query already finished!")
 

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -168,7 +168,7 @@ END $$;""".format(
                 "data VARCHAR(32));"
             )
             conn1.execute("INSERT INTO test_cancel_race_v2 (id) VALUES (1);")
-            conn1.execute("CREATE EXTENSION dblink SCHEMA public;")
+            conn1.execute("CREATE EXTENSION IF NOT EXISTS dblink SCHEMA public;")
 
             print("Run task1 on conn1")
             q1 = pool.submit(cur1.execute, sql1)


### PR DESCRIPTION
This patch adds a new implementation of test_cancel_race - test_cancel_race_v2.

It does not uses sleeps and must work without flakies.

### The main idea

- We wait for conn1 begin working within server
- After that we send cancel signals

conn2 is locked by conn1 and waits for cancel of conn1.

At the final we check that conn2 was not cancelled and did its query sucessfully.

----
Closes #1442