### PR TITLE
add filters to show commands

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -646,7 +646,7 @@ port
 pool_size
 :   Maximum number of server connections that can be made to this peer
 
-#### SHOW FDS
+#### SHOW FDS [fd]
 
 Internal command - shows list of file descriptors in use with internal state attached to them.
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -484,7 +484,7 @@ pool_mode
 load_balance_hosts
 :   The load_balance_hosts in use if the pool's host contains a comma-separated list.
 
-#### SHOW PEER_POOLS
+#### SHOW PEER_POOLS [peer_id]
 
 A new peer_pool entry is made for each configured peer.
 
@@ -632,7 +632,7 @@ paused
 disabled
 :   1 if this database is currently disabled, else 0.
 
-#### SHOW PEERS
+#### SHOW PEERS [peer_id]
 
 peer_id
 :   ID of the configured peer entry.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -683,7 +683,7 @@ cancel
 link
 :   fd for corresponding server/client.  NULL if idle.
 
-#### SHOW SOCKETS [id], SHOW ACTIVE_SOCKETS
+#### SHOW SOCKETS [id], SHOW ACTIVE_SOCKETS [id]
 
 Shows low-level information about sockets or only active sockets.
 This includes the information shown under **SHOW CLIENTS** and **SHOW

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -421,7 +421,7 @@ prepared_statements
 id
 :   Unique ID for client.
 
-#### SHOW POOLS
+#### SHOW POOLS [db]
 
 A new pool entry is made for each couple of (database, user).
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -172,7 +172,7 @@ drivers will not work for this.
 
 The **SHOW** commands output information. Each command is described below.
 
-#### SHOW STATS
+#### SHOW STATS [db]
 
 Shows statistics.  In this and related commands, the total figures are
 since process start, the averages are updated every `stats_period`.
@@ -263,12 +263,12 @@ avg_bind_count
     to PostgreSQL by **pgbouncer**. Only applicable in named prepared statement tracking
     mode, see `max_prepared_statements`.
 
-#### SHOW STATS_TOTALS
+#### SHOW STATS_TOTALS [db]
 
 Subset of **SHOW STATS** showing the total values (**total_**).
 
 
-#### SHOW STATS_AVERAGES
+#### SHOW STATS_AVERAGES [db]
 
 Subset of **SHOW STATS** showing the average values (**avg_**).
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -177,6 +177,8 @@ The **SHOW** commands output information. Each command is described below.
 Shows statistics.  In this and related commands, the total figures are
 since process start, the averages are updated every `stats_period`.
 
+If database name is given only stats for that single database are shown.
+
 database
 :   Statistics are presented per database.
 
@@ -274,7 +276,7 @@ Subset of **SHOW STATS** showing the average values (**avg_**).
 
 Like **SHOW STATS** but aggregated across all databases.
 
-#### SHOW SERVERS
+#### SHOW SERVERS [id]
 
 type
 :   S, for server.
@@ -350,7 +352,7 @@ id
 :   Unique ID for server.
 
 
-#### SHOW CLIENTS
+#### SHOW CLIENTS [id]
 
 type
 :   C, for client.
@@ -546,7 +548,7 @@ dns_queries
 dns_pending
 :   not used
 
-#### SHOW USERS
+#### SHOW USERS [user]
 
 name
 :   The user name
@@ -574,7 +576,7 @@ max_user_client_connections
 current_client_connections
 :   Current number of client connections that this user has open to PgBouncer.
 
-#### SHOW DATABASES
+#### SHOW DATABASES [db]
 
 name
 :   Name of configured database entry.
@@ -681,13 +683,13 @@ cancel
 link
 :   fd for corresponding server/client.  NULL if idle.
 
-#### SHOW SOCKETS, SHOW ACTIVE_SOCKETS
+#### SHOW SOCKETS [id], SHOW ACTIVE_SOCKETS
 
 Shows low-level information about sockets or only active sockets.
 This includes the information shown under **SHOW CLIENTS** and **SHOW
 SERVERS** as well as other more low-level information.
 
-#### SHOW CONFIG
+#### SHOW CONFIG [name]
 
 Show the current configuration settings, one per row, with the following
 columns:
@@ -706,7 +708,7 @@ changeable
     If **no**, the variable can be changed only at boot time.  Use
     **SET** to change a variable at run time.
 
