### PR TITLE
Refactor SCRAM logic for better clarity

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -521,7 +521,7 @@ struct PgCredentials {
 	 */
 	PgGlobalUser *global_user;
 
-	/* scram keys used for pass-through and client scram caching */
+	/* scram keys used for pass-through and verifier caching */
 	uint8_t scram_ClientKey[32];	/* only for pass-through */
 	uint8_t scram_ServerKey[32];	/* used by both verifier caching and pass-through */
 	uint8_t scram_StoredKey[32];	/* only for verifier caching */

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -521,21 +521,33 @@ struct PgCredentials {
 	 */
 	PgGlobalUser *global_user;
 
-	/* scram keys used for pass-though and adhoc auth caching */
-	uint8_t scram_ClientKey[32];
-	uint8_t scram_ServerKey[32];
-	uint8_t scram_StoredKey[32];
-	int scram_Iiterations;
-	char *scram_SaltKey;	/* base64-encoded */
-
-	/* true if ClientKey and ServerKey are valid and scram pass-though is in use. */
-	bool use_scram_keys;
+	/* scram keys used for pass-through and client scram caching */
+	uint8_t scram_ClientKey[32];	/* only for pass-through */
+	uint8_t scram_ServerKey[32];	/* used by both verifier caching and pass-through */
+	uint8_t scram_StoredKey[32];	/* only for verifier caching */
+	int scram_Iiterations;	/* only for verifier caching */
+	char *scram_SaltKey;	/* only for verifier caching, base64-encoded */
 
 	/*
-	 * true if ServerKey, StoredKey, Salt and Iterations is cached for
-	 * adhoc scram authentication.
+	 * true if scram_StoredKey/ServerKey/SaltKey/Iterations hold a cached
+	 * verifier, so clients can be authenticated without re-deriving it on
+	 * every connection. Never set for dynamic_passwd users.
 	 */
-	bool adhoc_scram_secrets_cached;
+	bool scram_verifier_cached;
+
+	/*
+	 * true if the cached verifier was derived adhoc from a plaintext password
+	 * (rather than parsed from a real SCRAM secret). Only meaningful when
+	 * scram_verifier_cached is set. Adhoc keys must NOT be reused as backend
+	 * pass-through keys, since they are not the backend's real credentials.
+	 */
+	bool scram_adhoc;
+
+	/*
+	 * true if scram_ClientKey/ServerKey are valid backend pass-through keys.
+	 * Never set for an adhoc verifier (see scram_adhoc).
+	 */
+	bool scram_passthrough_valid;
 };
 
 /*

--- a/src/admin.c
+++ b/src/admin.c
@@ -358,7 +358,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	if (cf_auth_type == AUTH_TYPE_PAM && !find_global_user(sk->login_user_credentials->name))
 		password = sk->login_user_credentials->passwd;
 
-	if (sk->pool && sk->pool->user_credentials && sk->pool->user_credentials->use_scram_keys)
+	if (sk->pool && sk->pool->user_credentials && sk->pool->user_credentials->scram_passthrough_valid)
 		send_scram_keys = true;
 
 	return send_one_fd(admin, sbuf_socket(&sk->sbuf),

--- a/src/client.c
+++ b/src/client.c
@@ -1355,7 +1355,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 						memcpy(client->pool->user_credentials->scram_ServerKey,
 						       client->scram_state.ServerKey,
 						       sizeof(client->scram_state.ServerKey));
-						client->pool->user_credentials->use_scram_keys = true;
+						client->pool->user_credentials->scram_passthrough_valid = true;
 					}
 
 					free_scram_state(&client->scram_state);

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -982,7 +982,7 @@ static void clean_cached_scram(struct AANode *n, void *arg)
 	if (user->scram_SaltKey != NULL) {
 		free(user->scram_SaltKey);
 		user->scram_SaltKey = NULL;
-		user->adhoc_scram_secrets_cached = false;
+		user->scram_verifier_cached = false;
 	}
 }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -637,11 +637,11 @@ static void unquote_add_authfile_user(const char *username, const char *password
 
 	user->credentials.dynamic_passwd = false;
 
-	/* Clear cached adhoc scram secrets since the user may have changed the password. */
+	/* Clear cached scram secrets since the user may have changed the password. */
 	if (user->credentials.scram_SaltKey != NULL) {
 		free(user->credentials.scram_SaltKey);
 		user->credentials.scram_SaltKey = NULL;
-		user->credentials.adhoc_scram_secrets_cached = false;
+		user->credentials.scram_verifier_cached = false;
 	}
 }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -2344,7 +2344,7 @@ bool use_client_socket(int fd, PgAddr *addr,
 
 		memcpy(credentials->scram_ClientKey, scram_client_key, sizeof(credentials->scram_ClientKey));
 		memcpy(credentials->scram_ServerKey, scram_server_key, sizeof(credentials->scram_ServerKey));
-		credentials->use_scram_keys = true;
+		credentials->scram_passthrough_valid = true;
 	}
 
 	client = accept_client(fd, pga_is_unix(addr));

