### PR TITLE
Increase the maximum LDAP URL length

### DIFF
--- a/src/ldapauth.c
+++ b/src/ldapauth.c
@@ -764,7 +764,7 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 {
 	LDAP *ldap;
 	int r;
-	char fulluser[LDAP_LONG_LENGTH];
+	char *fulluser;
 
 	if (!initialize_ldap_options(request, request->client->ldap_options)) {
 		return false;
@@ -890,7 +890,7 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 			ldap_msgfree(search_message);
 			return false;
 		}
-		snprintf(fulluser, LDAP_LONG_LENGTH, "%s", dn);
+		fulluser = strdup(dn);
 
 		ldap_memfree(dn);
 		ldap_msgfree(search_message);
@@ -903,6 +903,7 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 			(void) ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &error);
 			log_warning("could not unbind after searching for user \"%s\" on server \"%s\": %s",
 				    fulluser, request->ldapserver, ldap_err2string(error));
+			free(fulluser);
 			return false;
 		}
 
@@ -911,11 +912,18 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 		 * it with a different username.
 		 */
 		if (InitializeLDAPConnection(request, &ldap) == false) {
+			free(fulluser);
 			/* Error message already sent */
 			return false;
 		}
 	} else {
-		snprintf(fulluser, LDAP_LONG_LENGTH, "%s%s%s",
+		size_t maxlen = strlen(request->username);
+		if (request->ldapprefix)
+			maxlen += strlen(request->ldapprefix);
+		if (request->ldapsuffix)
+			maxlen += strlen(request->ldapsuffix);
+		fulluser = malloc(maxlen + 1);
+		snprintf(fulluser, maxlen + 1, "%s%s%s",
 			 request->ldapprefix ? request->ldapprefix : "",
 			 request->username,
 			 request->ldapsuffix ? request->ldapsuffix : "");
@@ -927,9 +935,11 @@ static bool check_ldap_auth(struct ldap_auth_request *request)
 	if (r != LDAP_SUCCESS) {
 		log_warning("LDAP login failed for user %s on server %s: %s",
 			    fulluser, request->ldapserver, ldap_err2string(r));
+		free(fulluser);
 		return false;
 	}
 
+	free(fulluser);
 	return true;
 }
 

--- a/test/start_openldap_server.sh
+++ b/test/start_openldap_server.sh
@@ -98,6 +98,25 @@ gidNumber: 100
 homeDirectory: /home/ldapuser1
 mail: ldapuser1@example.net
 
+dn: o=йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфыва,dc=example,dc=net
+objectClass: top
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: ExampleCo
+
+dn: uid=ldapuser2,o=йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфыва,dc=example,dc=net
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: ldapuser2
+sn: Lastname2
+givenName: Firstname2
+cn: Second Test User
+displayName: Second Test User
+uidNumber: 102
+gidNumber: 100
+homeDirectory: /home/ldapuser2
+mail: ldapuser2@example.net
 EOF
 
 
@@ -112,3 +131,4 @@ echo ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif -H $ldap_url
 ldapadd -x -w $ldap_rootpw -f $ldap_dir/ldap.ldif
 ldappasswd -x -w $ldap_rootpw -s secret1 'uid=ldapuser1,dc=example,dc=net'
 ldapsearch -x -b "dc=example,dc=net"
+ldappasswd -x -w $ldap_rootpw -s secret2 'uid=ldapuser2,o=йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфывапролджэячсмитьбю-йцукенгшщзхъфыва,dc=example,dc=net'

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1433,6 +1433,13 @@ def test_ldap_auth(bouncer_with_openldap):
     )
     bouncer_with_openldap.admin("reload")
     bouncer_with_openldap.test(user="ldapuser1", password="secret1")
+    # 11 test ldap auth_type with very long dn
+    bouncer_with_openldap.write_ini(f"auth_type = ldap")
+    bouncer_with_openldap.write_ini(
+        f'auth_ldap_options = ldapurl="ldap://127.0.0.1:{openldap.ldap_port}/dc=example,dc=net?uid?sub"'
+    )
+    bouncer_with_openldap.admin("reload")
+    bouncer_with_openldap.test(user="ldapuser2", password="secret2")
 
 
 def test_client_login_count(bouncer):


### PR DESCRIPTION
Currently, pgbouncer [limits](https://github.com/pgbouncer/pgbouncer/blob/fb0aade5a88b8a9775b0ac77d88f071328c0a0fb/src/ldapauth.c#L882-L893) the maximum LDAP URL length to 256 bytes, which can lead to authentication failures with long DNs, especially with Cyrillic characters. However, the similar PostgreSQL code [doesn't have](https://github.com/postgres/postgres/blob/331d829e62dbb08112bb3a2c5770cd10ba0ffccb/src/backend/libpq/auth.c#L2632-L2649) this limitation, and everything works fine there.