### PR TITLE
docs(config): clarify default_pool_size parameter

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -126,8 +126,9 @@ Default: 100
 
 ### default_pool_size
 
-How many server connections to allow per user/database pair. Can be overridden in
-the per-database configuration.
+The maximum number of server connections to allow per user/database pair. Can be overridden by
+`pool_size` in the per-database and per-user configuration; this is the default used if no specific
+`pool_size` is specified for a given database or user.
 
 Default: 20
 


### PR DESCRIPTION
make it more obvious that this is a maximum size and that it corresponds to `pool_size` in per-database/per-user settings

Call me an idiot, but I completely missed this because "default pool size" didn't sound like a maximum number of connections to me.  I had only set `max_db_connections = 80`, deployed to production, and was confused why the number of server connections was peaking at 20.

It doesn't help that most per-database/per-user parameters have the same name as the corresponding global parameters, but the global `default_pool_size` is a different name than the per-database or user `pool_size`.