--- a/src/proto.c
+++ b/src/proto.c
@@ -399,7 +399,7 @@ static bool login_scram_sha_256(PgSocket *server)
 		/* ok */
 		break;
 	case PASSWORD_TYPE_SCRAM_SHA_256:
-		if (!credentials->use_scram_keys) {
+		if (!credentials->scram_passthrough_valid) {
 			slog_error(server, "cannot do SCRAM authentication: password is SCRAM secret but client authentication did not provide SCRAM keys");
 			kill_pool_logins(server->pool, NULL, "server login failed: wrong password type");
 			return false;

--- a/src/scram.c
+++ b/src/scram.c
@@ -491,7 +491,7 @@ static bool calculate_client_proof(PgSocket *server,
 		goto failed;
 	}
 
-	if (credentials->use_scram_keys) {
+	if (credentials->scram_passthrough_valid) {
 		memcpy(ClientKey, credentials->scram_ClientKey, SCRAM_SHA_256_KEY_LEN);
 	} else
 	{
@@ -570,7 +570,7 @@ bool verify_server_signature(PgSocket *server, const PgCredentials *credentials,
 		return false;
 	}
 
-	if (credentials->use_scram_keys) {
+	if (credentials->scram_passthrough_valid) {
 		memcpy(ServerKey, credentials->scram_ServerKey, SCRAM_SHA_256_KEY_LEN);
 	} else
 	{
@@ -918,9 +918,8 @@ char *build_server_first_message(ScramState *state, PgCredentials *user, const c
 		if (!build_mock_scram_secret(user->name, state))
 			goto failed;
 	} else {
-		if (user->adhoc_scram_secrets_cached) {
-			if (get_password_type(stored_secret) == PASSWORD_TYPE_PLAINTEXT)
-				state->adhoc = true;
+		if (user->scram_verifier_cached) {
+			state->adhoc = user->scram_adhoc;
 			state->iterations = user->scram_Iiterations;
 			state->encoded_salt = strdup(user->scram_SaltKey);
 			memcpy(state->StoredKey, user->scram_StoredKey, sizeof(user->scram_StoredKey));
@@ -949,7 +948,8 @@ char *build_server_first_message(ScramState *state, PgCredentials *user, const c
 				user->scram_SaltKey = strdup(state->encoded_salt);
 				memcpy(user->scram_StoredKey, state->StoredKey, sizeof(state->StoredKey));
 				memcpy(user->scram_ServerKey, state->ServerKey, sizeof(state->ServerKey));
-				user->adhoc_scram_secrets_cached = true;
+				user->scram_adhoc = state->adhoc;
+				user->scram_verifier_cached = true;
 			}
 		}
 	}

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -362,10 +362,10 @@ def test_scram_passthrough_after_reconnect(bouncer):
     Regression test: SCRAM pass-through with a SCRAM hash in userlist.txt
     must work after server reconnection.
 
-    The adhoc_scram_secrets_cached flag is set for both plaintext and SCRAM
-    hash passwords, but only plaintext-derived secrets should be marked as
-    adhoc (preventing key saving). With a real SCRAM hash, the extracted
-    ClientKey/ServerKey must be saved for pass-through even on subsequent
+    Verifier secrets are cached for both plaintext and SCRAM hash passwords, but
+    only a plaintext-derived (scram_adhoc) verifier should be prevented from
+    saving pass-through keys. With a real SCRAM hash, the extracted
+    ClientKey/ServerKey must be saved as pass-through keys even on subsequent
     connections.
     """
     bouncer.admin(f"set auth_type='scram-sha-256'")


### PR DESCRIPTION
I needed way to much time to review #1504 for correctness. This refactors the scram caching + passthrough logic a bit and adds a bunch of comments. So hopefully next time it's easier for me (or anyone else) to understand how this code works in different setups.
