### PR TITLE
Add client address as parameter on auth_query

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -175,6 +175,8 @@ bool sending_auth_query(PgSocket *client)
 
 static void start_auth_query(PgSocket *client, const char *username)
 {
+	char detailsbuf[300];
+	const char *details;
 	int res;
 	PktBuf *buf;
 	const char *auth_query = client->db->auth_query ? client->db->auth_query : cf_auth_query;
@@ -214,7 +216,15 @@ static void start_auth_query(PgSocket *client, const char *username)
 	res = 0;
 	buf = pktbuf_dynamic(512);
 	if (buf) {
-		pktbuf_write_ExtQuery(buf, auth_query, 1, username);
+		/* bind client address if needed in auth_query */
+		if(strstr(auth_query, "$2")) {
+			details = pga_details(&client->remote_addr, detailsbuf, sizeof(detailsbuf));
+			pktbuf_write_ExtQuery(buf, auth_query, 2, username, details);
+		}
+		/* bind only username if client address is not required in the auth_query */
+		else {
+			pktbuf_write_ExtQuery(buf, auth_query, 1, username);
+		}
 		res = pktbuf_send_immediate(buf, client->link);
 		pktbuf_free(buf);
 		/*


### PR DESCRIPTION
  - Allow the `auth_query` to access the client address for authentication.