-#### SHOW MEM
+#### SHOW MEM [name]
 
 Shows low-level information about the current sizes of various
 internal memory allocations.  The information presented is subject to

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -946,4 +946,4 @@ bool load_config(void);
 
 bool set_config_param(const char *key, const char *val);
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),
-		     void *arg);
+		     void *arg, const char *filter_arg);

--- a/include/stats.h
+++ b/include/stats.h
@@ -18,7 +18,7 @@
 
 void stats_setup(void);
 
-bool admin_database_stats(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
-bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
-bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;
+bool admin_database_stats(PgSocket *client, struct StatList *pool_list, const char *filter_database)  _MUSTCHECK;
+bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list, const char *filter_database)  _MUSTCHECK;
+bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list, const char *filter_database)  _MUSTCHECK;
 bool show_stat_totals(PgSocket *client, struct StatList *pool_list)  _MUSTCHECK;

--- a/lib/usual/slab.c
+++ b/lib/usual/slab.c
@@ -215,13 +215,17 @@ static void run_slab_stats(struct Slab *slab, slab_stat_fn cb_func, void *cb_arg
 }
 
 /* call a function for all active slabs */
-void slab_stats(slab_stat_fn cb_func, void *cb_arg)
+void slab_stats(slab_stat_fn cb_func, void *cb_arg, const char *arg)
 {
 	struct Slab *slab;
 	struct List *item;
 
 	statlist_for_each(item, &slab_list) {
 		slab = container_of(item, struct Slab, head);
+		if (arg && *arg) {
+			if (strcasecmp(arg, slab->name) != 0)
+				continue;
+		}
 		run_slab_stats(slab, cb_func, cb_arg);
 	}
 }

--- a/lib/usual/slab.h
+++ b/lib/usual/slab.h
@@ -69,6 +69,6 @@ typedef void (*slab_stat_fn)(void *arg, const char *slab_name,
 			     unsigned total);
 
 /** Run stat info callback on all slabs */
-void slab_stats(slab_stat_fn cb_func, void *cb_arg);
+void slab_stats(slab_stat_fn cb_func, void *cb_arg, const char *arg);
 
 #endif

--- a/src/admin.c
+++ b/src/admin.c
@@ -349,7 +349,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk, int filter_fd)
 	const char *password = NULL;
 	bool send_scram_keys = false;
 
