### PR TITLE
Fix SCRAM pass-through with stored SCRAM secrets after reconnect

### DIFF
--- a/src/scram.c
+++ b/src/scram.c
@@ -919,7 +919,8 @@ char *build_server_first_message(ScramState *state, PgCredentials *user, const c
 			goto failed;
 	} else {
 		if (user->adhoc_scram_secrets_cached) {
-			state->adhoc = true;
+			if (get_password_type(stored_secret) == PASSWORD_TYPE_PLAINTEXT)
+				state->adhoc = true;
 			state->iterations = user->scram_Iiterations;
 			state->encoded_salt = strdup(user->scram_SaltKey);
 			memcpy(state->StoredKey, user->scram_StoredKey, sizeof(user->scram_StoredKey));

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -345,6 +345,31 @@ def test_scram_cached_adhoc_secrets_after_reconnect(bouncer):
     bouncer.test(dbname="p62", user="scramuser3", password="baz")
 
 
+@pytest.mark.skipif("not PG_SUPPORTS_SCRAM")
+def test_scram_passthrough_after_reconnect(bouncer):
+    """
+    Regression test: SCRAM pass-through with a SCRAM hash in userlist.txt
+    must work after server reconnection.
+
+    The adhoc_scram_secrets_cached flag is set for both plaintext and SCRAM
+    hash passwords, but only plaintext-derived secrets should be marked as
+    adhoc (preventing key saving). With a real SCRAM hash, the extracted
+    ClientKey/ServerKey must be saved for pass-through even on subsequent
+    connections.
+    """
+    bouncer.admin(f"set auth_type='scram-sha-256'")
+    bouncer.admin(f"set pool_mode='transaction'")
+
+    # First connection - parses SCRAM secret, caches it, extracts keys
+    bouncer.test(dbname="p62", user="scramuser1", password="foo")
+
+    # Kill server connections to force reconnection
+    bouncer.admin("reconnect")
+
+    # Second connection - must still work with pass-through keys
+    bouncer.test(dbname="p62", user="scramuser1", password="foo")
+
+
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 def test_auth_dbname_usage(
     bouncer,


### PR DESCRIPTION
The fix in bf06ce1f62a66e1c5b7b89cd9fe873370c1859f9 (https://github.com/pgbouncer/pgbouncer/pull/1432) unconditionally sets state->adhoc = true
when the cached path is hit. This is correct for plaintext passwords
(whose adhoc SCRAM secrets must not be saved for pass-through), but
incorrect for stored SCRAM secrets. When the password in userlist.txt
is a real SCRAM hash, the ClientKey/ServerKey extracted from the client
authentication are valid for server pass-through and must be saved.

Because the adhoc_scram_secrets_cached flag is shared by both plaintext
and SCRAM hash passwords, the second client connection after a server
reconnect incorrectly marks real SCRAM credentials as adhoc, preventing
key saving and causing server login to fail with "password is SCRAM
secret but client authentication did not provide SCRAM keys".

Fix by only setting state->adhoc when the stored password is actually
plaintext. Also add a regression test.

Related to https://github.com/pgbouncer/pgbouncer/pull/1432, https://github.com/pgbouncer/pgbouncer/pull/1338