### PR TITLE
add option to skip building man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,9 @@ dist_doc_DATA = README.md NEWS.md \
 DISTCLEANFILES = config.mak config.status lib/usual/config.h config.log
 
 DIST_SUBDIRS = doc test
+ifeq ($(build_man_pages),yes)
 dist_man_MANS = doc/pgbouncer.1 doc/pgbouncer.5
+endif
 
 pgbouncer_LDFLAGS := $(TLS_LDFLAGS)
 pgbouncer_LDADD := $(CARES_LIBS) $(LIBEVENT_LIBS) $(TLS_LIBS) $(LIBS)

--- a/config.mak.in
+++ b/config.mak.in
@@ -51,6 +51,7 @@ abs_top_srcdir ?= @abs_top_srcdir@
 abs_top_builddir ?= @abs_top_builddir@
 nosub_top_srcdir ?= @top_srcdir@
 nosub_top_builddir ?= @top_builddir@
+build_man_pages ?= @build_man_pages@
 
 CARES_CFLAGS = @CARES_CFLAGS@
 CARES_LIBS = @CARES_LIBS@

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,19 @@ PKG_PROG_PKG_CONFIG
 AC_CHECK_PROGS(PANDOC, pandoc, pandoc)
 AC_CHECK_PROGS(PYTHON, [python3 python], python3)
 
+dnl allow disabling man-page generation
+AC_MSG_CHECKING([whether to build man-pages])
+AC_ARG_ENABLE(man-pages, AS_HELP_STRING([--disable-man-pages], [skip building man pages]),
+              [build_man_pages=$enableval], [build_man_pages=yes])
+AC_MSG_RESULT([$build_man_pages])
+if test "$build_man_pages" = "yes"; then
+  if ! test -x "$PANDOC"; then
+      AC_MSG_WARN([pandoc not found - man pages will not be built])
+      build_man_pages=no
+  fi
+fi
+AC_SUBST(build_man_pages)
+
 dnl check for windows tools
 if test "$PORTNAME" = "win32"; then
   AC_CHECK_TOOL([WINDRES], [windres])


### PR DESCRIPTION
Attempts to fix https://github.com/pgbouncer/pgbouncer/issues/1453 by adding a check for `pandoc`. If it's not installed, we don't use it to generate the man pages. 

```sh
$ ./configure
...
checking for pandoc... no
checking for python3... python3
checking whether to build man-pages... yes
configure: WARNING: pandoc not found - man pages will not be built
...
```

The man pages can also be skipped directly using `./configure --disable-man-pages`. You can see this in the logs 

```sh
$ ./configure --disable-man-pages
...
checking for pandoc... no
checking for python3... python3
checking whether to build man-pages... no
...
```

Open to any suggestions, first time contributing to the project and first time modifying autoconf files. Any help is appreciated