### PR TITLE
tls: propagate real reason when loading cert/key files fails

### DIFF
--- a/lib/usual/tls/tls.c
+++ b/lib/usual/tls/tls.c
@@ -304,11 +304,28 @@ int tls_configure_keypair(struct tls *ctx, SSL_CTX *ssl_ctx,
 	if (keypair->cert_file != NULL) {
 		if (SSL_CTX_use_certificate_chain_file(ssl_ctx,
 						       keypair->cert_file) != 1) {
-			const char *errstr = "unknown error";
+			const char *errstr = NULL;
 			unsigned long err;
+			int save_errno = errno;
 
-			if ((err = ERR_peek_error()) != 0)
-				errstr = ERR_reason_error_string(err);
+			/*
+			 * Prefer an OpenSSL reason string when one is on the
+			 * error queue. When it returns NULL (happens for
+			 * SYS_LIB errors on recent OpenSSL versions) fall back
+			 * to a formatted textual reason via ERR_error_string,
+			 * or, if the failure is at the syscall level (e.g. the
+			 * file does not exist or is unreadable), to strerror.
+			 * This keeps the log actionable instead of printing
+			 * the literal string "(null)" — see pgbouncer#956.
+			 */
+			err = ERR_peek_error();
+			if (err != 0 &&
+			    (errstr = ERR_reason_error_string(err)) == NULL)
+				errstr = ERR_error_string(err, NULL);
+			if (err == 0 && save_errno != 0)
+				errstr = strerror(save_errno);
+			if (errstr == NULL)
+				errstr = "unknown error";
 			tls_set_errorx(ctx, "failed to load certificate file \"%s\": %s",
 				       keypair->cert_file, errstr);
 			goto err;
@@ -317,11 +334,18 @@ int tls_configure_keypair(struct tls *ctx, SSL_CTX *ssl_ctx,
 	if (keypair->key_file != NULL) {
 		if (SSL_CTX_use_PrivateKey_file(ssl_ctx,
 						keypair->key_file, SSL_FILETYPE_PEM) != 1) {
-			const char *errstr = "unknown error";
+			const char *errstr = NULL;
 			unsigned long err;
+			int save_errno = errno;
 
-			if ((err = ERR_peek_error()) != 0)
-				errstr = ERR_reason_error_string(err);
+			err = ERR_peek_error();
+			if (err != 0 &&
+			    (errstr = ERR_reason_error_string(err)) == NULL)
+				errstr = ERR_error_string(err, NULL);
+			if (err == 0 && save_errno != 0)
+				errstr = strerror(save_errno);
+			if (errstr == NULL)
+				errstr = "unknown error";
 			tls_set_errorx(ctx, "failed to load private key file \"%s\": %s",
 				       keypair->key_file, errstr);
 			goto err;


### PR DESCRIPTION
Fixes #956.

## Problem

When `client_tls_cert_file` points at a file pgbouncer cannot read, the log line silently loses the real reason:

```
TLS setup failed: failed to load certificate file "/root/cert.crt": (null)
```

The `(null)` makes it hard for the operator to tell whether the file is missing, has wrong permissions, is malformed PEM, etc.

## Cause

In `lib/usual/tls/tls.c`, the message is formatted from `ERR_reason_error_string(err)`, with two failure modes:

1. On newer OpenSSL releases `SSL_CTX_use_certificate_chain_file()` can surface `fopen()` failures through a SYS_LIB wrapper for which `ERR_reason_error_string()` returns `NULL`. The old code printed the raw `NULL` via `%s`, which most libcs render as `(null)`.
2. If `SSL_CTX_use_certificate_chain_file()` fails *before* any OpenSSL error is queued (typically when `fopen()` itself fails), `ERR_peek_error()` returns `0` and the message kept its placeholder `"unknown error"`, throwing away the much more useful `errno` reason (`No such file or directory`, `Permission denied`, …).

## Fix

Layer three fallbacks, applied symmetrically to the `cert_file` and `key_file` blocks:

1. `ERR_reason_error_string(err)` when non-`NULL`.
2. `ERR_error_string(err, NULL)` when (1) is `NULL` but an OpenSSL error is queued. Always returns a non-`NULL` formatted string.
3. `strerror(errno)` when no OpenSSL error is queued. `errno` is captured into `save_errno` immediately, before any libc call (e.g. inside `tls_set_errorx`) can overwrite it.
4. Literal `"unknown error"` as the last-resort guard.

Now the log line becomes something like:

```
TLS setup failed: failed to load certificate file "/root/cert.crt": No such file or directory
```

## Scope

Minimal, localized change in the two surrounding blocks; no new dependencies (the file already uses `strerror(errno)` elsewhere).