### PR TITLE
Fix late COPY messages causing pool exhaustion in transaction mode

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -685,7 +685,8 @@ struct PgSocket {
 	bool setting_vars : 1;		/* server: setting client vars */
 	bool exec_on_connect : 1;	/* server: executing connect_query */
 	bool resetting : 1;		/* server: executing reset query from auth login; don't release on flush */
-	bool copy_mode : 1;		/* server: in copy stream, ignores any Sync packets until CopyDone or CopyFail */
+	bool copy_mode : 1;		/* server: in copy stream, ignores Sync packets until CopyDone/CopyFail;
+					   client: in copy-in stream, expecting CopyData/CopyDone/CopyFail */
 
 	bool wait_for_welcome : 1;	/* client: no server yet in pool, cannot send welcome msg */
 	bool welcome_sent : 1;		/* client: client has been sent the welcome msg */

--- a/src/objects.c
+++ b/src/objects.c
@@ -1320,7 +1320,6 @@ static void unlink_server(PgSocket *server, const char *reason)
 
 	client = server->link;
 
-	client->copy_mode = false;
 	client->link = NULL;
 	server->link = NULL;
 	/*

--- a/src/objects.c
+++ b/src/objects.c
@@ -1214,6 +1214,7 @@ bool release_server(PgSocket *server)
 	case SV_BEING_CANCELED:
 	case SV_ACTIVE:
 		if (server->link) {
+			server->link->copy_mode = false;
 			server->link->link = NULL;
 			server->link = NULL;
 		}
@@ -1319,6 +1320,7 @@ static void unlink_server(PgSocket *server, const char *reason)
 
 	client = server->link;
 
+	client->copy_mode = false;
 	client->link = NULL;
 	server->link = NULL;
 	/*

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -139,6 +139,85 @@ def test_copy_stdout_extended(bouncer):
         conn.pgconn.exit_pipeline_mode()
 
 
+def test_copy_stdin_error_before_copy_done_transaction_pool(bouncer):
+    """Late CopyDone must not create phantom outstanding request in transaction pool mode.
+
+    When the server sends ErrorResponse + ReadyForQuery before the client
+    sends CopyDone (race condition triggered by flush + sleep), the late
+    CopyDone must not be tracked as an outstanding request.  Without the
+    fix, the phantom CopyDone entry in outstanding_requests prevents the
+    server from ever being released: pop_outstanding_request in the
+    ReadyForQuery handler fails to match it (not Query/Sync/FunctionCall),
+    so outstanding_requests never empties and the server stays linked.
+    """
+    bouncer.admin("set default_pool_size=1")
+    bouncer.admin("set query_wait_timeout=5")
+
+    with bouncer.conn(dbname="p3x") as conn:
+        conn.pgconn.send_query(b"COPY test_copy(i) FROM STDIN")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        # Flush and wait so PgBouncer receives ErrorResponse before CopyDone
+        conn.pgconn.flush()
+        time.sleep(1)
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_end()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+
+        # Follow-up query triggers ReadyForQuery which should release the
+        # server.  Without the fix the phantom CopyDone blocks release.
+        conn.pgconn.send_query(b"SELECT 1")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.TUPLES_OK
+        assert conn.pgconn.get_result() is None
+
+        # With pool_size=1, if the server is stuck, this second connection
+        # will fail with query_wait_timeout.
+        bouncer.sql("SELECT 1", dbname="p3x")
+
+
+def test_copy_stdin_error_before_copy_done_in_transaction(bouncer):
+    """Late CopyDone within explicit transaction must not block server release.
+
+    Same race condition as above, but wrapped in BEGIN/ROLLBACK.
+    ReadyForQuery state 'E' keeps the server linked during the error
+    transaction, then the late CopyDone arrives.  After ROLLBACK + a
+    follow-up query, the server should be released.  Without the fix,
+    the phantom CopyDone outstanding request prevents release.
+    """
+    bouncer.admin("set default_pool_size=1")
+    bouncer.admin("set query_wait_timeout=5")
+
+    with bouncer.conn(dbname="p3x") as conn:
+        conn.pgconn.send_query(b"BEGIN")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+
+        conn.pgconn.send_query(b"COPY test_copy(i) FROM STDIN")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        # Send bad row
+        conn.pgconn.put_copy_data(b"\n")
+        conn.pgconn.flush()
+        time.sleep(1)
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COPY_IN
+        conn.pgconn.put_copy_end()
+        assert conn.pgconn.get_result().status == pq.ExecStatus.FATAL_ERROR
+        assert conn.pgconn.get_result() is None
+
+        conn.pgconn.send_query(b"ROLLBACK")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.COMMAND_OK
+        assert conn.pgconn.get_result() is None
+
+        # Follow-up query to trigger server release
+        conn.pgconn.send_query(b"SELECT 1")
+        assert conn.pgconn.get_result().status == pq.ExecStatus.TUPLES_OK
+        assert conn.pgconn.get_result() is None
+
+        # Verify server was released back to the pool
+        bouncer.sql("SELECT 1", dbname="p3x")
+
+
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_copy_stdin_success_prepared(bouncer):
     bouncer.admin(f"set max_prepared_statements=100")


### PR DESCRIPTION
This is a more extensive fix that can be applied instead of https://github.com/pgbouncer/pgbouncer/pull/1470
The main difference is that this also allows COPY to work fine *outside* of an explicit transaction (BEGIN/END) (eg. see some background that this currently doesn't work in https://github.com/pgbouncer/pgbouncer/issues/57)
This is another issue we hit a while ago, which was mitigated by explicitly wrapping the client code in BEGIN/END, but I think it makes more sense if it's just properly supported by pgbouncer.