### PR TITLE
Fix sending duplicate NegotiateProtocolVersion message

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ task:
       env:
         ENABLE_VALGRIND: yes
         CFLAGS: -O0 -g
-        PGVERSION: 17
+        PGVERSION: 18
     - container:
         image: ubuntu:22.04
       env:

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -689,6 +689,7 @@ struct PgSocket {
 
 	bool wait_for_welcome : 1;	/* client: no server yet in pool, cannot send welcome msg */
 	bool welcome_sent : 1;		/* client: client has been sent the welcome msg */
+	bool protocol_negotiated : 1;	/* client: NegotiateProtocolVersion already sent */
 	bool wait_for_user_conn : 1;	/* client: waiting for auth_conn server connection */
 	bool wait_for_user : 1;		/* client: waiting for auth_conn query results */
 	bool wait_for_auth : 1;		/* client: waiting for external auth (PAM/LDAP) to be completed */

--- a/src/client.c
+++ b/src/client.c
@@ -1093,8 +1093,8 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			unsupported_protocol_extensions.write_pos
 			);
 		res = pktbuf_send_immediate(buf, client);
+		pktbuf_free(buf);
 		if (!res) {
-			pktbuf_free(buf);
 			disconnect_client(client, false, "unable to send protocol negotiation packet");
 			return false;
 		}

--- a/src/client.c
+++ b/src/client.c
@@ -1080,10 +1080,12 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 		}
 	}
 
-	if (pkt->type == PKT_STARTUP_V3_UNSUPPORTED || unsupported_protocol_extensions_count > 0) {
+	if ((pkt->type == PKT_STARTUP_V3_UNSUPPORTED || unsupported_protocol_extensions_count > 0)
+	    && !client->protocol_negotiated) {
 		PktBuf *buf = pktbuf_dynamic(512);
 		int res;
 
+		client->protocol_negotiated = true;
 		pktbuf_write_NegotiateProtocolVersion(
 			buf,
 			unsupported_protocol_extensions_count,


### PR DESCRIPTION
If we couldn't assign a server to the client right away, we would send the
protocol negotation message twice. This fixes that by tracking whether we've
already sent it or not.

Bumps our CI to PG18 so that we can actually test this code path.

Fixes #1459
