### PR TITLE
Introduce pool_idle_timeout to clean up inactive pools

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -767,6 +767,17 @@ aspect of that is that their statistics are also forgotten.  [seconds]
 
 Default: 3600.0
 
+### pool_idle_timeout
+
+If a pool (a specific database/user pair) has had no client connections and
+no server connections for this many seconds, it is freed. This is similar to
+`autodb_idle_timeout`, but frees individual pools rather than whole
+automatically created databases. Note that, unlike `server_idle_timeout`
+(which closes idle server connections but keeps the pool around), this frees
+the whole pool, and only once it is completely empty. 0 disables. [seconds]
+
+Default: 60
+
 ### dns_max_ttl
 
 How long DNS lookups can be cached.  The actual DNS TTL is ignored.
@@ -1062,12 +1073,6 @@ be larger than the client-side connection lifetime settings, and only used
 for network problems. [seconds]
 
 Default: 0.0 (disabled)
-
-### pool_idle_timeout
-
-Pools idling longer than this many seconds are closed. 0 disables. [seconds]
-
-Default: 60
 
 ### idle_transaction_timeout
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -774,9 +774,15 @@ no server connections for this many seconds, it is freed. This is similar to
 `autodb_idle_timeout`, but frees individual pools rather than whole
 automatically created databases. Note that, unlike `server_idle_timeout`
 (which closes idle server connections but keeps the pool around), this frees
-the whole pool, and only once it is completely empty. 0 disables. [seconds]
+the whole pool, and only once it is completely empty.
 
-Default: 60
+As with `autodb_idle_timeout`, the negative aspect is that a freed pool's
+statistics are forgotten. Because the per-database totals in `SHOW STATS` are
+the sum over the currently existing pools, freeing a pool makes those totals
+decrease, which monitoring systems may misread as a counter reset. For that
+reason this is disabled by default. 0 disables. [seconds]
+
+Default: 0 (disabled)
 
 ### dns_max_ttl
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -1063,6 +1063,12 @@ for network problems. [seconds]
 
 Default: 0.0 (disabled)
 
+### pool_idle_timeout
+
+Pools idling longer than this many seconds are closed. 0 disables. [seconds]
+
+Default: 60
+
 ### idle_transaction_timeout
 
 If a client has been in "idle in transaction" state longer,

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -313,6 +313,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; in this many seconds.
 ;client_login_timeout = 60
 
+;; Clean pools who have been idling for this many seconds.
+;pool_idle_timeout = 60
+
 ;; Clean automatically created database entries (via "*") if they stay
 ;; unused in this many seconds.
 ;autodb_idle_timeout = 3600

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -313,8 +313,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; in this many seconds.
 ;client_login_timeout = 60
 
