### PR TITLE
tls: no-op SSL_CTX_set_ciphersuites on OpenSSL < 1.1.1

### DIFF
--- a/lib/usual/tls/tls_compat.h
+++ b/lib/usual/tls/tls_compat.h
@@ -14,6 +14,16 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+/*
+ * OpenSSL < 1.1.1 has no TLSv1.3 cipher-suite API (and no TLS 1.3 at all),
+ * so SSL_CTX_set_ciphersuites() is undefined there. No-op it to allow
+ * building on e.g. OpenSSL 1.1.0 (Debian 9). Returns 1 (success) so the
+ * caller proceeds; on 1.1.0 there is no TLS 1.3 to configure anyway.
+ */
+#if OPENSSL_VERSION_NUMBER < 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
+#define SSL_CTX_set_ciphersuites(c, s) (1)
+#endif
+
 #include <stdbool.h>
 
 bool get_ecdh_curve_nid(EVP_PKEY *pk, int *nid);


### PR DESCRIPTION
SSL_CTX_set_ciphersuites() (TLSv1.3 cipher-suite API) only exists since OpenSSL 1.1.1. On OpenSSL 1.1.0 (e.g. Debian 9 stretch) the call in tls.c is undefined, breaking the link. Define it as a no-op returning success for OpenSSL < 1.1.1; those versions have no TLS 1.3 to configure anyway, so nothing is lost. Lets PgBouncer build on Debian 9.