-	if (filter_fd != 0){
+	if (filter_fd != 0) {
 		if (filter_fd != sbuf_socket(&sk->sbuf))
 			return true;
 	}

--- a/src/admin.c
+++ b/src/admin.c
@@ -985,6 +985,10 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 				    "load_balance_hosts");
 	statlist_for_each(item, &pool_list) {
 		pool = container_of(item, PgPool, head);
+		if (arg && *arg) {
+			if (strcasecmp(arg, pool->db->name) != 0)
+				continue;
+		}
 		waiter = first_socket(&pool->waiting_client_list);
 		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
 		pool_mode = probably_wrong_pool_pool_mode(pool);

--- a/src/admin.c
+++ b/src/admin.c
@@ -1657,17 +1657,17 @@ static bool admin_show_version(PgSocket *admin, const char *arg)
 
 static bool admin_show_stats(PgSocket *admin, const char *arg)
 {
-	return admin_database_stats(admin, &pool_list);
+	return admin_database_stats(admin, &pool_list, arg);
 }
 
 static bool admin_show_stats_totals(PgSocket *admin, const char *arg)
 {
-	return admin_database_stats_totals(admin, &pool_list);
+	return admin_database_stats_totals(admin, &pool_list, arg);
 }
 
 static bool admin_show_stats_averages(PgSocket *admin, const char *arg)
 {
-	return admin_database_stats_averages(admin, &pool_list);
+	return admin_database_stats_averages(admin, &pool_list, arg);
 }
 
 static bool admin_show_totals(PgSocket *admin, const char *arg)

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -1173,6 +1173,7 @@ struct WalkInfo {
 	adns_walk_name_f name_cb;
 	adns_walk_zone_f zone_cb;
 	void *arg;
+	const char *filter;
 };
 
 static void walk_name(struct AANode *n, void *arg)
@@ -1203,7 +1204,6 @@ void adns_walk_zones(struct DNSContext *ctx, adns_walk_zone_f cb, void *arg)
 {
 	struct WalkInfo w;
 	w.zone_cb = cb;
-	w.arg = arg;
 	aatree_walk(&ctx->zone_tree, AA_WALK_IN_ORDER, walk_zone, &w);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -394,7 +394,7 @@ bool set_config_param(const char *key, const char *val)
 }
 
 void config_for_each(void (*param_cb)(void *arg, const char *name, const char *val, const char *defval, bool reloadable),
-		     void *arg)
+		     void *arg, const char *filter_arg)
 {
 	const struct CfKey *k = bouncer_params;
 	char buf[256];
@@ -403,6 +403,10 @@ void config_for_each(void (*param_cb)(void *arg, const char *name, const char *v
 	int ro = CF_NO_RELOAD | CF_READONLY;
 
 	for (; k->key_name; k++) {
+		if (filter_arg && *filter_arg) {
+			if (strcasecmp(filter_arg, k->key_name) != 0)
+				continue;
+		}
 		val = cf_get(&main_config, "pgbouncer", k->key_name, buf, sizeof(buf));
 		reloadable = (k->flags & ro) == 0;
 		param_cb(arg, k->key_name, val, k->def_value, reloadable);

--- a/src/stats.c
+++ b/src/stats.c
@@ -117,7 +117,7 @@ static void write_stats(PktBuf *buf, PgStats *stat, PgStats *old, char *dbname)
 			     avg.ps_server_parse_count, avg.ps_bind_count);
 }
 
-bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
+bool admin_database_stats(PgSocket *client, struct StatList *pool_list, const char *filter_database)
 {
 	PgPool *pool;
 	struct List *item;
@@ -149,6 +149,10 @@ bool admin_database_stats(PgSocket *client, struct StatList *pool_list)
 				    "avg_server_parse_count", "avg_bind_count");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
+		if (filter_database && *filter_database) {
+			if (strcasecmp(filter_database, pool->db->name) != 0)
+				continue;
+		}
 
 		if (!cur_db)
 			cur_db = pool->db;
@@ -183,7 +187,7 @@ static void write_stats_totals(PktBuf *buf, PgStats *stat, PgStats *old, char *d
 			     stat->ps_server_parse_count, stat->ps_bind_count);
 }
 
-bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list)
+bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list, const char *filter_database)
 {
 	PgPool *pool;
 	struct List *item;
@@ -209,6 +213,10 @@ bool admin_database_stats_totals(PgSocket *client, struct StatList *pool_list)
 				    "server_parse_count", "bind_count");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
+		if (filter_database && *filter_database) {
+			if (strcasecmp(filter_database, pool->db->name) != 0)
+				continue;
+		}
 
 		if (!cur_db)
 			cur_db = pool->db;
@@ -245,7 +253,7 @@ static void write_stats_averages(PktBuf *buf, PgStats *stat, PgStats *old, char 
 			     avg.ps_server_parse_count, avg.ps_bind_count);
 }
 
-bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list)
+bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list, const char *filter_database)
 {
 	PgPool *pool;
 	struct List *item;
@@ -271,6 +279,10 @@ bool admin_database_stats_averages(PgSocket *client, struct StatList *pool_list)
 				    "avg_server_parse_count", "avg_bind_count");
 	statlist_for_each(item, pool_list) {
 		pool = container_of(item, PgPool, head);
+		if (filter_database && *filter_database) {
+			if (strcasecmp(filter_database, pool->db->name) != 0)
+				continue;
+		}
 
 		if (!cur_db)
 			cur_db = pool->db;

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -79,6 +79,9 @@ def test_show_filter(bouncer) -> None:
         "databases": 'name',
         "sockets": 'id',
         "mem": 'name',
+        "stats": 'database',
+        "stats_totals": 'database',
+        "stats_averages": 'database',
     }
     conn_2 = bouncer.conn(dbname="p1")
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -72,15 +72,20 @@ def test_show(bouncer):
         bouncer.admin(f"SHOW {item}")
 
 
-def test_show_clients(bouncer) -> None:
+def test_show_filter(bouncer) -> None:
+    show_items = {
+        "clients": 'id',
+        "servers": 'id',
+    }
     conn_2 = bouncer.conn(dbname="p1")
 
-    with bouncer.cur(row_factory=dict_row):
+    for show_command, primary_key in show_items.items():
         with bouncer.cur(row_factory=dict_row):
