### PR TITLE
Fix show user pool size

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -603,8 +603,6 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 	struct List *item;
 	PktBuf *buf = pktbuf_dynamic(256);
 	struct CfValue cv;
-	char pool_size_str[12] = "";
-	char res_pool_size_str[12] = "";
 	const char *pool_mode_str;
 
 	if (!buf) {
@@ -618,6 +616,8 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		"max_user_client_connections", "current_client_connections");
 	statlist_for_each(item, &user_list) {
 		PgGlobalUser *user = container_of(item, PgGlobalUser, head);
+		char pool_size_str[12] = "";
+		char res_pool_size_str[12] = "";
 		if (user->pool_size >= 0)
 			snprintf(pool_size_str, sizeof(pool_size_str), "%9d", user->pool_size);
 		if (user->res_pool_size >= 0)

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -39,6 +39,34 @@ def test_reload_error(bouncer):
         ):
             bouncer.admin("RELOAD")
 
+def test_show_user(bouncer):
+    """
+    Test that admin console correctly raises error during RELOAD
+    when invalid value set for auth_type.
+    """
+    config = f"""
+    [databases]
+    p1 = host={bouncer.pg.host} port={bouncer.pg.port}
+ 
+    [pgbouncer]
+    auth_file = {bouncer.auth_path}
+    auth_type = trust
+    auth_user = postgres
+    listen_addr = {bouncer.host}
+    listen_port = {bouncer.port}
+    admin_users = pgbouncer
+    pool_mode = session
+ 
+    [users]
+    test1 = pool_size=1 reserve_pool_size=1
+    test2 =
+    """
+
+    with bouncer.run_with_config(config):
+        users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
+        users = [user for user in users if user["name"] in ["test1", "test2"]]
+        assert [1, None] == [int(user["pool_size"].strip()) for user in users]
+        assert [1, None] == [int(user["res_pool_size"].strip()) for user in users]
 
 def test_show(bouncer):
     show_items = [

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -39,6 +39,7 @@ def test_reload_error(bouncer):
         ):
             bouncer.admin("RELOAD")
 
+
 def test_show_user(bouncer):
     """
     Test that admin console correctly raises error during RELOAD
@@ -47,7 +48,7 @@ def test_show_user(bouncer):
     config = f"""
     [databases]
     p1 = host={bouncer.pg.host} port={bouncer.pg.port}
- 
+
     [pgbouncer]
     auth_file = {bouncer.auth_path}
     auth_type = trust
@@ -56,7 +57,7 @@ def test_show_user(bouncer):
     listen_port = {bouncer.port}
     admin_users = pgbouncer
     pool_mode = session
- 
+
     [users]
     test1 = pool_size=1 reserve_pool_size=1
     test2 =
@@ -65,8 +66,9 @@ def test_show_user(bouncer):
     with bouncer.run_with_config(config):
         users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
         users = [user for user in users if user["name"] in ["test1", "test2"]]
-        assert [1, None] == [int(user["pool_size"].strip()) for user in users]
-        assert [1, None] == [int(user["res_pool_size"].strip()) for user in users]
+        assert ['1', ''] == [user["pool_size"].lstrip().rstrip() for user in users]
+        assert ['1', ''] == [user["reserve_pool_size"].lstrip().rstrip() for user in users]
+
 
 def test_show(bouncer):
     show_items = [

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -42,8 +42,11 @@ def test_reload_error(bouncer):
 
 def test_show_user(bouncer):
     """
-    Test that admin console correctly raises error during RELOAD
-    when invalid value set for auth_type.
+    Test `SHOW USERS` command.
+
+    Specifically we are trying to fix a bug where pool_size and reserve_pool_size
+    would take its value from the previous row if a pool_size was not set for a later
+    user. In this case test2's pool_size should not be impacted by test1's value.
     """
     config = f"""
     [databases]

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -69,8 +69,10 @@ def test_show_user(bouncer):
     with bouncer.run_with_config(config):
         users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
         users = [user for user in users if user["name"] in ["test1", "test2"]]
-        assert ['1', ''] == [user["pool_size"].lstrip().rstrip() for user in users]
-        assert ['1', ''] == [user["reserve_pool_size"].lstrip().rstrip() for user in users]
+        assert ["1", ""] == [user["pool_size"].lstrip().rstrip() for user in users]
+        assert ["1", ""] == [
+            user["reserve_pool_size"].lstrip().rstrip() for user in users
+        ]
 
 
 def test_show(bouncer):


### PR DESCRIPTION
Forked from https://github.com/pgbouncer/pgbouncer/pull/1326. Seems like the author of this patch is not interested in fixing the issues. Ran into this issue today and would really like to get this fixed.

The added test fails on pgbouncer compiled from current development head but passes with the changes in this patch.


Stdout from pgbouncer compiled against development head for reference
```
/home/ajackson/monorepo/external/public/pgbouncer/repo/fix_show_user_pool_size/test/test_admin.py:72: in test_show_user
    assert ['1', ''] == [user["pool_size"].lstrip().rstrip() for user in users]
E   AssertionError: assert ['1', ''] == ['1', '1']
E
E     At index 1 diff: '' != '1'
E     Use -v to get more diff

```

Fixes #1326 