### PR TITLE
Use ruff for formatting and linting Python code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-extend-ignore = E203, E265, F401, F541
-max-line-length = 150
-exclude =
-    .git,
-    __pycache__,
-    lib

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ doc/pgbouncer.1 doc/pgbouncer.5:
 	$(MAKE) -C doc $(@F)
 
 lint:
-	flake8
+	ruff check
 
 UNCRUSTIFY_FILES = include/*.h src/*.c test/*.c \
 		lib/test/*.c lib/usual/*.c lib/usual/crypto/*.c lib/usual/hashing/*.c lib/usual/tls/*.c \
@@ -212,8 +212,8 @@ UNCRUSTIFY_FILES = include/*.h src/*.c test/*.c \
 
 format-check: uncrustify
 	git diff-tree --check `git hash-object -t tree /dev/null` HEAD
-	black --check --diff .
-	isort --check --diff .
+	ruff format --check --diff
+	ruff check --select I --diff
 	./uncrustify -c uncrustify.cfg --check -L WARN $(UNCRUSTIFY_FILES)
 
 format: uncrustify
@@ -221,8 +221,8 @@ format: uncrustify
 	$(MAKE) format-python
 
 format-python: uncrustify
-	black .
-	isort .
+	ruff format
+	ruff check --select I --fix
 
 format-c: uncrustify
 	./uncrustify -c uncrustify.cfg --replace --no-backup -L WARN $(UNCRUSTIFY_FILES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,7 @@ dependencies = [
 # Needed for `make format-check` and `make lint`; install with `pip install .[dev]`.
 [project.optional-dependencies]
 dev = [
-    "black",
-    "flake8",
-    "flake8-bugbear",
-    "isort",
+    "ruff",
 ]
 
 [build-system]
@@ -79,5 +76,18 @@ filterwarnings = [
     # https://docs.pytest.org/en/latest/how-to/capture-warnings.html#controlling-warnings
 ]
 
-[tool.isort]
-profile = 'black'
+# ruff replaces black (formatting), isort (import sorting) and flake8 +
+# flake8-bugbear (linting). `make format` runs `ruff format`, `make lint` runs
+# `ruff check`.
+[tool.ruff]
+# lib/ is the vendored libusual C library plus its build helpers; nothing there
+# is ours to format or lint.
+extend-exclude = ["lib"]
+
+[tool.ruff.lint]
+# Ruff's default rules (a subset of pycodestyle E + pyflakes F); "I" adds
+# import sorting, replacing isort.
+extend-select = ["I"]
+# F401 (unused import) and F541 (f-string without placeholders) were ignored
+# under the old flake8 config and the test suite still relies on that.
+ignore = ["F401", "F541"]

--- a/test/README.md
+++ b/test/README.md
@@ -6,8 +6,8 @@ Tests
 To be able to run most of the tests you need a few Python tools. They are
 declared in the `pyproject.toml` at the root of the repository: the main
 dependencies are what the test suite needs, and the optional `dev` extra adds
-the formatters and linters used by `make format-check`/`make lint`. You can
-install them with either `pip` or `uv`.
+`ruff`, which is used for formatting and linting by `make format-check`/`make
+lint`. You can install them with either `pip` or `uv`.
 
 ### Option 1: With `pip`
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -40,7 +40,6 @@ def test_login_notify_message_negative(bouncer):
     """
 
     with bouncer.run_with_config(config):
-
         ret = bouncer.psql(
             query="SELECT 1;", dbname="postgres", user="puser1", password="foo"
         )
@@ -71,7 +70,6 @@ def test_login_notify_message(bouncer):
     """
 
     with bouncer.run_with_config(config):
-
         ret = bouncer.psql(
             query="SELECT 1;", dbname="postgres", user="puser1", password="foo"
         )
@@ -146,7 +144,6 @@ async def test_notify_queue_negative(bouncer):
         notices_received.append(diag.message_primary)
 
     with bouncer.run_with_config(config):
-
         sleep_future = bouncer.asql(
             "SELECT pg_sleep(6)", dbname="postgres", user="puser1"
         )
@@ -203,7 +200,6 @@ async def test_notify_queue(bouncer):
         notices_received.append(diag.message_primary)
 
     with bouncer.run_with_config(config):
-
         sleep_future = bouncer.asql(
             "SELECT pg_sleep(6)", dbname="postgres", user="puser1"
         )

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -62,7 +62,6 @@ async def test_query_wait_timeout(
     bouncer.default_user = "puser1"
 
     with bouncer.run_with_config(pgbouncer_ini):
-
         conn_1_fut = bouncer.asleep(3)
         await asyncio.sleep(0.1)
 


### PR DESCRIPTION
`ruff` is the new kid on the block for linting and formatting in Python. It's faster to run and it's actively being developed.
