### PR TITLE
Handle PasswordMessage packets that are larger than pkt_buf

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -709,6 +709,9 @@ struct PgSocket {
 					   client: in copy-in stream, expecting CopyData/CopyDone/CopyFail */
 
 	bool wait_for_welcome : 1;	/* client: no server yet in pool, cannot send welcome msg */
+	bool startup_message_received : 1;	/* client: the StartupMessage has been processed, so all
+						   following packets use V3 framing instead of the V2
+						   framing the StartupMessage */
 	bool welcome_sent : 1;		/* client: client has been sent the welcome msg */
 	bool protocol_negotiated : 1;	/* client: NegotiateProtocolVersion already sent */
 	bool wait_for_user_conn : 1;	/* client: waiting for auth_conn server connection */

--- a/include/proto.h
+++ b/include/proto.h
@@ -61,7 +61,7 @@ bool welcome_client(PgSocket *client) _MUSTCHECK;
 
 bool answer_authreq(PgSocket *server, PktHdr *pkt) _MUSTCHECK;
 
-bool send_startup_packet(PgSocket *server) _MUSTCHECK;
+bool send_startup_message(PgSocket *server) _MUSTCHECK;
 bool send_sslreq_packet(PgSocket *server) _MUSTCHECK;
 
 int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...) _MUSTCHECK;

--- a/src/client.c
+++ b/src/client.c
@@ -321,6 +321,23 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	int auth;
 	struct HBARule *rule = NULL;
 
+	/*
+	 * Reaching finish_set_pool means the StartupMessage has been fully
+	 * processed and we're moving on to authentication, so every following
+	 * packet from the client uses V3 framing. We track this to pick the
+	 * right header size when reassembling packets too large for pkt_buf.
+	 *
+	 * This is the single convergence point for all the ways a login can
+	 * proceed (directly, deferred while waiting for a server, or resumed
+	 * after an auth_query), so it's the reliable place to record it. It's
+	 * deliberately not set earlier, in the PKT_STARTUP_V3 handling: an
+	 * auth_query bails out of that handling before finish_set_pool and
+	 * leaves the buffered startup packet to be rewound and re-handled once
+	 * the query completes, so setting it there would make that re-handling
+	 * rewind the V2 startup packet as if it were V3.
+	 */
+	client->startup_message_received = true;
+
 	if (!client->login_user_credentials->mock_auth && !client->db->fake) {
 		PgCredentials *pool_user_credentials;
 
@@ -1689,10 +1706,15 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 
 
 /*
- * expect_startup_packet chooses returns true if we expect a startup packet and
- * false if we expect a regular packet.
+ * in_connection_startup_phase returns true while the client is still starting
+ * up its connection, so its packets should be dispatched to
+ * handle_client_startup (which handles both the StartupMessage and the
+ * password/SASL exchange that follows). It returns false once the client is
+ * fully logged in and sending regular queries. This is about which handler to
+ * use, not about the wire framing of the next packet (that is tracked
+ * separately by client->startup_message_received).
  */
-static bool expect_startup_packet(PgSocket *client)
+static bool in_connection_startup_phase(PgSocket *client)
 {
 	switch (client->state) {
 	case CL_LOGIN:
@@ -1718,12 +1740,13 @@ static bool expect_startup_packet(PgSocket *client)
 /* dispatch a fully buffered packet, see process_pkt_callback() */
 static bool client_handle_complete_packet(PgSocket *client, PktHdr *pkt)
 {
-	/* Make sure we start reading after the header. */
-	if (expect_startup_packet(client)) {
+	if (client->startup_message_received)
+		pkt_rewind_v3(pkt);
+	else
 		pkt_rewind_v2(pkt);
+
+	if (in_connection_startup_phase(client))
 		return handle_client_startup(client, pkt);
-	}
-	pkt_rewind_v3(pkt);
 	return handle_client_work(client, pkt);
 }
 
@@ -1793,7 +1816,7 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		}
 
 		client->request_time = get_cached_time();
-		if (expect_startup_packet(client)) {
+		if (in_connection_startup_phase(client)) {
 			res = handle_client_startup(client, &pkt);
 		} else {
 			res = handle_client_work(client, &pkt);

--- a/src/proto.c
+++ b/src/proto.c
@@ -711,7 +711,7 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt)
 	return res;
 }
 
-bool send_startup_packet(PgSocket *server)
+bool send_startup_message(PgSocket *server)
 {
 	PgPool *pool = server->pool;
 	PgDatabase *db = pool->db;

--- a/src/server.c
+++ b/src/server.c
@@ -715,7 +715,7 @@ static bool handle_connect(PgSocket *server)
 				server->wait_sslchar = true;
 		} else {
 			slog_noise(server, "P: startup");
-			res = send_startup_packet(server);
+			res = send_startup_message(server);
 		}
 		if (!res)
 			disconnect_server(server, false, "startup pkt failed");
@@ -754,7 +754,7 @@ static bool handle_sslchar(PgSocket *server, struct MBuf *data)
 		return false;
 	} else {
 		/* proceed with non-TLS connection */
-		ok = send_startup_packet(server);
+		ok = send_startup_message(server);
 	}
 
 	if (ok) {
@@ -920,7 +920,7 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		}
 
 		server->request_time = get_cached_time();
-		res = send_startup_packet(server);
+		res = send_startup_message(server);
 		if (res)
 			sbuf_continue(&server->sbuf);
 		else

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1463,3 +1463,28 @@ def test_client_login_count(bouncer):
     ):
         bouncer.test(dbname="p3", user="puser1", password="wrong")
     assert get_client_login_count() == 3
+
+
+async def test_auth_query_login_large_packets(bouncer):
+    """Login via auth_query works when auth packets exceed the small pkt_buf.
+
+    This is the trickiest variant of the large-packet login path: with
+    auth_query pgbouncer pauses the client after the StartupMessage, runs the
+    query on a server connection, and then resumes and re-processes the same
+    StartupMessage. Shrinking pkt_buf below both the startup and password sizes
+    forces both packets through the dynamic packet buffering path, so it checks
+    that the V2/V3 framing is tracked correctly across that pause/resume. The
+    password itself is fetched from pg_shadow by the auth_query rather than the
+    auth_file.
+    """
+    bouncer.write_ini("auth_type = plain")
+    bouncer.write_ini("auth_user = pswcheck")
+    bouncer.write_ini(
+        "auth_query = SELECT usename, passwd FROM pg_shadow where usename = $1"
+    )
+    bouncer.write_ini("pkt_buf = 75")
+    await bouncer.restart()
+
+    bouncer.test(user="longpass", password=LONG_PASSWORD)
+    with pytest.raises(psycopg.OperationalError, match="authentication failed"):
+        bouncer.test(user="longpass", password="X" + LONG_PASSWORD)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -9,6 +9,7 @@ import pytest
 from .utils import (
     HAVE_IPV6_LOCALHOST,
     LINUX,
+    LONG_PASSWORD,
     PG_MAJOR_VERSION,
     PG_SUPPORTS_SCRAM,
     PKT_BUF_SIZE,
@@ -629,7 +630,7 @@ def test_options_startup_param(bouncer):
     )
 
 
-def test_startup_packet_larger_than_pktbuf(bouncer):
+def test_startup_message_larger_than_pktbuf(bouncer):
     long_string = "1" * PKT_BUF_SIZE
     bouncer.test(options=f"-c extra_float_digits={long_string}")
 


### PR DESCRIPTION
If the password sent over the wire by the client was larger than what
fit in a pkt_buf the message would not be parsed correctly and valid
passwords would be rejected.

Related to #1310
