### PR TITLE
Implement support for a bounded accept loop

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1087,6 +1087,14 @@ Default: 10
 
 ## Low-level network settings
 
+### accept_batch
+
+Maximum number of client connections to accept from a single listening socket in
+one event loop iteration. 0 means no limit, so PgBouncer accepts connections
+until the accept queue is empty.
+
+Default: 0
+
 ### pkt_buf
 
 Internal buffer size for packets. Affects size of TCP packets sent and general

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -335,6 +335,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; man 2 listen
 ;listen_backlog = 128
 
+;; Max number of client connections to accept in one event loop.
+;; 0 means unlimited.
+;accept_batch = 0
+
 ;; Max number pkt_buf to process in one event loop.
 ;sbuf_loopcnt = 5
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -896,6 +896,7 @@ extern int cf_reboot;
 
 extern unsigned int cf_max_packet_size;
 
+extern int cf_accept_batch;
 extern int cf_sbuf_loopcnt;
 extern int cf_so_reuseport;
 extern int cf_tcp_keepalive;

--- a/src/main.c
+++ b/src/main.c
@@ -94,6 +94,7 @@ char *cf_config_file;
 char *cf_listen_addr;
 int cf_listen_port;
 int cf_listen_backlog;
+int cf_accept_batch;
 char *cf_unix_socket_dir;
 int cf_unix_socket_mode;
 char *cf_unix_socket_group;
@@ -261,6 +262,7 @@ const struct CfLookup load_balance_hosts_map[] = {
  * Add new parameters in alphabetical order. This order is used by SHOW CONFIG.
  */
 static const struct CfKey bouncer_params [] = {
+	CF_ABS("accept_batch", CF_INT, cf_accept_batch, 0, "0"),
 	CF_ABS("admin_users", CF_STR, cf_admin_users, 0, ""),
 	CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
 	CF_ABS("auth_dbname", CF_AUTHDB, cf_auth_dbname, 0, NULL),

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -367,6 +367,7 @@ static void pool_accept(evutil_socket_t sock, short flags, void *arg)
 	} raddr;
 	socklen_t len = sizeof(raddr);
 	bool is_unix = pga_is_unix(&ls->addr);
+	int accepted = 0;
 
 	if (!(flags & EV_READ)) {
 		log_warning("no EV_READ in pool_accept");
@@ -401,6 +402,9 @@ loop:
 
 	if (client)
 		slog_debug(client, "P: got connection: %s", conninfo(client));
+
+	if (cf_accept_batch > 0 && ++accepted >= cf_accept_batch)
+		return;
 
 	/*
 	 * there may be several clients waiting,


### PR DESCRIPTION
The current behavior accepts connections until the accept queue is empty. Under high connection load, that can monopolize the event loop. This new setting lets operators trade faster backlog draining for better event-loop fairness.