### PR TITLE
Enable SNI (Server Name Indication) for all TLS modes

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1450,9 +1450,6 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)
 	if (!sbuf_pause(sbuf))
 		return false;
 
-	if (cf_server_tls_sslmode != SSLMODE_VERIFY_FULL)
-		hostname = NULL;
-
 	ctls = tls_client();
 	if (!ctls)
 		return false;


### PR DESCRIPTION
## Description
Previously, SNI was only used when `server_tls_sslmode` was set to `SSLMODE_VERIFY_FULL`. This change enables SNI for all TLS connection modes, allowing proper hostname identification and supporting multi-certificate hosting on single IP addresses.

## Changes
- Remove the `sslmode` condition that prevented SNI from being used in non-VERIFY_FULL modes
- SNI hostname is now always passed to `tls_connect_fds()` regardless of `server_tls_sslmode` setting
- Minimal code change: 3 lines removed from `src/sbuf.c`

## Benefits
- **Security**: Proper hostname identification during TLS handshake enables certificate validation
- **Cloud-native**: Supports multi-certificate hosting scenarios on shared infrastructure
- **No breaking changes**: Backward compatible, no configuration required
- **Zero overhead**: SNI is a standard TLS extension with no performance impact

## Testing
- ✅ Verified with Orthanc + PostgreSQL backend
- ✅ TLSv1.3 connection established successfully (TLS_AES_256_GCM_SHA384)
- ✅ Cross-compiled for Linux x86_64 with Alpine Linux (musl libc)
- ✅ Original dependencies maintained: libevent, openssl

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
Fixes #

## Checklist
- [x] Code follows project style guidelines
- [x] Changes tested and verified
- [x] No new warnings introduced
- [x] Backward compatible