### PR TITLE
Replace multiple requirements.txt files with pyproject.toml based dependencies

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -73,7 +73,7 @@ jobs:
             sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.slapd || true
           fi
           python3 -m venv "$HOME/venv"
-          "$HOME/venv/bin/pip" install -r requirements.txt
+          "$HOME/venv/bin/pip" install .
       - name: Build
         run: |
           set -e
@@ -182,7 +182,7 @@ jobs:
           apt-get update
           apt-get -y --no-install-recommends install autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
           python3 -m venv /venv
-          /venv/bin/pip install -r requirements.txt
+          /venv/bin/pip install .
           # -m creates the home directory; `make install` writes to $HOME, and
           # unlike RHEL's useradd, Debian's doesn't create it by default.
           useradd -m user
@@ -237,7 +237,7 @@ jobs:
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
           if grep -q -F 'release 9' /etc/redhat-release; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
-          python -m pip install -r requirements.txt
+          python -m pip install .
           useradd user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
@@ -294,7 +294,7 @@ jobs:
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
           python3 -m venv /venv
-          /venv/bin/pip install -r requirements.txt
+          /venv/bin/pip install .
           adduser --disabled-password user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
@@ -320,7 +320,7 @@ jobs:
           set -e
           brew install autoconf automake libevent libtool openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
           python3 -m venv venv
-          venv/bin/pip install -r requirements.txt
+          venv/bin/pip install .
           # Allow the test suite to install its packet-filter anchor.
           echo 'anchor "pgbouncer_test/*"' | sudo tee -a /etc/pf.conf
           sudo pfctl -f /etc/pf.conf
@@ -381,7 +381,7 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-python-pip" \
             autoconf automake libtool pkg-config zip
           echo "127.0.0.1   localhost" >> /etc/hosts
-          pip install -r requirements.txt
+          pip install .
       - name: Build
         run: |
           ./autogen.sh
@@ -419,7 +419,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cmake curl gcc g++ git make
-          pip install -r dev_requirements.txt
+          pip install .[dev]
       # `make format-check` compiles uncrustify from source, which takes a
       # while. Cache the resulting binary keyed on the pinned version so it is
       # only rebuilt when we bump UNCRUSTIFY_VERSION in the Makefile.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@
 env
 venv
 .venv
+*.egg-info
+/uv.lock
 
 /uncrustify
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,0 @@
-black
-flake8
-flake8-bugbear
-isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,44 @@
+# PgBouncer itself is a C project; this [project] table exists only so the
+# Python tooling used by the test suite can be declared in one place. There is
+# no importable Python package here: the build backend produces an empty
+# distribution whose sole purpose is to carry the dependency lists below, so
+# `pip install .` installs the test tools and `pip install .[dev]` adds the
+# linters. Keeping them as regular dependencies (rather than PEP 735 dependency
+# groups) means any pip that understands pyproject.toml works — no need for the
+# very recent pip that `pip install --group` requires.
+[project]
+name = "pgbouncer"
+version = "0"
+requires-python = ">=3.9"
+# Needed to run the pytest-based test suite (`make check` / `pytest`).
+dependencies = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-timeout",
+    "pytest-xdist",
+    "psycopg",
+    "filelock",
+]
+
+# Needed for `make format-check` and `make lint`; install with `pip install .[dev]`.
+[project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "flake8-bugbear",
+    "isort",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+# There are no Python modules to ship, so disable setuptools' package
+# auto-discovery, which would otherwise try to package lib/, src/, etc. and
+# fail. The resulting distribution is empty apart from its metadata.
+[tool.setuptools]
+packages = []
+
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=prepend",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pytest
-pytest-asyncio
-pytest-timeout
-pytest-xdist
-psycopg
-filelock
-contextlib2; python_version < "3.7"

--- a/test/README.md
+++ b/test/README.md
@@ -3,16 +3,26 @@ Tests
 
 ## Setting up Python dependencies for testing
 
-To be able to run most of the tests you need to install a few python tools.  To
-do so, you should run the following from the root of the repository:
+To be able to run most of the tests you need a few Python tools. They are
+declared in the `pyproject.toml` at the root of the repository: the main
+dependencies are what the test suite needs, and the optional `dev` extra adds
+the formatters and linters used by `make format-check`/`make lint`. You can
+install them with either `pip` or `uv`.
+
+### Option 1: With `pip`
+
+`pip` is already installed alongside most Python interpreters, so this is the
+simplest option if you don't have `uv` installed yet. Run the following from
+the root of the repository:
 
 ```sh
-pip3 install --user -r requirements.txt
+# Installs the packages globally on your system.
+pip install .
 ```
 
-This will install the packages globally on your system, if you don't want to do
-that (or if tests are still not working after executing the above command) you can use a
-[virtual environment][1] instead:
+Installing globally is often undesirable, so you can use a [virtual
+environment][1] instead:
+
 ```sh
 # create a virtual environment (only needed once)
 python3 -m venv env
@@ -23,11 +33,27 @@ python3 -m venv env
 . env/bin/activate
 
 # Install the dependencies (only needed once, or whenever extra dependencies
-# get added to requirements.txt)
-pip install -r requirements.txt
+# get added to pyproject.toml). Use `.[dev]` to also install the linters.
+pip install .
+```
+
+### Option 2: With `uv`
+
+If you use [uv][2], it creates and manages the virtual environment for you:
+
+```sh
+# Installs the test dependencies into a .venv in the repository root.
+uv sync
+
+# Run the tests through that environment without activating it.
+uv run pytest
+
+# Add the formatters and linters too.
+uv sync --extra dev
 ```
 
 [1]: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
+[2]: https://docs.astral.sh/uv/
 
 
 ## Various ways to test PgBouncer


### PR DESCRIPTION
This is the modern way to define Python dependencies for projects. The primary benefit being that it works well with other dependency install managers than `pip`, such as `uv`.
