### PR TITLE
[#1478] New implementation for test_shutdown_wait_for_servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(PACKAGE_TARNAME)-$(PACKAGE_VERSION).tar.gz:
 PYTEST = $(shell command -v pytest || echo '$(PYTHON) -m pytest')
 
 CONCURRENCY = auto
-PYTEST_FLAGS = -r s
+PYTEST_FLAGS = -r s -vvv -l
 
 check: all
 	etc/optscan.sh

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2,6 +2,8 @@ import asyncio
 import re
 import threading
 import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import psycopg
 import pytest
@@ -14,6 +16,7 @@ from .utils import (
     PKT_BUF_SIZE,
     USE_UNIX_SOCKETS,
     WINDOWS,
+    wait_until,
 )
 
 
@@ -726,6 +729,139 @@ def test_shutdown_wait_for_servers(bouncer):
 
     with pytest.raises(psycopg.errors.OperationalError):
         bouncer.test(host=socket_directory)
+
+
+@pytest.fixture(
+    params=[pytest.param(x, id="step_timeout_{}".format(x)) for x in range(3)]
+)
+def way4_timeout(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
+@pytest.mark.skipif(
+    "not USE_UNIX_SOCKETS", reason="This test does not apply to non unix sockets"
+)
+def test_shutdown_wait_for_servers_v2(bouncer, way4_timeout: int):
+    """
+    Test that after issuing `SHUTDOWN WAIT_FOR_SERVERS` pgbouncer
+    is no longer accessible via 127.0.0.1 but is still accessible
+    on UNIX socket until the last client leaves the pgbouncer instance.
+    """
+    assert type(way4_timeout) is int
+    assert way4_timeout >= 0
+
+    def LOCAL_sleep(step_id: str):
+        print(
+            "step [{}]. sleep {} sec(s)...".format(
+                step_id,
+                way4_timeout,
+            )
+        )
+        time.sleep(way4_timeout)
+        return
+
+    socket_directory = bouncer.config_dir if LINUX else "/tmp"
+
+    test_dbname = "user_passthrough2"
+    test_user = "postgres"
+
+    signal_table = "tbl_{}".format(uuid.uuid4().bytes.hex())
+
+    print("test table is [{}]".format(signal_table))
+
+    C_TASK_SQL_TEMPL = """DO $$
+DECLARE
+    row_exists boolean;
+    counter int := 0;
+BEGIN
+    /* It is a signal "we are within server" in an autonomous transaction */
+    PERFORM dblink_exec('{0}', 'INSERT INTO {1} (id) VALUES (1);');
+
+    LOOP
+        SELECT t.found INTO row_exists
+        FROM dblink('{0}',
+                    'SELECT EXISTS (SELECT 1 FROM {1} WHERE id = 1)')
+        AS t(found boolean);
+
+        IF NOT row_exists THEN
+            EXIT;
+        END IF;
+
+        counter := counter + 1;
+        IF counter >= 60 THEN
+            RAISE EXCEPTION 'Polling timeout: signal record did not disappear';
+        END IF;
+
+        PERFORM pg_sleep(1);
+    END LOOP;
+END $$;"""
+
+    with ThreadPoolExecutor(max_workers=100) as pool, bouncer.cur(
+        autocommit=True, dbname=test_dbname, user=test_user
+    ) as cur1, bouncer.admin_runner.cur():
+        cur1.execute(
+            "CREATE TABLE {} (id INTEGER NOT NULL PRIMARY KEY);".format(
+                signal_table,
+            )
+        )
+        cur1.execute("CREATE EXTENSION IF NOT EXISTS dblink SCHEMA public;")
+
+        real_db = cur1.execute("SELECT current_database();").fetchall()[0][0]
+        assert real_db == "p2"  # It is so!
+
+        print("Run task1 on conn1")
+        pg_cn_str = "host={} port={} dbname={} user={}".format(
+            bouncer.pg.host,
+            bouncer.pg.port,
+            real_db,
+            test_user,
+        )
+        task_sql = C_TASK_SQL_TEMPL.format(
+            pg_cn_str,
+            signal_table,
+        )
+        q1 = pool.submit(cur1.execute, task_sql)
+
+        with bouncer.pg.cur(autocommit=True, dbname=real_db, user=test_user) as cur2:
+            for _ in wait_until("Did not get signal from conn1", timeout=60):
+                print("Waits for signal from conn1")
+                r = cur2.execute(
+                    "SELECT id FROM {} WHERE id=1;".format(signal_table)
+                ).fetchall()
+                if len(r) == 1:
+                    break
+                continue
+
+        LOCAL_sleep("1")
+        bouncer.admin("SHUTDOWN WAIT_FOR_SERVERS")
+        LOCAL_sleep("2")
+        with pytest.raises(psycopg.errors.OperationalError):
+            bouncer.test(host=bouncer.config_dir)
+        LOCAL_sleep("3")
+        bouncer.admin("SHOW VERSION", host=socket_directory)
+        LOCAL_sleep("4")
+        with pytest.raises(psycopg.errors.OperationalError):
+            bouncer.test(host="127.0.0.1")
+
+        print("stop task1")
+        with bouncer.pg.cur(
+            autocommit=True,
+            dbname=real_db,
+            user=test_user,
+        ) as cur2:
+            cur2.execute("delete from {} where id=1;".format(signal_table))
+
+        print("wait for task1")
+        q1.result()
+        print("task1 finished!")
+
+    # Wait for janitor to close unix socket
+    for _ in wait_until("Bouncer did not exit", timeout=60):
+        try:
+            bouncer.test(host=socket_directory)
+        except psycopg.errors.OperationalError:
+            break  # Success!
+        continue
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This patch adds a new implementation of test_shutdown_wait_for_servers test - test_shutdown_wait_for_servers_v2 that does not have a problem with timeout on a slow systems.

Base idea was gotten from #1448.

Closes #1478 