### PR TITLE
fix(ldap): increase max ldap url length

### DIFF
--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -41,7 +41,7 @@
  * Default is 100 milliseconds.
  */
 #define LDAP_QUEUE_WAIT_SLEEP_MCS    (100*1000)
-#define LDAP_LONG_LENGTH 256
+#define LDAP_LONG_LENGTH 1024
 #define MAX_INT_LENGTH 10
 
 struct ldap_auth_request {


### PR DESCRIPTION
In following up on an issue[0] the resolution ended up being to increase the size of `LDAP_LONG_LENGTH` in `src/ldapauth.c`. Looking at the postgres source code for `pg_service.conf` file parsing it allows an LDAP string of 1024 characters.

[0] https://github.com/pgbouncer/pgbouncer/issues/1469
[1] https://github.com/postgres/postgres/blob/786552e7f22315c4103c5404f9c4c6bccc95f8c1/src/interfaces/libpq/fe-connect.c#L6075