### PR TITLE
Add client login counter stat

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -221,6 +221,9 @@ total_bind_count
     to PostgreSQL by **pgbouncer**. Only applicable in named prepared statement tracking
     mode, see `max_prepared_statements`.
 
+total_client_login_count
+:   Total number of successful client logins.
+
 avg_xact_count
 :   Average transactions per second in last stat period.
 
@@ -260,6 +263,9 @@ avg_bind_count
 :   Average number of prepared statements readied for execution by clients and forwarded
     to PostgreSQL by **pgbouncer**. Only applicable in named prepared statement tracking
     mode, see `max_prepared_statements`.
+
+avg_client_login_count
+:   Average number of successful client logins per second.
 
 #### SHOW STATS_TOTALS
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -331,6 +331,8 @@ struct PgStats {
 	uint64_t ps_server_parse_count;
 	uint64_t ps_client_parse_count;
 	uint64_t ps_bind_count;
+
+	uint64_t client_login_count;
 };
 
 /*

--- a/src/objects.c
+++ b/src/objects.c
@@ -2052,6 +2052,7 @@ bool finish_client_login(PgSocket *client)
 	switch (client->state) {
 	case CL_LOGIN:
 		change_client_state(client, CL_ACTIVE);
+		client->pool->stats.client_login_count++;
 	case CL_ACTIVE:
 		break;
 	default:

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -410,6 +410,7 @@ def test_show_stats(bouncer):
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
     assert p3_stats["total_server_assignment_count"] == 5
+    assert p3_stats["total_client_login_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["total_xact_count"] == 6
     # 11 SELECT 1 + 2 times COMMIT and ROLLBACK
@@ -420,14 +421,17 @@ def test_show_stats(bouncer):
     assert p3_stats is not None
     # 5 connection attempts (and thus assignments)
     assert p3_stats["server_assignment_count"] == 5
+    assert p3_stats["client_login_count"] == 5
     # 4 autocommit queries + 2 transactions
     assert p3_stats["xact_count"] == 6
     # 11 SELECT 1 + 2 times COMMIT and ROLLBACK
     assert p3_stats["query_count"] == 15
 
     totals = bouncer.admin("SHOW TOTALS")
-    # 5 connection attempts (and thus assignments)
+    # 5 p3 connection attempts (and thus assignments)
     assert ("total_server_assignment_count", 5) in totals
+    # 5 p3 connections + 3 admin connections from this test + 1 admin connection from Bouncer.wait_until_running()
+    assert ("total_client_login_count", 9) in totals
     # 4 autocommit queries + 2 transactions + 4 admin commands
     assert ("total_xact_count", 10) in totals
     # 11 SELECT 1 + 2 times COMMIT and ROLLBACK + 4 admin commands


### PR DESCRIPTION
Adds a `client_login_count` stat that is incremented each time a client successfully authenticates.

This can help identify when clients are churning connections or events that trigger a large number of client reconnects, which cannot be seen when looking at the current number of open client connections.