-;; Clean pools who have been idling for this many seconds.
-;pool_idle_timeout = 60
+;; Free pools (database/user pairs) that have had no client and no server
+;; connections for this many seconds. Disabled by default because freeing a
+;; pool also forgets its statistics.
+;pool_idle_timeout = 0
 
 ;; Clean automatically created database entries (via "*") if they stay
 ;; unused in this many seconds.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -462,6 +462,7 @@ struct PgPool {
 
 	/* if last connect to server failed, there should be delay before next */
 	usec_t last_connect_time;
+	usec_t last_active_time;
 	bool last_connect_failed : 1;
 	char last_connect_failed_message[100];
 	bool last_login_failed : 1;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -861,6 +861,7 @@ extern usec_t cf_query_timeout;
 extern usec_t cf_query_wait_timeout;
 extern usec_t cf_cancel_wait_timeout;
 extern usec_t cf_client_idle_timeout;
+extern usec_t cf_pool_idle_timeout;
 extern usec_t cf_client_login_timeout;
 extern usec_t cf_idle_transaction_timeout;
 extern usec_t cf_transaction_timeout;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -782,6 +782,21 @@ static void cleanup_inactive_pools(void)
 		if (pool->db->admin)
 			continue;
 
+		/*
+		 * Never reap a forced-user pool that keeps a minimum number of
+		 * server connections around. The janitor proactively (re)creates
+		 * such pools every maintenance round to enforce min_pool_size
+		 * even without clients, so reaping it here just causes a
+		 * kill/recreate churn every round while the backend is
+		 * unreachable (when it is reachable the pool has connected
+		 * servers and isn't considered idle anyway). Non-forced pools
+		 * only maintain min_pool_size while a client is connected, so a
+		 * non-forced pool with no clients and no servers is genuinely
+		 * idle and safe to reap.
+		 */
+		if (pool_min_pool_size(pool) > 0 && pool->db->forced_user_credentials != NULL)
+			continue;
+
 		/* Check if the pool is actually "unused" */
 		if (pool_client_count(pool) == 0 && pool_connected_server_count(pool) == 0) {
 			if ((now - pool->last_active_time) > cf_pool_idle_timeout) {

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -772,10 +772,7 @@ static void cleanup_inactive_pools(void)
 	PgPool *pool;
 	usec_t now = get_cached_time();
 
-	/* Use autodb timeout as a reference if a specific pool timeout isn't defined */
-	usec_t timeout = cf_autodb_idle_timeout;
-
-	if (timeout <= 0)
+	if (cf_pool_idle_timeout <= 0)
 		return;
 
 	statlist_for_each_safe(item, &pool_list, tmp) {
@@ -787,10 +784,9 @@ static void cleanup_inactive_pools(void)
 
 		/* Check if the pool is actually "unused" */
 		if (pool_client_count(pool) == 0 && pool_connected_server_count(pool) == 0) {
-			usec_t now = get_cached_time();
-			/* 10s inactivity */
-			if ((now - pool->last_active_time) / USEC > 10) {
-				log_debug("cleaning up inactive pool for user %s on db %s", pool->user_credentials->name, pool->db->name);
+			if ((now - pool->last_active_time) > cf_pool_idle_timeout) {
+				log_info("cleaning up idle pool for user %s on db %s because: pool idle timeout (age=%" PRIu64 "s)",
+					pool->user_credentials->name, pool->db->name, (now - pool->last_active_time) / USEC);
 				kill_pool(pool);
 			}
 		} else {

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -766,6 +766,40 @@ static void cleanup_inactive_autodatabases(void)
 	}
 }
 
+static void cleanup_inactive_pools(void)
+{
+	struct List *item, *tmp;
+	PgPool *pool;
+	usec_t now = get_cached_time();
+
+	/* Use autodb timeout as a reference if a specific pool timeout isn't defined */
+	usec_t timeout = cf_autodb_idle_timeout;
+
+	if (timeout <= 0)
+		return;
+
+	statlist_for_each_safe(item, &pool_list, tmp) {
+		pool = container_of(item, PgPool, head);
+
+		/* Do not kill admin pools or pools currently in use */
+		if (pool->db->admin)
+			continue;
+
+		/* Check if the pool is actually "unused" */
+		if (pool_client_count(pool) == 0 && pool_connected_server_count(pool) == 0) {
+			usec_t now = get_cached_time();
+			/* 10s inactivity */
+			if ((now - pool->last_active_time) / USEC > 10) {
+				log_debug("cleaning up inactive pool for user %s on db %s", pool->user_credentials->name, pool->db->name);
+				kill_pool(pool);
+			}
+		} else {
+			/* Reset activity timer if it is being used */
+			pool->last_active_time = now;
+		}
+	}
+}
+
 /* full-scale maintenance, done only occasionally */
 static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 {
@@ -834,6 +868,8 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 	}
 
 	cleanup_inactive_autodatabases();
+
+	cleanup_inactive_pools();
 
 	cleanup_client_logins();
 

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -785,8 +785,8 @@ static void cleanup_inactive_pools(void)
 		/* Check if the pool is actually "unused" */
 		if (pool_client_count(pool) == 0 && pool_connected_server_count(pool) == 0) {
 			if ((now - pool->last_active_time) > cf_pool_idle_timeout) {
-				log_info("cleaning up idle pool for user %s on db %s because: pool idle timeout (age=%" PRIu64 "s)",
-					pool->user_credentials->name, pool->db->name, (now - pool->last_active_time) / USEC);
+				log_info("cleaning up idle pool for user %s on db %s because: pool idle timeout (age= %" PRIu64 "s)",
+					 pool->user_credentials->name, pool->db->name, (now - pool->last_active_time) / USEC);
 				kill_pool(pool);
 			}
 		} else {

--- a/src/main.c
+++ b/src/main.c
@@ -315,7 +315,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
 	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
 	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
-	CF_ABS("pool_idle_timeout", CF_TIME_USEC, cf_pool_idle_timeout, 0, "60"),
+	CF_ABS("pool_idle_timeout", CF_TIME_USEC, cf_pool_idle_timeout, 0, "0"),
 	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
 	CF_ABS("query_wait_notify", CF_INT, cf_query_wait_notify, 0, "5"),
 	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),

--- a/src/main.c
+++ b/src/main.c
@@ -167,6 +167,7 @@ usec_t cf_query_wait_timeout;
 usec_t cf_cancel_wait_timeout;
 usec_t cf_client_idle_timeout;
 usec_t cf_client_login_timeout;
+usec_t cf_pool_idle_timeout;
 usec_t cf_idle_transaction_timeout;
 usec_t cf_transaction_timeout;
 usec_t cf_suspend_timeout;
@@ -314,6 +315,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("pidfile", CF_STR, cf_pidfile, CF_NO_RELOAD, ""),
 	CF_ABS("pkt_buf", CF_INT, cf_sbuf_len, CF_NO_RELOAD, "4096"),
 	CF_ABS("pool_mode", CF_LOOKUP(pool_mode_map), cf_pool_mode, 0, "session"),
+	CF_ABS("pool_idle_timeout", CF_TIME_USEC, cf_pool_idle_timeout, 0, "60"),
 	CF_ABS("query_timeout", CF_TIME_USEC, cf_query_timeout, 0, "0"),
 	CF_ABS("query_wait_notify", CF_INT, cf_query_wait_notify, 0, "5"),
 	CF_ABS("query_wait_timeout", CF_TIME_USEC, cf_query_wait_timeout, 0, "120"),

--- a/src/objects.c
+++ b/src/objects.c
@@ -1988,6 +1988,7 @@ force_new:
 	server->connect_time = get_cached_time();
 	statlist_init(&server->canceling_clients, "canceling_clients");
 	pool->last_connect_time = get_cached_time();
+	pool->last_active_time = get_cached_time();
 	change_server_state(server, SV_LOGIN);
 	pool->db->connection_count++;
 	if (pool->user_credentials)
@@ -2080,6 +2081,7 @@ bool finish_client_login(PgSocket *client)
 	client->welcome_sent = true;
 	slog_debug(client, "logged in");
 
+	client->pool->last_active_time = get_cached_time();
 	return true;
 }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -711,6 +711,7 @@ static PgPool *new_pool(PgDatabase *db, PgCredentials *user_credentials)
 
 	pool->user_credentials = user_credentials;
 	pool->db = db;
+	pool->last_active_time = get_cached_time();
 
 	statlist_init(&pool->active_client_list, "active_client_list");
 	statlist_init(&pool->waiting_client_list, "waiting_client_list");

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -546,6 +546,32 @@ def test_pool_idle_timeout(pg, bouncer):
     assert pg.connection_count() == 1
 
 
+def test_pool_idle_timeout_ignores_min_pool_size(pg, bouncer):
+    """A pool configured with min_pool_size must not be reaped by
+    pool_idle_timeout, even when it currently has zero live server
+    connections.
+
+    We use a forced user together with min_pool_size, so the janitor
+    proactively creates the pool and keeps trying to maintain backend
+    connections even without any clients. The backend database does not
+    exist, so every connection attempt fails, which leaves the pool with
+    zero connected servers. On top of that, once a connect fails there is a
+    server_login_retry backoff during which no new connection is launched,
+    so the pool's last_active_time stops getting bumped. Without an
+    exemption for min_pool_size, cleanup_inactive_pools then reaps the pool.
+    """
+    bouncer.write_ini("pool_idle_timeout = 1")
+    bouncer.write_ini(
+        "[databases]\n"
+        "min_pool_size_dead = port=6666 host=127.0.0.1"
+        " dbname=non_existing_pg_db min_pool_size=3 user=pswcheck"
+    )
+    bouncer.admin("reload")
+
+    with bouncer.log_contains(r"cleaning up idle pool.*min_pool_size_dead", times=0):
+        time.sleep(3)
+
+
 async def test_server_login_retry(pg, bouncer):
     bouncer.admin(f"set query_timeout=10")
     bouncer.admin(f"set server_login_retry=3")

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -529,6 +529,23 @@ def test_client_idle_timeout(bouncer):
                 cur.execute("select 1")
 
 
+def test_pool_idle_timeout(pg, bouncer):
+    """Test that the pool closes server connections after being idle."""
+    bouncer.admin("set pool_idle_timeout=1")
+    bouncer.admin("set server_idle_timeout=1")
+
+    bouncer.test()
+    assert pg.connection_count() == 1
+
+    with bouncer.log_contains(r"cleaning up idle pool"):
+        time.sleep(3)
+
+    assert pg.connection_count() == 0
+
+    bouncer.test()
+    assert pg.connection_count() == 1
+
+
 async def test_server_login_retry(pg, bouncer):
     bouncer.admin(f"set query_timeout=10")
     bouncer.admin(f"set server_login_retry=3")

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -537,8 +537,19 @@ def test_pool_idle_timeout(pg, bouncer):
     bouncer.test()
     assert pg.connection_count() == 1
 
+    # The non-admin pool exists after connecting. Column 0 of SHOW POOLS is
+    # the database, and there's always an admin ("pgbouncer") pool.
+    pools_before = bouncer.admin("show pools")
+    print("pools before idle timeout:", pools_before)
+    assert any(row[0] != "pgbouncer" for row in pools_before)
+
     with bouncer.log_contains(r"cleaning up idle pool"):
         time.sleep(3)
+
+    # The idle pool is gone entirely, not just its server connections.
+    pools_after = bouncer.admin("show pools")
+    print("pools after idle timeout:", pools_after)
+    assert all(row[0] == "pgbouncer" for row in pools_after)
 
     assert pg.connection_count() == 0
 


### PR DESCRIPTION
This PR introduces a `cleanup_inactive_pools()` function.

This function is meant to kill pools that don't have active users and haven't had any in some amount of time (currently hardcoded for 10s).

I noticed by using dynamic users that their pools aren't periodically cleaned by pgbouncer (only on restart, but that's quite disruptive), leading to a buildup that'll result in the instance's metrics extraction (with prometheus' pgbouncer exporter) being noticeably slower since it has to traverse an ever larger pool of users.

This is my first contribution, I'm sure there's plenty to be fixed, I'd love to contribute for a fix, if anything just by getting the discussion started.

Perhaps an alternative would be, instead of adding `last_active_time`, relying on PgPool's `last_connect_time` instead, but maybe I'm missing some context as to how that wouldn't be desirable.

Looking forward to hearing from you.