### PR TITLE
Fix errors pointed out by static analyzer

### DIFF
--- a/src/varcache.c
+++ b/src/varcache.c
@@ -71,8 +71,10 @@ static void init_var_lookup_from_config(const char *cf_track_extra_parameters, i
 		HASH_FIND_STR(lookup_map, var_name, lookup);
 
 		/* If the var name is already on the hash map, do not update its idx */
-		if (lookup != NULL)
+		if (lookup != NULL) {
+			free(var_name);
 			continue;
+		}
 
 		lookup = (struct var_lookup *)malloc(sizeof *lookup);
 		if (lookup == NULL)

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -75,7 +75,12 @@ static void init_var_lookup_from_config(const char *cf_track_extra_parameters, i
 			continue;
 
 		lookup = (struct var_lookup *)malloc(sizeof *lookup);
+		if (lookup == NULL)
+			die("failed to allocate memory in init_var_lookup_from_config");
+
 		lookup->name = strdup(var_name);
+		if (lookup->name == NULL)
+			die("failed to allocate memory in init_var_lookup_from_config");
 
 		lookup->idx = (*num_vars)++;
 		HASH_ADD_KEYPTR(hh, lookup_map, lookup->name, strlen(lookup->name), lookup);
@@ -96,6 +101,9 @@ void init_var_lookup(const char *cf_track_extra_parameters)
 	/* Always add the static list of names for compatibility */
 	for (; names[idx]; idx++) {
 		lookup = (struct var_lookup *)malloc(sizeof *lookup);
+		if (lookup == NULL)
+			die("failed to allocate memory in init_var_lookup_from_config");
+
 		lookup->name = names[idx];
 		lookup->idx = idx;
 		HASH_ADD_KEYPTR(hh, lookup_map, lookup->name, strlen(lookup->name), lookup);


### PR DESCRIPTION
Hi,

A static analyzer found several errors :
1. Potential null pointer dereference (fixed in the first commit)
2. Potential memory leak (fixed in the second commit)

Please, see fixes in this pull request.

***
Comments on the implementation :
`varcache.c` already contains example of out-of-memory handling (see `apply_var` function). I decided to do the same, i.e. just `die`.