-            clients = bouncer.admin(f"SHOW CLIENTS", row_factory=dict_row)
-            assert len(clients) == 4
-            clients = bouncer.admin(f"SHOW CLIENTS {clients[0]['id']}", row_factory=dict_row)
-            assert len(clients) == 1
+            with bouncer.cur(row_factory=dict_row):
+                clients = bouncer.admin(f"SHOW {show_command}", row_factory=dict_row)
+                filtered_clients = bouncer.admin(f"SHOW {show_command} {clients[0][primary_key]}", row_factory=dict_row)
+                assert len(filtered_clients) == 1
+                assert filtered_clients[0][primary_key] == clients[0][primary_key]
 
 
 def test_socket_id(bouncer) -> None:

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -72,6 +72,17 @@ def test_show(bouncer):
         bouncer.admin(f"SHOW {item}")
 
 
+def test_show_clients(bouncer) -> None:
+    conn_2 = bouncer.conn(dbname="p1")
+
+    with bouncer.cur(row_factory=dict_row):
+        with bouncer.cur(row_factory=dict_row):
+            clients = bouncer.admin(f"SHOW CLIENTS", row_factory=dict_row)
+            assert len(clients) == 4
+            clients = bouncer.admin(f"SHOW CLIENTS {clients[0]['id']}", row_factory=dict_row)
+            assert len(clients) == 1
+
+
 def test_socket_id(bouncer) -> None:
     """Test that PgSocket id is assigned as expected for sockets."""
     config = f"""

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -76,6 +76,9 @@ def test_show_filter(bouncer) -> None:
     show_items = {
         "clients": 'id',
         "servers": 'id',
+        "databases": 'name',
+        "sockets": 'id',
+        "mem": 'name',
     }
     conn_2 = bouncer.conn(dbname="p1")
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -95,6 +95,7 @@ def test_show_filter(bouncer) -> None:
                 )
                 assert len(filtered_clients) == 1
                 assert filtered_clients[0][primary_key] == clients[0][primary_key]
+    conn_2.close()
 
 
 def test_socket_id(bouncer) -> None:

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -74,14 +74,14 @@ def test_show(bouncer):
 
 def test_show_filter(bouncer) -> None:
     show_items = {
-        "clients": 'id',
-        "servers": 'id',
-        "databases": 'name',
-        "sockets": 'id',
-        "mem": 'name',
-        "stats": 'database',
-        "stats_totals": 'database',
-        "stats_averages": 'database',
+        "clients": "id",
+        "servers": "id",
+        "databases": "name",
+        "sockets": "id",
+        "mem": "name",
+        "stats": "database",
+        "stats_totals": "database",
+        "stats_averages": "database",
     }
     conn_2 = bouncer.conn(dbname="p1")
 
@@ -89,7 +89,10 @@ def test_show_filter(bouncer) -> None:
         with bouncer.cur(row_factory=dict_row):
             with bouncer.cur(row_factory=dict_row):
                 clients = bouncer.admin(f"SHOW {show_command}", row_factory=dict_row)
-                filtered_clients = bouncer.admin(f"SHOW {show_command} {clients[0][primary_key]}", row_factory=dict_row)
+                filtered_clients = bouncer.admin(
+                    f"SHOW {show_command} {clients[0][primary_key]}",
+                    row_factory=dict_row,
+                )
                 assert len(filtered_clients) == 1
                 assert filtered_clients[0][primary_key] == clients[0][primary_key]
 


### PR DESCRIPTION
One thing that I feel like has been missing from pgbouncer is the ability to filter via the show commands. It is especially cumbersome when running show clients on a pgbouncer with thousands of connections. Currently the most convenient way of querying the admin console is probably via `pgbouncer_fdw`[0]. 

This PR adds the ability to filter show commands by the "primary key" column of the admin output. 

For example you can query like this.
```console
> show mem user_cache;
    name    | size | used | free | memtotal
------------+------+------+------+----------
 user_cache | 2432 |    2 |   48 |   121600
(1 row)
```

Currently it is a very rough patch, needs some testing, etc. Figure I would just throw this out here and see if others are interested in this functionality.

Alternatively maybe this feature is unneeded complexity and users should just be pushed towards `pgbouncer_fdw`. Happy to close this PR if this is the consensus.

[0] https://github.com/CrunchyData/pgbouncer_fdw