### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.cirrus.yml
+.dockerignore
+Dockerfile
+docker-compose.yml
+docs/
+test/
+*.html
+*.xml
+*.gz
+*.swp
+__pycache__/
+env/
+venv/
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    autoconf \
+    automake \
+    libtool \
+    libevent-dev \
+    libssl-dev \
+    libc-ares-dev \
+    python3 \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+WORKDIR /src
+
+RUN ./autogen.sh \
+    && ./configure --prefix=/usr/local --with-cares \
+    && make -j"$(nproc)" \
+    && make install
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libevent-2.1-7 \
+    libssl3 \
+    libc-ares2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r pgbouncer && useradd -r -g pgbouncer -u 1000 pgbouncer \
+    && mkdir -p /etc/pgbouncer \
+    && chown pgbouncer:pgbouncer /etc/pgbouncer
+
+COPY --from=build /usr/local/bin/pgbouncer /usr/local/bin/pgbouncer
+
+USER 1000
+EXPOSE 6432
+
+ENTRYPOINT ["pgbouncer"]
+CMD ["/etc/pgbouncer/pgbouncer.ini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libevent-dev \
     libssl-dev \
     libc-ares-dev \
+    libpam0g-dev \
+    libldap2-dev \
     python3 \
     pandoc \
     && rm -rf /var/lib/apt/lists/*
@@ -17,7 +19,7 @@ COPY . /src
 WORKDIR /src
 
 RUN ./autogen.sh \
-    && ./configure --prefix=/usr/local --with-cares \
+    && ./configure --prefix=/usr/local --with-cares --with-pam --with-ldap \
     && make -j"$(nproc)" \
     && make install
 
@@ -27,6 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libevent-2.1-7 \
     libssl3 \
     libc-ares2 \
+    libpam0g \
+    libldap-2.5-0 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r pgbouncer && useradd -r -g pgbouncer -u 1000 pgbouncer \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  pgbouncer:
+    build: .
+    ports:
+      - "6432:6432"
+    volumes:
+      - ./etc/pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
+      - ./etc/userlist.txt:/etc/pgbouncer/userlist.txt:ro
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
Adds a minimal multi-stage Dockerfile that builds pgbouncer from source.

- Build stage: `debian:bookworm` with autotools
- Runtime stage: `debian:bookworm-slim` (~126MB) with only runtime libs
- Runs as non-root (UID 1000)
- No custom env vars, no entrypoint scripts — users mount their own `pgbouncer.ini`

Also includes `.dockerignore` and an example `docker-compose.yml`.

Relates to #1050 and #1020.

### Usage

```bash
docker build -t pgbouncer .
docker run -v ./my-pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro -p 6432:6432 pgbouncer
```

Running without a config is self-explanatory:

```
$ docker run --rm pgbouncer
ERROR could not load file "/etc/pgbouncer/pgbouncer.ini": No such file or directory
FATAL cannot load config file
```