### PR TITLE
Fix CI again by dowgrading autoconf requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([PgBouncer],
         [https://www.pgbouncer.org/])
 AC_CONFIG_SRCDIR(src/janitor.c)
 AC_CONFIG_HEADERS([lib/usual/config.h])
-AC_PREREQ([2.70])
+AC_PREREQ([2.59])
 
 dnl basic init
 AC_USUAL_INIT

--- a/lib/configure.ac
+++ b/lib/configure.ac
@@ -3,7 +3,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT([libusual],[1.0],[https://libusual.github.io])
 AC_CONFIG_SRCDIR(usual/base.h)
 AC_CONFIG_HEADERS([usual/config.h])
-AC_PREREQ([2.70])
+AC_PREREQ([2.59])
 
 AC_USUAL_INIT
 

--- a/lib/m4/usual.m4
+++ b/lib/m4/usual.m4
@@ -64,11 +64,66 @@ dnl Old name for initial checks
 AC_DEFUN([AC_USUAL_PORT_CHECK], [AC_USUAL_INIT])
 
 dnl
+dnl AC_USUAL_C11:  Make sure the compiler builds in C11 mode.
+dnl
+dnl Autoconf 2.70+ makes AC_PROG_CC select a C11-enabling flag on its own, but
+dnl we still support the Autoconf 2.69 shipped by distributions such as Rocky
+dnl Linux and Debian Bullseye, where AC_PROG_CC leaves the compiler in its
+dnl default (often pre-C11) mode.  So detect the flag ourselves.  We only add a
+dnl -std= flag when the compiler does not already accept C11 by default, to
+dnl avoid overriding a newer default (e.g. gnu17) unnecessarily.
+dnl
+AC_DEFUN([AC_USUAL_C11], [
+AC_MSG_CHECKING([for C11 support])
+ac_usual_c11=no
+for ac_usual_c11_flag in '' '-std=gnu11' '-std=c11'; do
+  ac_usual_c11_save_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $ac_usual_c11_flag"
+  dnl Require a genuine C11 mode, not just the underlying keywords.  GCC
+  dnl accepts _Static_assert/_Alignof/_Generic as extensions even in pre-C11
+  dnl modes (only warning, so a -c compile still succeeds), while glibc gates
+  dnl the <assert.h>/<stdalign.h> macros the code actually uses (static_assert,
+  dnl alignof) on __STDC_VERSION__ >= 201112L.  So key the check off that macro
+  dnl and also exercise the library macros themselves.
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+    [[#include <assert.h>
+      #include <stdalign.h>
+      #if __STDC_VERSION__ < 201112L
+      #error "C11 mode is not enabled"
+      #endif
+      static_assert(1, "static assertions work");
+      _Noreturn void ac_usual_noret(void);
+      _Noreturn void ac_usual_noret(void) { for (;;) {} }]],
+    [[int x = 0;
+      int g = _Generic(x, int: 1, default: 0);
+      int a = (int) alignof(int);
+      return g + a - g - a;]])],
+    [ac_usual_c11=yes])
+  CFLAGS="$ac_usual_c11_save_CFLAGS"
+  if test "$ac_usual_c11" = yes; then
+    test -n "$ac_usual_c11_flag" && CFLAGS="$CFLAGS $ac_usual_c11_flag"
+    break
+  fi
+done
+if test "$ac_usual_c11" = yes; then
+  if test -n "$ac_usual_c11_flag"; then
+    AC_MSG_RESULT([yes ($ac_usual_c11_flag)])
+  else
+    AC_MSG_RESULT([yes])
+  fi
+else
+  AC_MSG_RESULT([no])
+  AC_MSG_ERROR([a C11-capable compiler is required to build this software])
+fi
+])
+
+dnl
 dnl AC_USUAL_PROGRAM_CHECK:  Simple C environment: CC, CPP, INSTALL
 dnl
 AC_DEFUN([AC_USUAL_PROGRAM_CHECK], [
 AC_PROG_CC
 AC_PROG_CPP
+AC_USUAL_C11
 
 dnl Check if linker supports -Wl,--as-needed
 if test "$GCC" = "yes"; then


### PR DESCRIPTION
This was bumped for easy C11 support. Some distros don't have that newer
autoconf version yet though.
