### PR TITLE
Meson build support v2

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -178,7 +178,6 @@ jobs:
       matrix:
         include:
           - { name: bookworm, image: debian:bookworm, pgversion: "15" }
-          - { name: bullseye, image: debian:bullseye, pgversion: "13" }
     env:
       PGVERSION: ${{ matrix.pgversion }}
     steps:

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -269,12 +269,12 @@ jobs:
           dnf -y install 'dnf-command(config-manager)'
           # ninja-build (and the -devel packages) live in PowerTools, which is
           # called CRB on EL9; meson itself is in AppStream.
-          if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
+          if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
           dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
           if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf -y install c-ares-devel; fi
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
-          if grep -q -F 'release 9' /etc/redhat-release; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
+          if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
           # Installs the `pytest` console script (with the right python shebang)
           # onto PATH, which meson finds at configure time.
           python -m pip install .

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -190,12 +190,9 @@ jobs:
           apt-get -y --no-install-recommends install gnupg postgresql-common
           /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           apt-get update
-          apt-get -y --no-install-recommends install ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev ninja-build pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
+          apt-get -y --no-install-recommends install ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
           python3 -m venv /venv
           /venv/bin/pip install .
-          # The meson in Debian bullseye predates our meson_version floor, so
-          # install a current meson (and ninja) from PyPI into the venv.
-          /venv/bin/pip install meson ninja
           # -m creates the home directory; `meson install` writes to $HOME, and
           # unlike RHEL's useradd, Debian's doesn't create it by default.
           useradd -m user
@@ -244,7 +241,9 @@ jobs:
           set -e
           dnf -y install 'dnf-command(config-manager)'
           if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "plus"; else dnf config-manager --set-enabled "powertools"; fi
-          dnf -y install diffutils file iptables libevent-devel libpq-devel make openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+          # meson is in AppStream; ninja-build comes from EPEL.
+          dnf -y install epel-release
+          dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
           case "$meson_args" in *cares=enabled*) dnf -y install c-ares-devel;; esac
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
@@ -252,9 +251,6 @@ jobs:
           # Installs the `pytest` console script (with the right python shebang)
           # onto PATH, which meson finds at configure time.
           python -m pip install .
-          # RHEL 8's packaged meson is too old for our meson_version floor, so
-          # install meson and ninja from PyPI.
-          python -m pip install meson ninja
           useradd user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -40,7 +40,9 @@ jobs:
         include:
           - { name: cares-pam-ldap, meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled", dist: "yes" }
           - { name: no-evdns-no-openssl, meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled" }
-          - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes" }
+          # LDAP/PAM each spawn a background thread whose stack valgrind reports
+          # as "possibly lost", so disable them here (they are auto by default).
+          - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes", meson_args: "-Dcares=disabled -Dldap=disabled -Dpam=disabled" }
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
       # Baseline flags mirror the old `--without-cares --with-systemd`; each

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -214,6 +214,53 @@ jobs:
           path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
+  # Debian bullseye ships a meson too old to build PgBouncer, so instead of the
+  # meson job above it exercises the autoconf build here. This doubles as
+  # coverage that the autoconf build keeps working while the two coexist.
+  linux-debian-autoconf:
+    name: Linux Debian (bullseye, autoconf)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/master' ||
+      contains(github.event.pull_request.labels.*.name, 'ci-full')
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bullseye
+    env:
+      PGVERSION: "13"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          set -e
+          apt-get update
+          apt-get -y --no-install-recommends install gnupg postgresql-common
+          /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          apt-get update
+          apt-get -y --no-install-recommends install autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
+          python3 -m venv /venv
+          /venv/bin/pip install .
+          useradd -m user
+          chown -R user .
+          echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+      - name: Build
+        run: |
+          set -e
+          su user -c "./autogen.sh"
+          su user -c "./configure --prefix=\$HOME/install --enable-cassert --enable-werror --without-cares --with-systemd"
+          su user -c "make -j4"
+      - name: Test
+        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH make -j4 check CONCURRENCY=4"
+      - name: Install
+        run: su user -c "make -j4 install"
+      - name: Upload config.log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: config-log-debian-bullseye
+          path: config.log
+          if-no-files-found: ignore
+
   # Red Hat-compatible releases in their official container images. Same
   # build-and-test-as-`user` approach as the Debian job above.
   linux-rhel:

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -42,7 +42,8 @@ jobs:
           - { name: no-evdns-no-openssl, meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled" }
           # LDAP/PAM each spawn a background thread whose stack valgrind reports
           # as "possibly lost", so disable them here (they are auto by default).
-          - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes", meson_args: "-Dcares=disabled -Dldap=disabled -Dpam=disabled" }
+          # c-ares is event-driven (no threads), so exercise it under valgrind.
+          - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes", meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled" }
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
       # Baseline flags mirror the old `--without-cares --with-systemd`; each

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -23,32 +23,50 @@ env:
   DEBIAN_FRONTEND: noninteractive
   LANG: C
 
+# While the meson and autoconf build systems coexist, every platform is built
+# and tested with both. The per-step commands live in ci/run.sh, which takes the
+# build system as an argument; each job passes it in via the `build_system`
+# matrix dimension and provides the matching MESON_ARGS / CONFIGURE_ARGS.
+
 jobs:
   # Builds and tests on native GitHub-hosted Ubuntu runners. These run as the
   # unprivileged `runner` user, so unlike the Cirrus containers there is no
   # need to create a separate user and su into it.
   #
   # `linux-extra` below reuses this job's steps via a YAML anchor and only
-  # differs in its matrix, env and trigger. Matrix entries list only the keys
-  # that differ from the defaults set in `env`.
+  # differs in its matrix, env and trigger.
   linux:
-    name: Linux (${{ matrix.name }})
+    name: Linux (${{ matrix.name }}, ${{ matrix.build_system }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
+        build_system: [meson, autoconf]
+        name: [cares-pam-ldap, no-evdns-no-openssl, valgrind]
         include:
-          - { name: cares-pam-ldap, meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled", dist: "yes" }
-          - { name: no-evdns-no-openssl, meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled" }
+          - name: cares-pam-ldap
+            meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled"
+            configure_args: "--with-cares --with-pam --with-ldap"
+            dist: "yes"
+          - name: no-evdns-no-openssl
+            meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled"
+            configure_args: "--without-cares --disable-evdns --without-openssl"
           # LDAP/PAM each spawn a background thread whose stack valgrind reports
-          # as "possibly lost", so disable them here (they are auto by default).
-          # c-ares is event-driven (no threads), so exercise it under valgrind.
-          - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes", meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled" }
+          # as "possibly lost", so disable them here. c-ares is event-driven (no
+          # threads), so exercise it under valgrind.
+          - name: valgrind
+            pgversion: "18"
+            cflags: "-O0 -g"
+            enable_valgrind: "yes"
+            meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled"
+            configure_args: "--with-cares"
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
-      # Baseline flags mirror the old `--without-cares --with-systemd`; each
-      # matrix entry can override cares/openssl/etc. via meson_args.
-      meson_args: ${{ matrix.meson_args || '-Dcares=disabled' }}
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      # Baseline flags common to every Linux config; each matrix entry adds its
+      # own feature toggles.
+      MESON_ARGS: -Dcassert=true -Dsystemd=enabled ${{ matrix.meson_args }}
+      CONFIGURE_ARGS: --enable-cassert --with-systemd ${{ matrix.configure_args }}
       # CFLAGS_OVERRIDE is exported into the real CFLAGS by the build step only
       # when non-empty, so entries that don't set it keep the default flags.
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
@@ -63,7 +81,7 @@ jobs:
           sudo apt-get -y --no-install-recommends install gnupg postgresql-common
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get update
-          pkgs="ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
+          pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
           if [ "$ENABLE_VALGRIND" = "yes" ]; then pkgs="$pkgs valgrind"; fi
           if [ "$USE_SCAN_BUILD" = "yes" ]; then pkgs="$pkgs clang clang-tools"; fi
           # $pkgs is an intentionally word-split package list.
@@ -85,60 +103,52 @@ jobs:
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
           [ -n "$CFLAGS_OVERRIDE" ] && export CFLAGS="$CFLAGS_OVERRIDE"
-          # scan-build wraps `meson setup` so meson records the analyzer as the
-          # compiler, and `meson compile` so the analysis actually runs.
-          SCANBUILD=""
-          [ "$USE_SCAN_BUILD" = "yes" ] && SCANBUILD="scan-build"
-          # $meson_args and the optional scan-build prefix are meant to
-          # word-split.
-          # shellcheck disable=SC2086
-          $SCANBUILD meson setup build --prefix="$HOME/install" -Dcassert=true --werror -Dsystemd=enabled $meson_args
-          # shellcheck disable=SC2086
-          $SCANBUILD meson compile -C build -v
+          [ "${USE_SCAN_BUILD:-}" = "yes" ] && export SCANBUILD="scan-build"
+          sh ci/run.sh build "$BUILD_SYSTEM"
       - name: Test
         run: |
           set -e
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
-          PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH" meson test -C build -v --print-errorlogs
+          export PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH"
+          sh ci/run.sh test "$BUILD_SYSTEM"
       - name: Install
         run: |
+          set -e
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
-          meson install -C build
+          sh ci/run.sh install "$BUILD_SYSTEM"
       # Verify the dist tarball builds from a clean checkout, like Cirrus did.
-      # `meson dist` re-extracts the tarball and does a fresh build of it; only
-      # needs to run once, so it is gated on the `DIST` flag.
+      # Only needs to run once per build system, so it is gated on `DIST`.
       - name: Build distribution tarball
         if: ${{ env.DIST == 'yes' }}
         run: |
           set -e
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
-          # gztar to match the upload glob below (meson defaults to xztar).
-          meson dist -C build --no-tests --formats gztar
+          sh ci/run.sh dist "$BUILD_SYSTEM"
       - name: Upload tarball
         if: ${{ env.DIST == 'yes' }}
         uses: actions/upload-artifact@v4
         with:
-          name: pgbouncer-tarball
-          path: build/meson-dist/pgbouncer-*.tar.gz
+          name: pgbouncer-tarball-${{ matrix.name }}-${{ matrix.build_system }}
+          path: dist/pgbouncer-*.tar.gz
           if-no-files-found: error
-      - name: Upload meson log
+      - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log-${{ matrix.name }}
-          path: build/meson-logs/meson-log.txt
+          name: logs-${{ matrix.name }}-${{ matrix.build_system }}
+          path: |
+            build/meson-logs/meson-log.txt
+            config.log
           if-no-files-found: ignore
 
   # The native-runner builds Cirrus only ran on manual trigger. Reuses the
   # `linux` job's steps via a YAML anchor. Runs on master, on manual dispatch,
-  # or when a PR carries the `ci-full` label. Matrix entries list only what
-  # differs from the defaults in `env` (all use PG 16 and the baseline meson
-  # args).
+  # or when a PR carries the `ci-full` label.
   linux-extra:
-    name: Linux extra (${{ matrix.name }})
+    name: Linux extra (${{ matrix.name }}, ${{ matrix.build_system }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -147,15 +157,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_system: [meson, autoconf]
+        name: [plain, ubsan, scan-build, arm, ubuntu-2404]
         include:
-          - { name: plain }
-          - { name: ubsan, cflags: "-fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift" }
-          - { name: scan-build, scan_build: "yes" }
-          - { name: arm, runner: ubuntu-24.04-arm }
-          - { name: ubuntu-2404, runner: ubuntu-24.04 }
+          - name: ubsan
+            cflags: "-fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift"
+          - name: scan-build
+            scan_build: "yes"
+          - name: arm
+            runner: ubuntu-24.04-arm
+          - name: ubuntu-2404
+            runner: ubuntu-24.04
     env:
       PGVERSION: "16"
-      meson_args: "-Dcares=disabled"
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dcares=disabled
+      CONFIGURE_ARGS: --enable-cassert --with-systemd --without-cares
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
       USE_SCAN_BUILD: ${{ matrix.scan_build }}
       DIST: ""
@@ -164,8 +181,11 @@ jobs:
   # Debian releases have no native GitHub-hosted runner, so they run in their
   # official container images. Container jobs run as root, where PostgreSQL
   # refuses to initdb, so we build and test as an unprivileged `user`.
+  #
+  # bookworm is built both ways; bullseye's packaged meson (0.56) is below our
+  # floor, so it is autoconf-only (excluded from the meson combination).
   linux-debian:
-    name: Linux Debian (${{ matrix.name }})
+    name: Linux Debian (${{ matrix.name }}, ${{ matrix.build_system }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -176,10 +196,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_system: [meson, autoconf]
+        name: [bookworm, bullseye]
         include:
           - { name: bookworm, image: debian:bookworm, pgversion: "15" }
+          - { name: bullseye, image: debian:bullseye, pgversion: "13" }
+        exclude:
+          - { build_system: meson, name: bullseye }
     env:
       PGVERSION: ${{ matrix.pgversion }}
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dcares=disabled
+      CONFIGURE_ARGS: --enable-cassert --with-systemd --without-cares
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -189,82 +217,34 @@ jobs:
           apt-get -y --no-install-recommends install gnupg postgresql-common
           /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           apt-get update
-          apt-get -y --no-install-recommends install ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
+          apt-get -y --no-install-recommends install autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make meson ninja-build pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
           python3 -m venv /venv
           /venv/bin/pip install .
-          # -m creates the home directory; `meson install` writes to $HOME, and
+          # -m creates the home directory; the install step writes to $HOME, and
           # unlike RHEL's useradd, Debian's doesn't create it by default.
           useradd -m user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
       - name: Build
-        run: |
-          set -e
-          su user -c "PATH=/venv/bin:\$PATH meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=disabled -Dsystemd=enabled"
-          su user -c "PATH=/venv/bin:\$PATH meson compile -C build -v"
+        run: su user -c "MESON_ARGS='$MESON_ARGS' CONFIGURE_ARGS='$CONFIGURE_ARGS' PATH=/venv/bin:\$PATH sh ci/run.sh build $BUILD_SYSTEM"
       - name: Test
-        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH meson test -C build -v --print-errorlogs"
+        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH sh ci/run.sh test $BUILD_SYSTEM"
       - name: Install
-        run: su user -c "PATH=/venv/bin:\$PATH meson install -C build"
-      - name: Upload meson log
+        run: su user -c "PATH=/venv/bin:\$PATH sh ci/run.sh install $BUILD_SYSTEM"
+      - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log-${{ matrix.name }}
-          path: build/meson-logs/meson-log.txt
-          if-no-files-found: ignore
-
-  # Debian bullseye ships a meson too old to build PgBouncer, so instead of the
-  # meson job above it exercises the autoconf build here. This doubles as
-  # coverage that the autoconf build keeps working while the two coexist.
-  linux-debian-autoconf:
-    name: Linux Debian (bullseye, autoconf)
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/master' ||
-      contains(github.event.pull_request.labels.*.name, 'ci-full')
-    runs-on: ubuntu-latest
-    container:
-      image: debian:bullseye
-    env:
-      PGVERSION: "13"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          set -e
-          apt-get update
-          apt-get -y --no-install-recommends install gnupg postgresql-common
-          /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-          apt-get update
-          apt-get -y --no-install-recommends install autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
-          python3 -m venv /venv
-          /venv/bin/pip install .
-          useradd -m user
-          chown -R user .
-          echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-      - name: Build
-        run: |
-          set -e
-          su user -c "./autogen.sh"
-          su user -c "./configure --prefix=\$HOME/install --enable-cassert --enable-werror --without-cares --with-systemd"
-          su user -c "make -j4"
-      - name: Test
-        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH make -j4 check CONCURRENCY=4"
-      - name: Install
-        run: su user -c "make -j4 install"
-      - name: Upload config.log
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: config-log-debian-bullseye
-          path: config.log
+          name: logs-${{ matrix.name }}-${{ matrix.build_system }}
+          path: |
+            build/meson-logs/meson-log.txt
+            config.log
           if-no-files-found: ignore
 
   # Red Hat-compatible releases in their official container images. Same
   # build-and-test-as-`user` approach as the Debian job above.
   linux-rhel:
-    name: Linux Red Hat (${{ matrix.name }})
+    name: Linux Red Hat (${{ matrix.name }}, ${{ matrix.build_system }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -275,11 +255,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_system: [meson, autoconf]
+        name: [rocky-8, rocky-9]
         include:
-          - { name: rocky-9, image: rockylinux:9, meson_args: -Dcares=enabled }
-          - { name: rocky-8, image: rockylinux:8, meson_args: "" }
+          - { name: rocky-9, image: rockylinux:9, meson_args: "-Dcares=enabled", configure_args: "--with-cares" }
+          - { name: rocky-8, image: rockylinux:8, meson_args: "", configure_args: "" }
     env:
-      meson_args: ${{ matrix.meson_args }}
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dldap=enabled -Dpam=enabled ${{ matrix.meson_args }}
+      CONFIGURE_ARGS: --enable-cassert --with-systemd --with-ldap --with-pam ${{ matrix.configure_args }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -289,8 +273,8 @@ jobs:
           # ninja-build (and the -devel packages) live in PowerTools, which is
           # called CRB on EL9; meson itself is in AppStream.
           if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
-          dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
-          case "$meson_args" in *cares=enabled*) dnf -y install c-ares-devel;; esac
+          dnf -y install autoconf automake diffutils file iptables libevent-devel libpq-devel libtool make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+          if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf -y install c-ares-devel; fi
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
           if grep -q -F 'release 9' /etc/redhat-release; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
@@ -301,21 +285,19 @@ jobs:
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
       - name: Build
-        run: |
-          set -e
-          # $meson_args is meant to word-split inside the quoted su command.
-          su user -c "meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dldap=enabled -Dpam=enabled -Dsystemd=enabled $meson_args"
-          su user -c "meson compile -C build -v"
+        run: su user -c "MESON_ARGS='$MESON_ARGS' CONFIGURE_ARGS='$CONFIGURE_ARGS' sh ci/run.sh build $BUILD_SYSTEM"
       - name: Test
-        run: su user -c "meson test -C build -v --print-errorlogs"
+        run: su user -c "sh ci/run.sh test $BUILD_SYSTEM"
       - name: Install
-        run: su user -c "meson install -C build"
-      - name: Upload meson log
+        run: su user -c "sh ci/run.sh install $BUILD_SYSTEM"
+      - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log-${{ matrix.name }}
-          path: build/meson-logs/meson-log.txt
+          name: logs-${{ matrix.name }}-${{ matrix.build_system }}
+          path: |
+            build/meson-logs/meson-log.txt
+            config.log
           if-no-files-found: ignore
 
   # Alpine runs in its official container image. Its musl libc can't run the
@@ -324,7 +306,7 @@ jobs:
   # artifact upload. bash isn't installed on Alpine either, so steps run under
   # POSIX sh.
   linux-alpine:
-    name: Linux (alpine)
+    name: Linux (alpine, ${{ matrix.build_system }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -332,13 +314,21 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: alpine:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_system: [meson, autoconf]
     defaults:
       run:
         shell: sh
+    env:
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      MESON_ARGS: -Dcassert=true -Dcares=enabled -Dldap=enabled -Dsystemd=disabled
+      CONFIGURE_ARGS: --enable-cassert --with-cares --with-ldap
     steps:
       - name: Install dependencies
         run: |
-          apk add --no-cache build-base c-ares-dev git iptables libevent-dev meson ninja openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
+          apk add --no-cache autoconf automake build-base c-ares-dev git iptables libevent-dev libtool meson ninja openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
       - name: Checkout
         run: |
           git config --global --add safe.directory "$PWD"
@@ -357,18 +347,24 @@ jobs:
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
           # /venv/bin on PATH so meson finds pytest at configure time.
-          su user -c "PATH=/venv/bin:\$PATH meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=enabled -Dldap=enabled -Dsystemd=disabled"
-          su user -c "meson compile -C build -v"
-          su user -c "PATH=/venv/bin:\$PATH meson test -C build -v --print-errorlogs"
-          su user -c "meson install -C build"
+          su user -c "MESON_ARGS='$MESON_ARGS' CONFIGURE_ARGS='$CONFIGURE_ARGS' PATH=/venv/bin:\$PATH sh ci/run.sh build $BUILD_SYSTEM"
+          su user -c "PATH=/venv/bin:\$PATH sh ci/run.sh test $BUILD_SYSTEM"
+          su user -c "PATH=/venv/bin:\$PATH sh ci/run.sh install $BUILD_SYSTEM"
 
   macos:
-    name: macOS
+    name: macOS (${{ matrix.build_system }})
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        build_system: [meson, autoconf]
     env:
       HAVE_IPV6_LOCALHOST: "yes"
       USE_SUDO: "true"
       PGVERSION: "16"
+      BUILD_SYSTEM: ${{ matrix.build_system }}
+      MESON_ARGS: -Dldap=enabled
+      CONFIGURE_ARGS: --with-ldap
       # openldap and openssl@3 are keg-only, so point the compiler and
       # pkg-config at their Homebrew prefixes.
       CPPFLAGS: -I/opt/homebrew/opt/openldap/include -I/opt/homebrew/opt/openssl@3/include
@@ -379,7 +375,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -e
-          brew install libevent meson ninja openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
+          brew install autoconf automake libevent libtool meson ninja openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
           python3 -m venv venv
           venv/bin/pip install .
           # Allow the test suite to install its packet-filter anchor.
@@ -391,31 +387,37 @@ jobs:
           # shellcheck disable=SC1091
           source venv/bin/activate   # so meson finds pytest at configure time
           export PATH="/opt/homebrew/opt/postgresql@$PGVERSION/bin:$PATH"
-          meson setup build --prefix="$HOME/install" --werror -Dldap=enabled
-          meson compile -C build -v
+          sh ci/run.sh build "$BUILD_SYSTEM"
       - name: Test
         run: |
           set -e
           # shellcheck disable=SC1091
           source venv/bin/activate
           export PATH="/opt/homebrew/opt/postgresql@$PGVERSION/bin:$PATH"
-          meson test -C build -v --print-errorlogs
+          sh ci/run.sh test "$BUILD_SYSTEM"
       - name: Install
-        run: meson install -C build
-      - name: Upload meson log
+        run: sh ci/run.sh install "$BUILD_SYSTEM"
+      - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log-macos
-          path: build/meson-logs/meson-log.txt
+          name: logs-macos-${{ matrix.build_system }}
+          path: |
+            build/meson-logs/meson-log.txt
+            config.log
           if-no-files-found: ignore
 
   windows:
-    name: Windows
+    name: Windows (${{ matrix.build_system }})
     runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        build_system: [meson, autoconf]
     env:
       HAVE_IPV6_LOCALHOST: "yes"
       MSYSTEM: MINGW64
+      BUILD_SYSTEM: ${{ matrix.build_system }}
       # Without this the MSYS2 login shell starts in the home directory; we want
       # it to stay in the checkout directory.
       CHERE_INVOKING: "1"
@@ -437,7 +439,7 @@ jobs:
         run: Add-Content c:\Windows\System32\Drivers\etc\hosts "127.0.0.1 localhost"
       - name: Install MSYS2 packages
         run: |
-          pacman -S --noconfirm --needed base-devel \
+          pacman -S --noconfirm --needed autoconf automake base-devel libtool \
             "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-libevent" \
             "${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-postgresql" \
             "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-python-pip" \
@@ -445,31 +447,41 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-pkgconf" zip
           echo "127.0.0.1   localhost" >> /etc/hosts
           pip install --break-system-packages .
+      # The autoconf build needs static linking and a couple of extra Windows
+      # libraries passed through configure, which don't fit ci/run.sh's simple
+      # arg model, so it is spelled out here; meson goes through the script.
       - name: Build
         run: |
           export PATH="/c/programdata/chocolatey/bin:$PATH"
-          meson setup build --prefix="$(pwd)/install" --werror -Dsystemd=disabled -Dc_link_args=-static
-          meson compile -C build -v
+          if [ "$BUILD_SYSTEM" = meson ]; then
+            PREFIX="$(pwd)/install" MESON_ARGS="-Dsystemd=disabled -Dc_link_args=-static" sh ci/run.sh build meson
+          else
+            ./autogen.sh
+            ./configure --prefix="$(pwd)/install" --enable-werror PANDOC=/c/programdata/chocolatey/bin/pandoc LDFLAGS=-static "LIBS=-liphlpapi $(pkgconf --libs --static openssl)" PKG_CONFIG='pkg-config --static'
+            make -j4
+          fi
       - name: Test
-        run: meson test -C build -v --print-errorlogs
+        run: CONCURRENCY=3 sh ci/run.sh test "$BUILD_SYSTEM"
       - name: Install
-        run: meson install -C build
+        run: sh ci/run.sh install "$BUILD_SYSTEM"
       - name: Build zip
         run: |
           cd install
-          zip -r "../pgbouncer-windows.zip" .
+          zip -r "../pgbouncer-windows-$BUILD_SYSTEM.zip" .
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
-          name: pgbouncer-windows-zip
-          path: pgbouncer-*.zip
+          name: pgbouncer-windows-${{ matrix.build_system }}
+          path: pgbouncer-windows-*.zip
           if-no-files-found: error
-      - name: Upload meson log
+      - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: meson-log-windows
-          path: build/meson-logs/meson-log.txt
+          name: logs-windows-${{ matrix.build_system }}
+          path: |
+            build/meson-logs/meson-log.txt
+            config.log
           if-no-files-found: ignore
 
   format-check:

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -42,27 +42,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [cares-pam-ldap, no-evdns-no-openssl, valgrind]
         include:
-          - name: cares-pam-ldap
-            meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled"
+          # Keep the autoconf build exercised (while both build systems coexist)
+          # on the same stock Ubuntu runner rather than a separate distro. This
+          # also produces the release dist tarball, which (unlike meson's) bundles
+          # the generated `configure` so it can be built without autoconf tools.
+          - name: autoconf
+            build_system: autoconf
+            configure_args: "--with-cares --with-pam --with-ldap"
             dist: "yes"
+          - name: cares-pam-ldap
+            build_system: meson
+            meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled"
           - name: no-evdns-no-openssl
+            build_system: meson
             meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled"
           # LDAP/PAM each spawn a background thread whose stack valgrind reports
           # as "possibly lost", so disable them here. c-ares is event-driven (no
           # threads), so exercise it under valgrind.
           - name: valgrind
+            build_system: meson
             pgversion: "18"
             cflags: "-O0 -g"
             enable_valgrind: "yes"
             meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled"
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
-      BUILD_SYSTEM: meson
+      BUILD_SYSTEM: ${{ matrix.build_system }}
       # Baseline flags common to every Linux config; each matrix entry adds its
       # own feature toggles.
       MESON_ARGS: -Dcassert=true -Dsystemd=enabled ${{ matrix.meson_args }}
+      CONFIGURE_ARGS: --enable-cassert --with-systemd ${{ matrix.configure_args }}
       # CFLAGS_OVERRIDE is exported into the real CFLAGS by the build step only
       # when non-empty, so entries that don't set it keep the default flags.
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
@@ -77,7 +87,7 @@ jobs:
           sudo apt-get -y --no-install-recommends install gnupg postgresql-common
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get update
-          pkgs="ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
+          pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
           if [ "$ENABLE_VALGRIND" = "yes" ]; then pkgs="$pkgs valgrind"; fi
           if [ "$USE_SCAN_BUILD" = "yes" ]; then pkgs="$pkgs clang clang-tools"; fi
           # $pkgs is an intentionally word-split package list.
@@ -232,10 +242,9 @@ jobs:
           if-no-files-found: ignore
 
   # Red Hat-compatible releases in their official container images. Same
-  # build-and-test-as-`user` approach as the Debian job above. rocky-8 is built
-  # both ways (meson and autoconf); rocky-9 with meson.
+  # build-and-test-as-`user` approach as the Debian job above. Built with meson.
   linux-rhel:
-    name: Linux Red Hat (${{ matrix.name }}, ${{ matrix.build_system }})
+    name: Linux Red Hat (${{ matrix.name }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -247,13 +256,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: rocky-8, image: rockylinux:8, build_system: meson }
-          - { name: rocky-8, image: rockylinux:8, build_system: autoconf }
-          - { name: rocky-9, image: rockylinux:9, build_system: meson, meson_args: "-Dcares=enabled", configure_args: "--with-cares" }
+          - { name: rocky-8, image: rockylinux:8 }
+          - { name: rocky-9, image: rockylinux:9, meson_args: "-Dcares=enabled" }
     env:
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dldap=enabled -Dpam=enabled ${{ matrix.meson_args }}
-      CONFIGURE_ARGS: --enable-cassert --with-systemd --with-ldap --with-pam ${{ matrix.configure_args }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -263,7 +270,7 @@ jobs:
           # ninja-build (and the -devel packages) live in PowerTools, which is
           # called CRB on EL9; meson itself is in AppStream.
           if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
-          dnf -y install autoconf automake diffutils file iptables libevent-devel libpq-devel libtool make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+          dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
           if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf -y install c-ares-devel; fi
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
@@ -284,7 +291,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.name }}-${{ matrix.build_system }}
+          name: logs-${{ matrix.name }}
           path: |
             build/meson-logs/meson-log.txt
             config.log

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -24,10 +24,11 @@ env:
   LANG: C
 
 # Platforms build with meson. The autoconf build still coexists and is kept
-# exercised on two representative container jobs (Debian bullseye, whose packaged
-# meson is too old, and RHEL 8, which also gets a meson build). The per-step
-# commands live in ci/run.sh, which takes the build system as an argument, so
-# both are driven the same way.
+# exercised on two jobs: the `autoconf` entry in the `linux` matrix (a stock
+# Ubuntu runner, which also produces the dist tarball) and the Debian bullseye
+# container, whose packaged meson is too old. The per-step commands live in
+# ci/run.sh, which takes the build system as an argument, so both are driven
+# the same way.
 
 jobs:
   # Builds and tests on native GitHub-hosted Ubuntu runners. These run as the

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -163,8 +163,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [plain, ubsan, scan-build, arm, ubuntu-2404]
         include:
+          - name: plain
           - name: ubsan
             cflags: "-fno-sanitize-recover=all -fsanitize=undefined -fsanitize-address-use-after-scope -fno-sanitize=shift"
           - name: scan-build

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -432,11 +432,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake curl gcc g++ git make
+          sudo apt-get install -y --no-install-recommends cmake curl gcc g++ git
           pip install .[dev]
-      # `make format-check` compiles uncrustify from source, which takes a
-      # while. Cache the resulting binary keyed on the pinned version so it is
-      # only rebuilt when we bump UNCRUSTIFY_VERSION in the Makefile.
+      # dev/format.sh compiles uncrustify from source, which takes a while.
+      # Cache the resulting binary keyed on the pinned version so it is only
+      # rebuilt when we bump UNCRUSTIFY_VERSION in the script.
       - name: Cache uncrustify
         uses: actions/cache@v4
         with:
@@ -444,6 +444,5 @@ jobs:
           key: uncrustify-0.77.1-${{ runner.os }}
       - name: Run checks
         run: |
-          touch config.mak # Pretend that ./configure has run
-          make format-check
-          make lint
+          dev/format.sh check
+          dev/format.sh lint

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -270,7 +270,10 @@ jobs:
           # ninja-build (and the -devel packages) live in PowerTools, which is
           # called CRB on EL9; meson itself is in AppStream.
           if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
-          dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+          # RHEL 9 dropped the OpenLDAP server; Rocky rebuilds openldap-servers
+          # in their "plus" repo.
+          if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf config-manager --set-enabled "plus"; fi
+          dnf -y install diffutils file gcc iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
           if [ "${{ matrix.name }}" = "rocky-9" ]; then dnf -y install c-ares-devel; fi
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -245,6 +245,8 @@ jobs:
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
           if grep -q -F 'release 9' /etc/redhat-release; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
+          # Installs the `pytest` console script (with the right python shebang)
+          # onto PATH, which meson finds at configure time.
           python -m pip install .
           # RHEL 8's packaged meson is too old for our meson_version floor, so
           # install meson and ninja from PyPI.
@@ -308,7 +310,8 @@ jobs:
           adduser --disabled-password user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-          su user -c "meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=enabled -Dldap=enabled -Dsystemd=disabled"
+          # /venv/bin on PATH so meson finds pytest at configure time.
+          su user -c "PATH=/venv/bin:\$PATH meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=enabled -Dldap=enabled -Dsystemd=disabled"
           su user -c "meson compile -C build -v"
           su user -c "PATH=/venv/bin:\$PATH meson test -C build -v --print-errorlogs"
           su user -c "meson install -C build"
@@ -339,6 +342,8 @@ jobs:
       - name: Build
         run: |
           set -e
+          # shellcheck disable=SC1091
+          source venv/bin/activate   # so meson finds pytest at configure time
           export PATH="/opt/homebrew/opt/postgresql@$PGVERSION/bin:$PATH"
           meson setup build --prefix="$HOME/install" --werror -Dldap=enabled
           meson compile -C build -v

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -38,14 +38,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: cares-pam-ldap, configure_args: "--with-cares --with-pam --with-ldap", dist: "yes" }
-          - { name: no-evdns-no-openssl, configure_args: "--disable-evdns --without-openssl" }
+          - { name: cares-pam-ldap, meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled", dist: "yes" }
+          - { name: no-evdns-no-openssl, meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled" }
           - { name: valgrind, pgversion: "18", cflags: "-O0 -g", enable_valgrind: "yes" }
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
-      configure_args: ${{ matrix.configure_args }}
+      # Baseline flags mirror the old `--without-cares --with-systemd`; each
+      # matrix entry can override cares/openssl/etc. via meson_args.
+      meson_args: ${{ matrix.meson_args || '-Dcares=disabled' }}
       # CFLAGS_OVERRIDE is exported into the real CFLAGS by the build step only
-      # when non-empty, so entries that don't set it keep configure's defaults.
+      # when non-empty, so entries that don't set it keep the default flags.
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
       ENABLE_VALGRIND: ${{ matrix.enable_valgrind }}
       DIST: ${{ matrix.dist }}
@@ -58,7 +60,7 @@ jobs:
           sudo apt-get -y --no-install-recommends install gnupg postgresql-common
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get update
-          pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
+          pkgs="ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
           if [ "$ENABLE_VALGRIND" = "yes" ]; then pkgs="$pkgs valgrind"; fi
           if [ "$USE_SCAN_BUILD" = "yes" ]; then pkgs="$pkgs clang clang-tools"; fi
           # $pkgs is an intentionally word-split package list.
@@ -77,55 +79,59 @@ jobs:
       - name: Build
         run: |
           set -e
+          # shellcheck disable=SC1091
+          source "$HOME/venv/bin/activate"
           [ -n "$CFLAGS_OVERRIDE" ] && export CFLAGS="$CFLAGS_OVERRIDE"
-          ./autogen.sh
-          # $configure_args and the optional scan-build prefix are meant to
+          # scan-build wraps `meson setup` so meson records the analyzer as the
+          # compiler, and `meson compile` so the analysis actually runs.
+          SCANBUILD=""
+          [ "$USE_SCAN_BUILD" = "yes" ] && SCANBUILD="scan-build"
+          # $meson_args and the optional scan-build prefix are meant to
           # word-split.
           # shellcheck disable=SC2086
-          ${USE_SCAN_BUILD:+scan-build} ./configure --prefix="$HOME/install" --enable-cassert --enable-werror --without-cares --with-systemd $configure_args
+          $SCANBUILD meson setup build --prefix="$HOME/install" -Dcassert=true --werror -Dsystemd=enabled $meson_args
           # shellcheck disable=SC2086
-          ${USE_SCAN_BUILD:+scan-build} make -j4
+          $SCANBUILD meson compile -C build -v
       - name: Test
         run: |
           set -e
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
-          PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH" make -j4 check CONCURRENCY=4
+          PATH="/usr/lib/postgresql/$PGVERSION/bin:$PATH" meson test -C build -v --print-errorlogs
       - name: Install
-        run: make -j4 install
+        run: |
+          # shellcheck disable=SC1091
+          source "$HOME/venv/bin/activate"
+          meson install -C build
       # Verify the dist tarball builds from a clean checkout, like Cirrus did.
-      # Only needs to run once, so it is gated on the `DIST` flag.
+      # `meson dist` re-extracts the tarball and does a fresh build of it; only
+      # needs to run once, so it is gated on the `DIST` flag.
       - name: Build distribution tarball
         if: ${{ env.DIST == 'yes' }}
         run: |
           set -e
-          make dist
-          PACKAGE_VERSION=$(sed -n 's/PACKAGE_VERSION = //p' config.mak)
-          tar -x -v -f "pgbouncer-${PACKAGE_VERSION}.tar.gz"
-          cd "pgbouncer-${PACKAGE_VERSION}/"
-          # shellcheck disable=SC2086
-          ./configure --prefix="$HOME/install2" --enable-werror --without-cares $configure_args
-          make -j4
-          make -j4 install
+          # shellcheck disable=SC1091
+          source "$HOME/venv/bin/activate"
+          meson dist -C build --no-tests
       - name: Upload tarball
         if: ${{ env.DIST == 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: pgbouncer-tarball
-          path: pgbouncer-*.tar.gz
+          path: build/meson-dist/pgbouncer-*.tar.gz
           if-no-files-found: error
-      - name: Upload config.log
+      - name: Upload meson log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: config-log-${{ matrix.name }}
-          path: config.log
+          name: meson-log-${{ matrix.name }}
+          path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
   # The native-runner builds Cirrus only ran on manual trigger. Reuses the
   # `linux` job's steps via a YAML anchor. Runs on master, on manual dispatch,
   # or when a PR carries the `ci-full` label. Matrix entries list only what
-  # differs from the defaults in `env` (all use PG 16 and the baseline configure
+  # differs from the defaults in `env` (all use PG 16 and the baseline meson
   # args).
   linux-extra:
     name: Linux extra (${{ matrix.name }})
@@ -145,7 +151,7 @@ jobs:
           - { name: ubuntu-2404, runner: ubuntu-24.04 }
     env:
       PGVERSION: "16"
-      configure_args: ""
+      meson_args: "-Dcares=disabled"
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
       USE_SCAN_BUILD: ${{ matrix.scan_build }}
       DIST: ""
@@ -180,10 +186,13 @@ jobs:
           apt-get -y --no-install-recommends install gnupg postgresql-common
           /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           apt-get update
-          apt-get -y --no-install-recommends install autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
+          apt-get -y --no-install-recommends install ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev ninja-build pandoc pkg-config "postgresql-$PGVERSION" python3 python3-pip python3-venv slapd socat sudo
           python3 -m venv /venv
           /venv/bin/pip install .
-          # -m creates the home directory; `make install` writes to $HOME, and
+          # The meson in Debian bullseye predates our meson_version floor, so
+          # install a current meson (and ninja) from PyPI into the venv.
+          /venv/bin/pip install meson ninja
+          # -m creates the home directory; `meson install` writes to $HOME, and
           # unlike RHEL's useradd, Debian's doesn't create it by default.
           useradd -m user
           chown -R user .
@@ -191,19 +200,18 @@ jobs:
       - name: Build
         run: |
           set -e
-          su user -c "./autogen.sh"
-          su user -c "./configure --prefix=\$HOME/install --enable-cassert --enable-werror --without-cares --with-systemd"
-          su user -c "make -j4"
+          su user -c "PATH=/venv/bin:\$PATH meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=disabled -Dsystemd=enabled"
+          su user -c "PATH=/venv/bin:\$PATH meson compile -C build -v"
       - name: Test
-        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH make -j4 check CONCURRENCY=4"
+        run: su user -c "PATH=/usr/lib/postgresql/$PGVERSION/bin:/venv/bin:\$PATH meson test -C build -v --print-errorlogs"
       - name: Install
-        run: su user -c "make -j4 install"
-      - name: Upload config.log
+        run: su user -c "PATH=/venv/bin:\$PATH meson install -C build"
+      - name: Upload meson log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: config-log-${{ matrix.name }}
-          path: config.log
+          name: meson-log-${{ matrix.name }}
+          path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
   # Red Hat-compatible releases in their official container images. Same
@@ -221,10 +229,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: rocky-9, image: rockylinux:9, configure_args: --with-cares }
-          - { name: rocky-8, image: rockylinux:8 }
+          - { name: rocky-9, image: rockylinux:9, meson_args: -Dcares=enabled }
+          - { name: rocky-8, image: rockylinux:8, meson_args: "" }
     env:
-      configure_args: ${{ matrix.configure_args }}
+      meson_args: ${{ matrix.meson_args }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -232,32 +240,34 @@ jobs:
           set -e
           dnf -y install 'dnf-command(config-manager)'
           if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "plus"; else dnf config-manager --set-enabled "powertools"; fi
-          dnf -y install autoconf automake diffutils file iptables libevent-devel libpq-devel libtool make openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
-          case "$configure_args" in *with-cares*) dnf -y install c-ares-devel;; esac
+          dnf -y install diffutils file iptables libevent-devel libpq-devel make openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
+          case "$meson_args" in *cares=enabled*) dnf -y install c-ares-devel;; esac
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz
           tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/
           if grep -q -F 'release 9' /etc/redhat-release; then dnf -y install python-unversioned-command; else dnf -y install python39 python39-pip && alternatives --set python /usr/bin/python3.9; fi
           python -m pip install .
+          # RHEL 8's packaged meson is too old for our meson_version floor, so
+          # install meson and ninja from PyPI.
+          python -m pip install meson ninja
           useradd user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
       - name: Build
         run: |
           set -e
-          su user -c "./autogen.sh"
-          # $configure_args is meant to word-split inside the quoted su command.
-          su user -c "./configure --prefix=\$HOME/install --enable-cassert --enable-werror --with-ldap --with-pam --with-systemd $configure_args"
-          su user -c "make -j4"
+          # $meson_args is meant to word-split inside the quoted su command.
+          su user -c "meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dldap=enabled -Dpam=enabled -Dsystemd=enabled $meson_args"
+          su user -c "meson compile -C build -v"
       - name: Test
-        run: su user -c "make -j4 check CONCURRENCY=4"
+        run: su user -c "meson test -C build -v --print-errorlogs"
       - name: Install
-        run: su user -c "make -j4 install"
-      - name: Upload config.log
+        run: su user -c "meson install -C build"
+      - name: Upload meson log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: config-log-${{ matrix.name }}
-          path: config.log
+          name: meson-log-${{ matrix.name }}
+          path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
   # Alpine runs in its official container image. Its musl libc can't run the
@@ -280,7 +290,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apk add --no-cache autoconf automake build-base c-ares-dev git iptables libevent-dev libtool openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
+          apk add --no-cache build-base c-ares-dev git iptables libevent-dev meson ninja openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
       - name: Checkout
         run: |
           git config --global --add safe.directory "$PWD"
@@ -298,11 +308,10 @@ jobs:
           adduser --disabled-password user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-          su user -c "./autogen.sh"
-          su user -c "./configure --prefix=\$HOME/install --enable-cassert --enable-werror --with-cares --with-ldap"
-          su user -c "make -j4"
-          su user -c "PATH=/venv/bin:\$PATH make -j4 check CONCURRENCY=4"
-          su user -c "make -j4 install"
+          su user -c "meson setup build --prefix=\$HOME/install -Dcassert=true --werror -Dcares=enabled -Dldap=enabled -Dsystemd=disabled"
+          su user -c "meson compile -C build -v"
+          su user -c "PATH=/venv/bin:\$PATH meson test -C build -v --print-errorlogs"
+          su user -c "meson install -C build"
 
   macos:
     name: macOS
@@ -311,14 +320,17 @@ jobs:
       HAVE_IPV6_LOCALHOST: "yes"
       USE_SUDO: "true"
       PGVERSION: "16"
+      # openldap and openssl@3 are keg-only, so point the compiler and
+      # pkg-config at their Homebrew prefixes.
       CPPFLAGS: -I/opt/homebrew/opt/openldap/include -I/opt/homebrew/opt/openssl@3/include
       LDFLAGS: -L/opt/homebrew/opt/openldap/lib -L/opt/homebrew/opt/openssl@3/lib
+      PKG_CONFIG_PATH: /opt/homebrew/opt/openssl@3/lib/pkgconfig:/opt/homebrew/opt/openldap/lib/pkgconfig
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           set -e
-          brew install autoconf automake libevent libtool openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
+          brew install libevent meson ninja openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
           python3 -m venv venv
           venv/bin/pip install .
           # Allow the test suite to install its packet-filter anchor.
@@ -328,24 +340,23 @@ jobs:
         run: |
           set -e
           export PATH="/opt/homebrew/opt/postgresql@$PGVERSION/bin:$PATH"
-          ./autogen.sh
-          ./configure --prefix="$HOME/install" --enable-werror --with-ldap
-          make -j4
+          meson setup build --prefix="$HOME/install" --werror -Dldap=enabled
+          meson compile -C build -v
       - name: Test
         run: |
           set -e
           # shellcheck disable=SC1091
           source venv/bin/activate
           export PATH="/opt/homebrew/opt/postgresql@$PGVERSION/bin:$PATH"
-          make -j4 check CONCURRENCY=4
+          meson test -C build -v --print-errorlogs
       - name: Install
-        run: make -j4 install
-      - name: Upload config.log
+        run: meson install -C build
+      - name: Upload meson log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: config-log-macos
-          path: config.log
+          name: meson-log-macos
+          path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
   windows:
@@ -379,32 +390,35 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-libevent" \
             "${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-postgresql" \
             "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-python-pip" \
-            autoconf automake libtool pkg-config zip
+            "${MINGW_PACKAGE_PREFIX}-meson" "${MINGW_PACKAGE_PREFIX}-ninja" \
+            "${MINGW_PACKAGE_PREFIX}-pkgconf" zip
           echo "127.0.0.1   localhost" >> /etc/hosts
-          pip install .
+          pip install --break-system-packages .
       - name: Build
         run: |
-          ./autogen.sh
-          ./configure --prefix="$(pwd)/install" --enable-werror PANDOC=/c/programdata/chocolatey/bin/pandoc LDFLAGS=-static "LIBS=-liphlpapi $(pkgconf --libs --static openssl)" PKG_CONFIG='pkg-config --static'
-          make -j4
+          export PATH="/c/programdata/chocolatey/bin:$PATH"
+          meson setup build --prefix="$(pwd)/install" --werror -Dsystemd=disabled -Dc_link_args=-static
+          meson compile -C build -v
       - name: Test
-        run: |
-          make -j4 check CONCURRENCY=3
-          windres pgbouncer.exe
+        run: meson test -C build -v --print-errorlogs
+      - name: Install
+        run: meson install -C build
       - name: Build zip
-        run: make -j4 zip
+        run: |
+          cd install
+          zip -r "../pgbouncer-windows.zip" .
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
           name: pgbouncer-windows-zip
           path: pgbouncer-*.zip
           if-no-files-found: error
-      - name: Upload config.log
+      - name: Upload meson log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: config-log-windows
-          path: config.log
+          name: meson-log-windows
+          path: build/meson-logs/meson-log.txt
           if-no-files-found: ignore
 
   format-check:

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -240,9 +240,9 @@ jobs:
         run: |
           set -e
           dnf -y install 'dnf-command(config-manager)'
-          if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "plus"; else dnf config-manager --set-enabled "powertools"; fi
-          # meson is in AppStream; ninja-build comes from EPEL.
-          dnf -y install epel-release
+          # ninja-build (and the -devel packages) live in PowerTools, which is
+          # called CRB on EL9; meson itself is in AppStream.
+          if grep -q -F 'release 9' /etc/redhat-release; then dnf config-manager --set-enabled "crb"; else dnf config-manager --set-enabled "powertools"; fi
           dnf -y install diffutils file iptables libevent-devel libpq-devel make meson ninja-build openldap-clients openldap-devel openldap-servers openssl-devel pam-devel pkg-config postgresql-server postgresql-contrib python3 python3-pip socat sudo systemd-devel wget
           case "$meson_args" in *cares=enabled*) dnf -y install c-ares-devel;; esac
           wget -O /tmp/pandoc.tar.gz https://github.com/jgm/pandoc/releases/download/2.10.1/pandoc-2.10.1-linux-amd64.tar.gz

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -112,7 +112,8 @@ jobs:
           set -e
           # shellcheck disable=SC1091
           source "$HOME/venv/bin/activate"
-          meson dist -C build --no-tests
+          # gztar to match the upload glob below (meson defaults to xztar).
+          meson dist -C build --no-tests --formats gztar
       - name: Upload tarball
         if: ${{ env.DIST == 'yes' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -429,7 +429,7 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-meson" "${MINGW_PACKAGE_PREFIX}-ninja" \
             "${MINGW_PACKAGE_PREFIX}-pkgconf" zip
           echo "127.0.0.1   localhost" >> /etc/hosts
-          pip install --break-system-packages .
+          pip install .
       - name: Build
         run: |
           export PATH="/c/programdata/chocolatey/bin:$PATH"

--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -23,10 +23,11 @@ env:
   DEBIAN_FRONTEND: noninteractive
   LANG: C
 
-# While the meson and autoconf build systems coexist, every platform is built
-# and tested with both. The per-step commands live in ci/run.sh, which takes the
-# build system as an argument; each job passes it in via the `build_system`
-# matrix dimension and provides the matching MESON_ARGS / CONFIGURE_ARGS.
+# Platforms build with meson. The autoconf build still coexists and is kept
+# exercised on two representative container jobs (Debian bullseye, whose packaged
+# meson is too old, and RHEL 8, which also gets a meson build). The per-step
+# commands live in ci/run.sh, which takes the build system as an argument, so
+# both are driven the same way.
 
 jobs:
   # Builds and tests on native GitHub-hosted Ubuntu runners. These run as the
@@ -36,21 +37,18 @@ jobs:
   # `linux-extra` below reuses this job's steps via a YAML anchor and only
   # differs in its matrix, env and trigger.
   linux:
-    name: Linux (${{ matrix.name }}, ${{ matrix.build_system }})
+    name: Linux (${{ matrix.name }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        build_system: [meson, autoconf]
         name: [cares-pam-ldap, no-evdns-no-openssl, valgrind]
         include:
           - name: cares-pam-ldap
             meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled"
-            configure_args: "--with-cares --with-pam --with-ldap"
             dist: "yes"
           - name: no-evdns-no-openssl
             meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled"
-            configure_args: "--without-cares --disable-evdns --without-openssl"
           # LDAP/PAM each spawn a background thread whose stack valgrind reports
           # as "possibly lost", so disable them here. c-ares is event-driven (no
           # threads), so exercise it under valgrind.
@@ -59,14 +57,12 @@ jobs:
             cflags: "-O0 -g"
             enable_valgrind: "yes"
             meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled"
-            configure_args: "--with-cares"
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       # Baseline flags common to every Linux config; each matrix entry adds its
       # own feature toggles.
       MESON_ARGS: -Dcassert=true -Dsystemd=enabled ${{ matrix.meson_args }}
-      CONFIGURE_ARGS: --enable-cassert --with-systemd ${{ matrix.configure_args }}
       # CFLAGS_OVERRIDE is exported into the real CFLAGS by the build step only
       # when non-empty, so entries that don't set it keep the default flags.
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
@@ -81,7 +77,7 @@ jobs:
           sudo apt-get -y --no-install-recommends install gnupg postgresql-common
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get update
-          pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
+          pkgs="ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
           if [ "$ENABLE_VALGRIND" = "yes" ]; then pkgs="$pkgs valgrind"; fi
           if [ "$USE_SCAN_BUILD" = "yes" ]; then pkgs="$pkgs clang clang-tools"; fi
           # $pkgs is an intentionally word-split package list.
@@ -119,7 +115,7 @@ jobs:
           source "$HOME/venv/bin/activate"
           sh ci/run.sh install "$BUILD_SYSTEM"
       # Verify the dist tarball builds from a clean checkout, like Cirrus did.
-      # Only needs to run once per build system, so it is gated on `DIST`.
+      # Only needs to run once, so it is gated on the `DIST` flag.
       - name: Build distribution tarball
         if: ${{ env.DIST == 'yes' }}
         run: |
@@ -131,14 +127,14 @@ jobs:
         if: ${{ env.DIST == 'yes' }}
         uses: actions/upload-artifact@v4
         with:
-          name: pgbouncer-tarball-${{ matrix.name }}-${{ matrix.build_system }}
+          name: pgbouncer-tarball-${{ matrix.name }}
           path: dist/pgbouncer-*.tar.gz
           if-no-files-found: error
       - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.name }}-${{ matrix.build_system }}
+          name: logs-${{ matrix.name }}
           path: |
             build/meson-logs/meson-log.txt
             config.log
@@ -148,7 +144,7 @@ jobs:
   # `linux` job's steps via a YAML anchor. Runs on master, on manual dispatch,
   # or when a PR carries the `ci-full` label.
   linux-extra:
-    name: Linux extra (${{ matrix.name }}, ${{ matrix.build_system }})
+    name: Linux extra (${{ matrix.name }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -157,7 +153,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_system: [meson, autoconf]
         name: [plain, ubsan, scan-build, arm, ubuntu-2404]
         include:
           - name: ubsan
@@ -170,9 +165,8 @@ jobs:
             runner: ubuntu-24.04
     env:
       PGVERSION: "16"
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dcares=disabled
-      CONFIGURE_ARGS: --enable-cassert --with-systemd --without-cares
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
       USE_SCAN_BUILD: ${{ matrix.scan_build }}
       DIST: ""
@@ -182,8 +176,8 @@ jobs:
   # official container images. Container jobs run as root, where PostgreSQL
   # refuses to initdb, so we build and test as an unprivileged `user`.
   #
-  # bookworm is built both ways; bullseye's packaged meson (0.56) is below our
-  # floor, so it is autoconf-only (excluded from the meson combination).
+  # bookworm is built with meson; bullseye's packaged meson (0.56) is below our
+  # floor, so it exercises the autoconf build instead.
   linux-debian:
     name: Linux Debian (${{ matrix.name }}, ${{ matrix.build_system }})
     if: >-
@@ -196,13 +190,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_system: [meson, autoconf]
-        name: [bookworm, bullseye]
         include:
-          - { name: bookworm, image: debian:bookworm, pgversion: "15" }
-          - { name: bullseye, image: debian:bullseye, pgversion: "13" }
-        exclude:
-          - { build_system: meson, name: bullseye }
+          - { name: bookworm, image: debian:bookworm, pgversion: "15", build_system: meson }
+          - { name: bullseye, image: debian:bullseye, pgversion: "13", build_system: autoconf }
     env:
       PGVERSION: ${{ matrix.pgversion }}
       BUILD_SYSTEM: ${{ matrix.build_system }}
@@ -242,7 +232,8 @@ jobs:
           if-no-files-found: ignore
 
   # Red Hat-compatible releases in their official container images. Same
-  # build-and-test-as-`user` approach as the Debian job above.
+  # build-and-test-as-`user` approach as the Debian job above. rocky-8 is built
+  # both ways (meson and autoconf); rocky-9 with meson.
   linux-rhel:
     name: Linux Red Hat (${{ matrix.name }}, ${{ matrix.build_system }})
     if: >-
@@ -255,11 +246,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_system: [meson, autoconf]
-        name: [rocky-8, rocky-9]
         include:
-          - { name: rocky-9, image: rockylinux:9, meson_args: "-Dcares=enabled", configure_args: "--with-cares" }
-          - { name: rocky-8, image: rockylinux:8, meson_args: "", configure_args: "" }
+          - { name: rocky-8, image: rockylinux:8, build_system: meson }
+          - { name: rocky-8, image: rockylinux:8, build_system: autoconf }
+          - { name: rocky-9, image: rockylinux:9, build_system: meson, meson_args: "-Dcares=enabled", configure_args: "--with-cares" }
     env:
       BUILD_SYSTEM: ${{ matrix.build_system }}
       MESON_ARGS: -Dcassert=true -Dsystemd=enabled -Dldap=enabled -Dpam=enabled ${{ matrix.meson_args }}
@@ -306,7 +296,7 @@ jobs:
   # artifact upload. bash isn't installed on Alpine either, so steps run under
   # POSIX sh.
   linux-alpine:
-    name: Linux (alpine, ${{ matrix.build_system }})
+    name: Linux (alpine)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
@@ -314,21 +304,16 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: alpine:latest
-    strategy:
-      fail-fast: false
-      matrix:
-        build_system: [meson, autoconf]
     defaults:
       run:
         shell: sh
     env:
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       MESON_ARGS: -Dcassert=true -Dcares=enabled -Dldap=enabled -Dsystemd=disabled
-      CONFIGURE_ARGS: --enable-cassert --with-cares --with-ldap
     steps:
       - name: Install dependencies
         run: |
-          apk add --no-cache autoconf automake build-base c-ares-dev git iptables libevent-dev libtool meson ninja openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
+          apk add --no-cache build-base c-ares-dev git iptables libevent-dev meson ninja openldap openldap-clients openldap-dev openssl openssl-dev pkgconf postgresql postgresql-contrib python3 py3-pip socat sudo wget
       - name: Checkout
         run: |
           git config --global --add safe.directory "$PWD"
@@ -347,24 +332,19 @@ jobs:
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
           # /venv/bin on PATH so meson finds pytest at configure time.
-          su user -c "MESON_ARGS='$MESON_ARGS' CONFIGURE_ARGS='$CONFIGURE_ARGS' PATH=/venv/bin:\$PATH sh ci/run.sh build $BUILD_SYSTEM"
+          su user -c "MESON_ARGS='$MESON_ARGS' PATH=/venv/bin:\$PATH sh ci/run.sh build $BUILD_SYSTEM"
           su user -c "PATH=/venv/bin:\$PATH sh ci/run.sh test $BUILD_SYSTEM"
           su user -c "PATH=/venv/bin:\$PATH sh ci/run.sh install $BUILD_SYSTEM"
 
   macos:
-    name: macOS (${{ matrix.build_system }})
+    name: macOS
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        build_system: [meson, autoconf]
     env:
       HAVE_IPV6_LOCALHOST: "yes"
       USE_SUDO: "true"
       PGVERSION: "16"
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       MESON_ARGS: -Dldap=enabled
-      CONFIGURE_ARGS: --with-ldap
       # openldap and openssl@3 are keg-only, so point the compiler and
       # pkg-config at their Homebrew prefixes.
       CPPFLAGS: -I/opt/homebrew/opt/openldap/include -I/opt/homebrew/opt/openssl@3/include
@@ -375,7 +355,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -e
-          brew install autoconf automake libevent libtool meson ninja openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
+          brew install libevent meson ninja openldap openssl pandoc pkg-config "postgresql@$PGVERSION"
           python3 -m venv venv
           venv/bin/pip install .
           # Allow the test suite to install its packet-filter anchor.
@@ -401,23 +381,19 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs-macos-${{ matrix.build_system }}
+          name: logs-macos
           path: |
             build/meson-logs/meson-log.txt
             config.log
           if-no-files-found: ignore
 
   windows:
-    name: Windows (${{ matrix.build_system }})
+    name: Windows
     runs-on: windows-2022
-    strategy:
-      fail-fast: false
-      matrix:
-        build_system: [meson, autoconf]
     env:
       HAVE_IPV6_LOCALHOST: "yes"
       MSYSTEM: MINGW64
-      BUILD_SYSTEM: ${{ matrix.build_system }}
+      BUILD_SYSTEM: meson
       # Without this the MSYS2 login shell starts in the home directory; we want
       # it to stay in the checkout directory.
       CHERE_INVOKING: "1"
@@ -439,7 +415,7 @@ jobs:
         run: Add-Content c:\Windows\System32\Drivers\etc\hosts "127.0.0.1 localhost"
       - name: Install MSYS2 packages
         run: |
-          pacman -S --noconfirm --needed autoconf automake base-devel libtool \
+          pacman -S --noconfirm --needed base-devel \
             "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-libevent" \
             "${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-postgresql" \
             "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-python-pip" \
@@ -447,38 +423,29 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-pkgconf" zip
           echo "127.0.0.1   localhost" >> /etc/hosts
           pip install --break-system-packages .
-      # The autoconf build needs static linking and a couple of extra Windows
-      # libraries passed through configure, which don't fit ci/run.sh's simple
-      # arg model, so it is spelled out here; meson goes through the script.
       - name: Build
         run: |
           export PATH="/c/programdata/chocolatey/bin:$PATH"
-          if [ "$BUILD_SYSTEM" = meson ]; then
-            PREFIX="$(pwd)/install" MESON_ARGS="-Dsystemd=disabled -Dc_link_args=-static" sh ci/run.sh build meson
-          else
-            ./autogen.sh
-            ./configure --prefix="$(pwd)/install" --enable-werror PANDOC=/c/programdata/chocolatey/bin/pandoc LDFLAGS=-static "LIBS=-liphlpapi $(pkgconf --libs --static openssl)" PKG_CONFIG='pkg-config --static'
-            make -j4
-          fi
+          PREFIX="$(pwd)/install" MESON_ARGS="-Dsystemd=disabled -Dc_link_args=-static" sh ci/run.sh build "$BUILD_SYSTEM"
       - name: Test
-        run: CONCURRENCY=3 sh ci/run.sh test "$BUILD_SYSTEM"
+        run: sh ci/run.sh test "$BUILD_SYSTEM"
       - name: Install
         run: sh ci/run.sh install "$BUILD_SYSTEM"
       - name: Build zip
         run: |
           cd install
-          zip -r "../pgbouncer-windows-$BUILD_SYSTEM.zip" .
+          zip -r "../pgbouncer-windows.zip" .
       - name: Upload zip
         uses: actions/upload-artifact@v4
         with:
-          name: pgbouncer-windows-${{ matrix.build_system }}
-          path: pgbouncer-windows-*.zip
+          name: pgbouncer-windows-zip
+          path: pgbouncer-*.zip
           if-no-files-found: error
       - name: Upload build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs-windows-${{ matrix.build_system }}
+          name: logs-windows
           path: |
             build/meson-logs/meson-log.txt
             config.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 /aclocal.m4
 /config.guess
 /config.log

--- a/Makefile
+++ b/Makefile
@@ -203,40 +203,20 @@ htmls:
 doc/pgbouncer.1 doc/pgbouncer.5:
 	$(MAKE) -C doc $(@F)
 
+# Formatting and linting live in a build-system-independent script so the same
+# logic is shared with meson (`meson compile -C build format` etc.); these
+# targets just forward to it.
 lint:
-	ruff check
+	dev/format.sh lint
 
-UNCRUSTIFY_FILES = include/*.h src/*.c test/*.c \
-		lib/test/*.c lib/usual/*.c lib/usual/crypto/*.c lib/usual/hashing/*.c lib/usual/tls/*.c \
-		lib/test/*.h lib/usual/*.h lib/usual/crypto/*.h lib/usual/hashing/*.h lib/usual/tls/*.h
+format-check:
+	dev/format.sh check
 
-format-check: uncrustify
-	git diff-tree --check `git hash-object -t tree /dev/null` HEAD
-	ruff format --check --diff
-	ruff check --select I --diff
-	./uncrustify -c uncrustify.cfg --check -L WARN $(UNCRUSTIFY_FILES)
+format:
+	dev/format.sh fix
 
-format: uncrustify
-	$(MAKE) format-c
-	$(MAKE) format-python
+format-c:
+	dev/format.sh fix-c
 
-format-python: uncrustify
-	ruff format
-	ruff check --select I --fix
-
-format-c: uncrustify
-	./uncrustify -c uncrustify.cfg --replace --no-backup -L WARN $(UNCRUSTIFY_FILES)
-
-UNCRUSTIFY_VERSION=0.77.1
-
-uncrustify:
-	temp=$$(mktemp -d) \
-		&& cd $$temp \
-		&& curl -L https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-$(UNCRUSTIFY_VERSION).tar.gz --output uncrustify.tar.gz \
-		&& tar xzf uncrustify.tar.gz \
-		&& cd uncrustify-uncrustify-$(UNCRUSTIFY_VERSION) \
-		&& mkdir -p build \
-		&& cd build \
-		&& cmake .. \
-		&& $(MAKE) \
-		&& cp uncrustify $(CURDIR)/uncrustify
+format-python:
+	dev/format.sh fix-python

--- a/README.md
+++ b/README.md
@@ -10,23 +10,36 @@ Sources, bug tracking: <https://github.com/pgbouncer/pgbouncer>
 Building
 ---------
 
-PgBouncer depends on few things to get compiled:
+PgBouncer can be built with either [Meson] (recommended) or the older
+Autoconf-based build system.  Both are supported for now; the Autoconf build
+will eventually be removed.  Compilation depends on a few things:
 
-* [GNU Make] 3.81+
 * [Libevent] 2.0+
 * [pkg-config]
 * [OpenSSL] 1.0.1+ for TLS support
+* a C11-capable C compiler
 * (optional) [c-ares] as alternative to Libevent's evdns
 * (optional) LDAP libraries
 * (optional) PAM libraries
 
+The Meson build additionally needs [Meson] 0.58+ and [Ninja]; the Autoconf
+build needs [GNU Make] 3.81+.
+
+[Meson]: https://mesonbuild.com/
+[Ninja]: https://ninja-build.org/
 [GNU Make]: https://www.gnu.org/software/make/
 [Libevent]: http://libevent.org/
 [pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
 [OpenSSL]: https://www.openssl.org/
 [c-ares]: http://c-ares.haxx.se/
 
-When dependencies are installed just run:
+When dependencies are installed, build with Meson:
+
+    $ meson setup build --prefix=/usr/local
+    $ meson compile -C build
+    $ meson install -C build
+
+or with Autoconf:
 
     $ ./configure --prefix=/usr/local
     $ make
@@ -61,41 +74,54 @@ with the listed restrictions.  The other backends are mostly legacy
 options at this point and don't receive much testing anymore.
 
 By default, c-ares is used if it can be found.  Its use can be forced
-with `configure --with-cares` or disabled with `--without-cares`.  If
-c-ares is not used (not found or disabled), then Libevent is used.  Specify
-`--disable-evdns` to disable the use of Libevent's evdns and fall back to a
-libc-based implementation.
+with `-Dcares=enabled` (configure: `--with-cares`) or disabled with
+`-Dcares=disabled` (configure: `--without-cares`).  If c-ares is not used
+(not found or disabled), then Libevent is used.  Specify `-Devdns=false`
+(configure: `--disable-evdns`) to disable the use of Libevent's evdns and
+fall back to a libc-based implementation.
 
 PAM authentication
 ------------------
 
-To enable PAM authentication, `./configure` has a flag `--with-pam`
-(default value is no).  When compiled with PAM support, a new global
-authentication type `pam` is available to validate users through PAM.
+To enable PAM authentication, use the meson option `-Dpam=enabled`
+(configure: `--with-pam`; disabled by default).  When compiled with PAM
+support, a new global authentication type `pam` is available to validate
+users through PAM.
 
 LDAP authentication
 ------------------
 
-To enable LDAP authentication, `./configure` has a flag `--with-ldap`
-(default value is no).  When compiled with LDAP support, a new global
-authentication type `ldap` is available to validate users through LDAP.
+To enable LDAP authentication, use the meson option `-Dldap=enabled`
+(configure: `--with-ldap`; disabled by default).  When compiled with LDAP
+support, a new global authentication type `ldap` is available to validate
+users through LDAP.
 
 systemd integration
 -------------------
 
-To enable systemd integration, use the `configure` option
-`--with-systemd`.  This allows using `Type=notify` (or `Type=notify-reload` if
+To enable systemd integration, use the meson option `-Dsystemd=enabled`
+(configure: `--with-systemd`).  This allows using
+`Type=notify` (or `Type=notify-reload` if
 you are using systemd 253 or later) as well as socket activation.  See
 `etc/pgbouncer.service` and `etc/pgbouncer.socket` for examples.
 
 Building from Git
 -----------------
 
-Building PgBouncer from Git requires that you generate the header and
-configuration files before you can run `configure`:
+With Meson you can build straight from a checkout; pandoc is required to
+build the man pages:
 
 	$ git clone https://github.com/pgbouncer/pgbouncer.git
 	$ cd pgbouncer
+	$ meson setup build
+	$ meson compile -C build
+	$ meson install -C build
+
+Run `meson configure build` to list the available `-D` options.
+
+The Autoconf build instead requires that you generate the header and
+configuration files before you can run `configure`:
+
 	$ ./autogen.sh
 	$ ./configure
 	$ make
@@ -106,7 +132,8 @@ supply one or more command-line options to `configure`. Run
 `./configure --help` to list the available options and the environment
 variables that customizes the configuration.
 
-Additional packages required: autoconf, automake, libtool, pandoc
+Additional packages required for the Autoconf build from Git: autoconf,
+automake, libtool, pandoc
 
 Testing
 -------
@@ -121,12 +148,17 @@ Building on Windows
 The only supported build environment on Windows is MinGW.  Cygwin and
 Visual $ANYTHING are not supported.
 
-To build on MinGW, do the usual:
+To build on MinGW, do the usual Meson build:
+
+	$ meson setup build
+	$ meson compile -C build
+
+or the Autoconf build:
 
 	$ ./configure
 	$ make
 
-If cross-compiling from Unix:
+If cross-compiling from Unix with Autoconf:
 
 	$ ./configure --host=i586-mingw32msvc
 

--- a/README.md
+++ b/README.md
@@ -80,33 +80,32 @@ with `-Dcares=enabled` (configure: `--with-cares`) or disabled with
 (configure: `--disable-evdns`) to disable the use of Libevent's evdns and
 fall back to a libc-based implementation.
 
+Optional features
+-----------------
+
+The PAM, LDAP and systemd features are auto-detected by meson: their `-Dpam`,
+`-Dldap` and `-Dsystemd` options default to `auto`, so each is built when its
+libraries are present.  Force one on with `-D<feature>=enabled` or off with
+`-D<feature>=disabled`.  The Autoconf build does not auto-detect them; opt in
+explicitly with `--with-pam`, `--with-ldap` or `--with-systemd`.
+
 PAM authentication
 ------------------
 
-With meson, PAM support is enabled automatically when the PAM libraries are
-detected (the `-Dpam` option defaults to `auto`); pass `-Dpam=enabled` to
-require it or `-Dpam=disabled` to turn it off.  The Autoconf build instead
-has it off by default and needs `--with-pam` to opt in.  When compiled with
-PAM support, a new global authentication type `pam` is available to validate
-users through PAM.
+When compiled with PAM support, a new global authentication type `pam` is
+available to validate users through PAM.
 
 LDAP authentication
 ------------------
 
-With meson, LDAP support is enabled automatically when the LDAP libraries are
-detected (the `-Dldap` option defaults to `auto`); pass `-Dldap=enabled` to
-require it or `-Dldap=disabled` to turn it off.  The Autoconf build instead
-has it off by default and needs `--with-ldap` to opt in.  When compiled with
-LDAP support, a new global authentication type `ldap` is available to validate
-users through LDAP.
+When compiled with LDAP support, a new global authentication type `ldap` is
+available to validate users through LDAP.
 
 systemd integration
 -------------------
 
-To enable systemd integration, use the meson option `-Dsystemd=enabled`
-(configure: `--with-systemd`).  This allows using
-`Type=notify` (or `Type=notify-reload` if
-you are using systemd 253 or later) as well as socket activation.  See
+systemd support allows using `Type=notify` (or `Type=notify-reload` if you are
+using systemd 253 or later) as well as socket activation.  See
 `etc/pgbouncer.service` and `etc/pgbouncer.socket` for examples.
 
 Building from Git

--- a/README.md
+++ b/README.md
@@ -83,17 +83,21 @@ fall back to a libc-based implementation.
 PAM authentication
 ------------------
 
-To enable PAM authentication, use the meson option `-Dpam=enabled`
-(configure: `--with-pam`; disabled by default).  When compiled with PAM
-support, a new global authentication type `pam` is available to validate
+With meson, PAM support is enabled automatically when the PAM libraries are
+detected (the `-Dpam` option defaults to `auto`); pass `-Dpam=enabled` to
+require it or `-Dpam=disabled` to turn it off.  The Autoconf build instead
+has it off by default and needs `--with-pam` to opt in.  When compiled with
+PAM support, a new global authentication type `pam` is available to validate
 users through PAM.
 
 LDAP authentication
 ------------------
 
-To enable LDAP authentication, use the meson option `-Dldap=enabled`
-(configure: `--with-ldap`; disabled by default).  When compiled with LDAP
-support, a new global authentication type `ldap` is available to validate
+With meson, LDAP support is enabled automatically when the LDAP libraries are
+detected (the `-Dldap` option defaults to `auto`); pass `-Dldap=enabled` to
+require it or `-Dldap=disabled` to turn it off.  The Autoconf build instead
+has it off by default and needs `--with-ldap` to opt in.  When compiled with
+LDAP support, a new global authentication type `ldap` is available to validate
 users through LDAP.
 
 systemd integration

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+# Drive a build/test/install/dist step for either build system, so CI can
+# exercise both meson and autoconf on every platform from one place.
+#
+# Usage: ci/run.sh <build|test|install|dist> <meson|autoconf>
+#
+# Env:
+#   MESON_ARGS      extra `meson setup` options      (build, meson only)
+#   CONFIGURE_ARGS  extra `./configure` options      (build, autoconf only)
+#   PREFIX          install prefix (default: $HOME/install)
+#   SCANBUILD       optional command prefix, e.g. "scan-build"
+#   MAKE_JOBS       make/ninja parallelism (default: 4)
+#   CONCURRENCY     pytest workers for autoconf `make check` (default: 4)
+#
+# --werror is passed for every build; everything else that differs per job
+# (cassert, systemd, feature toggles, ...) comes in via MESON_ARGS/CONFIGURE_ARGS.
+set -eu
+
+action=${1:?usage: ci/run.sh <build|test|install|dist> <meson|autoconf>}
+bs=${2:?usage: ci/run.sh <build|test|install|dist> <meson|autoconf>}
+
+prefix=${PREFIX:-$HOME/install}
+scanbuild=${SCANBUILD:-}
+jobs=${MAKE_JOBS:-4}
+
+case "$bs" in
+meson | autoconf) ;;
+*) echo "unknown build system: $bs" >&2; exit 2 ;;
+esac
+
+case "$action.$bs" in
+build.meson)
+	# shellcheck disable=SC2086
+	$scanbuild meson setup build --prefix="$prefix" --werror ${MESON_ARGS:-}
+	$scanbuild meson compile -C build -v
+	;;
+build.autoconf)
+	./autogen.sh
+	# shellcheck disable=SC2086
+	$scanbuild ./configure --prefix="$prefix" --enable-werror ${CONFIGURE_ARGS:-}
+	$scanbuild make -j"$jobs"
+	;;
+test.meson)
+	meson test -C build -v --print-errorlogs
+	;;
+test.autoconf)
+	make -j"$jobs" check CONCURRENCY="${CONCURRENCY:-4}"
+	;;
+install.meson)
+	meson install -C build
+	;;
+install.autoconf)
+	make -j"$jobs" install
+	;;
+dist.meson)
+	# gztar to match the artifact glob (meson defaults to xztar).
+	meson dist -C build --no-tests --formats gztar
+	mkdir -p dist && cp build/meson-dist/pgbouncer-*.tar.gz dist/
+	;;
+dist.autoconf)
+	make dist
+	mkdir -p dist && cp pgbouncer-*.tar.gz dist/
+	;;
+*)
+	echo "usage: ci/run.sh <build|test|install|dist> <meson|autoconf>" >&2
+	exit 2
+	;;
+esac

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -54,13 +54,30 @@ install.autoconf)
 	make -j"$jobs" install
 	;;
 dist.meson)
-	# gztar to match the artifact glob (meson defaults to xztar).
+	# gztar to match the artifact glob (meson defaults to xztar). --no-tests
+	# because the test suite already ran against this checkout; the tarball
+	# itself is verified below by building from a fresh extraction instead.
 	meson dist -C build --no-tests --formats gztar
 	mkdir -p dist && cp build/meson-dist/pgbouncer-*.tar.gz dist/
+	tar -x -f dist/pgbouncer-*.tar.gz -C dist
+	cd dist/pgbouncer-*/
+	# shellcheck disable=SC2086
+	meson setup build --prefix="$prefix-dist" --werror ${MESON_ARGS:-}
+	meson compile -C build -v
+	meson install -C build
 	;;
 dist.autoconf)
 	make dist
 	mkdir -p dist && cp pgbouncer-*.tar.gz dist/
+	# Build from a fresh extraction of the tarball. No autogen.sh here: the
+	# tarball bundles the generated `configure`, and skipping it verifies the
+	# tarball can be built without the autoconf tools installed.
+	tar -x -f dist/pgbouncer-*.tar.gz -C dist
+	cd dist/pgbouncer-*/
+	# shellcheck disable=SC2086
+	./configure --prefix="$prefix-dist" --enable-werror ${CONFIGURE_ARGS:-}
+	make -j"$jobs"
+	make -j"$jobs" install
 	;;
 *)
 	echo "usage: ci/run.sh <build|test|install|dist> <meson|autoconf>" >&2

--- a/dev/format.sh
+++ b/dev/format.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+#
+# Formatting and linting for pgbouncer, independent of the build system.
+#
+# Usage:
+#   dev/format.sh check       verify C and Python formatting + import order (CI)
+#   dev/format.sh fix         reformat C and Python in place
+#   dev/format.sh fix-c       reformat only C in place
+#   dev/format.sh fix-python  reformat only Python in place
+#   dev/format.sh lint        run only the ruff linter
+#
+# C code is formatted with a pinned uncrustify that is built from source on
+# first use and cached as ./uncrustify in the repo root; CI caches that file
+# keyed on UNCRUSTIFY_VERSION so it is only rebuilt when the version is bumped.
+# Python formatting, import sorting and linting are all handled by ruff.
+#
+# This replaces the format/format-check/lint/uncrustify targets that used to
+# live in the autoconf Makefile.
+
+set -eu
+
+UNCRUSTIFY_VERSION=0.77.1
+
+# Run from the repo root regardless of where the script was invoked from, so the
+# globs and the cached ./uncrustify path resolve consistently.
+cd "$(git rev-parse --show-toplevel)"
+
+UNCRUSTIFY=./uncrustify
+
+# The set of C sources and headers uncrustify is responsible for. Kept in sync
+# with the UNCRUSTIFY_FILES list that the Makefile used.
+uncrustify_globs='
+	include/*.h src/*.c test/*.c
+	lib/test/*.c lib/usual/*.c lib/usual/crypto/*.c lib/usual/hashing/*.c lib/usual/tls/*.c
+	lib/test/*.h lib/usual/*.h lib/usual/crypto/*.h lib/usual/hashing/*.h lib/usual/tls/*.h
+'
+
+# Build the pinned uncrustify unless the cached binary is already present.
+ensure_uncrustify() {
+	if [ -x "$UNCRUSTIFY" ]; then
+		return
+	fi
+
+	echo "Building uncrustify $UNCRUSTIFY_VERSION ..."
+	root=$(pwd)
+	tmp=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmp'" EXIT
+
+	tarball="uncrustify-$UNCRUSTIFY_VERSION.tar.gz"
+	curl -L \
+		"https://github.com/uncrustify/uncrustify/archive/refs/tags/$tarball" \
+		--output "$tmp/$tarball"
+	tar xzf "$tmp/$tarball" -C "$tmp"
+	cmake -S "$tmp/uncrustify-uncrustify-$UNCRUSTIFY_VERSION" -B "$tmp/build"
+	cmake --build "$tmp/build"
+	cp "$tmp/build/uncrustify" "$root/uncrustify"
+}
+
+do_check() {
+	ensure_uncrustify
+	# Reject trailing whitespace / other whitespace errors across the tree.
+	git diff-tree --check "$(git hash-object -t tree /dev/null)" HEAD
+	ruff format --check --diff
+	ruff check --select I --diff
+	# shellcheck disable=SC2086
+	"$UNCRUSTIFY" -c uncrustify.cfg --check -L WARN $uncrustify_globs
+}
+
+do_fix_c() {
+	ensure_uncrustify
+	# shellcheck disable=SC2086
+	"$UNCRUSTIFY" -c uncrustify.cfg --replace --no-backup -L WARN $uncrustify_globs
+}
+
+do_fix_python() {
+	ruff format
+	ruff check --select I --fix
+}
+
+do_fix() {
+	do_fix_c
+	do_fix_python
+}
+
+do_lint() {
+	ruff check
+}
+
+case "${1:-}" in
+	check) do_check ;;
+	fix) do_fix ;;
+	fix-c) do_fix_c ;;
+	fix-python) do_fix_python ;;
+	lint) do_lint ;;
+	*)
+		echo "usage: $0 {check|fix|fix-c|fix-python|lint}" >&2
+		exit 2
+		;;
+esac

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,34 @@
+mandir = get_option('mandir')
+
+env = environment()
+env.set('PACKAGE_VERSION', meson.project_version())
+
+pgbouncer_1_md = \
+  custom_target(output: 'pgbouncer_1.md',
+                input: ['filter.py', 'frag-usage-man.md', 'usage.md'],
+                command: [python, '@INPUT@'],
+                capture: true,
+                env: env,
+               )
+
+pgbouncer_5_md = \
+  custom_target(output: 'pgbouncer_5.md',
+                input: ['filter.py', 'frag-config-man.md', 'config.md'],
+                command: [python, '@INPUT@'],
+                capture: true,
+                env: env,
+               )
+
+custom_target(output: 'pgbouncer.1',
+              input: [pgbouncer_1_md],
+              command: [pandoc, '-s', '-t', 'man', '-o', '@OUTPUT@', '@INPUT@'],
+              install: true,
+              install_dir: mandir / 'man1',
+             )
+
+custom_target(output: 'pgbouncer.5',
+              input: [pgbouncer_5_md],
+              command: [pandoc, '-s', '-t', 'man', '-o', '@OUTPUT@', '@INPUT@'],
+              install: true,
+              install_dir: mandir / 'man5',
+             )

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -3,8 +3,11 @@ mandir = get_option('mandir')
 env = environment()
 env.set('PACKAGE_VERSION', meson.project_version())
 
+# The custom_target()s are named (first positional arg) so this builds on meson
+# older than 0.60, which required a name.
 pgbouncer_1_md = \
-  custom_target(output: 'pgbouncer_1.md',
+  custom_target('pgbouncer_1.md',
+                output: 'pgbouncer_1.md',
                 input: ['filter.py', 'frag-usage-man.md', 'usage.md'],
                 command: [python, '@INPUT@'],
                 capture: true,
@@ -12,21 +15,24 @@ pgbouncer_1_md = \
                )
 
 pgbouncer_5_md = \
-  custom_target(output: 'pgbouncer_5.md',
+  custom_target('pgbouncer_5.md',
+                output: 'pgbouncer_5.md',
                 input: ['filter.py', 'frag-config-man.md', 'config.md'],
                 command: [python, '@INPUT@'],
                 capture: true,
                 env: env,
                )
 
-custom_target(output: 'pgbouncer.1',
+custom_target('pgbouncer.1',
+              output: 'pgbouncer.1',
               input: [pgbouncer_1_md],
               command: [pandoc, '-s', '-t', 'man', '-o', '@OUTPUT@', '@INPUT@'],
               install: true,
               install_dir: mandir / 'man1',
              )
 
-custom_target(output: 'pgbouncer.5',
+custom_target('pgbouncer.5',
+              output: 'pgbouncer.5',
               input: [pgbouncer_5_md],
               command: [pandoc, '-s', '-t', 'man', '-o', '@OUTPUT@', '@INPUT@'],
               install: true,

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,237 @@
+project('PgBouncer',
+        ['c'],
+        version: '1.24.1',
+        license: 'ISC',
+)
+
+cc = meson.get_compiler('c')
+
+not_found_dep = dependency('', required: false)
+
+cdata = configuration_data()
+
+
+libcares = dependency('libcares', required: false)
+libevent = dependency('libevent', required: true)
+openssl = dependency('openssl', required: false)
+
+#
+# cares option
+#
+libcares = not_found_dep
+caresopt = get_option('cares')
+libcares = dependency('libcares', required: caresopt, version: '>= 1.6.0')
+cdata.set('USE_CARES', libcares.found() ? 1 : false,
+          description: 'Use c-ares for name resolution.')
+
+#
+# systemd option
+#
+systemd = not_found_dep
+systemdopt = get_option('systemd')
+systemdopt = systemdopt.disable_auto_if(host_machine.system() != 'linux')
+systemd = dependency('libsystemd', required: systemdopt)
+cdata.set('USE_SYSTEMD', systemd.found() ? 1 : false,
+          description: 'Define to build with systemd support. (-Dsystemd=enabled)')
+
+
+cdata.set('_GNU_SOURCE', 1,
+          description: 'Define to get some GNU functions in headers.')
+
+cdata.set('CASSERT', get_option('cassert') ? 1 : false,
+          description: 'Define to enable assert checking')
+
+check_funcs = [
+  'arc4random_buf',
+  'getentropy',
+  'getopt',
+  'getopt_long',
+  'getrandom',
+  'inet_ntop',
+  'inet_pton',
+  'lstat',
+  'poll',
+  'regcomp',
+  'sigaction',
+  'strerror_r',
+  'strlcpy',
+]
+
+foreach func : check_funcs
+  found = cc.has_function(func)
+  cdata.set('HAVE_' + func.to_upper(), found ? 1 : false,
+           description: 'Define to 1 if you have the `@0@\' function.'.format(func))
+endforeach
+
+cdata.set('HAVE_PTHREAD', 1)
+
+header_checks = [
+  'arpa/inet.h',
+  'getopt.h',
+  'grp.h',
+  'netdb.h',
+  'netinet/in.h',
+  'netinet/tcp.h',
+  'poll.h',
+  'pthread.h',
+  'pwd.h',
+  'regex.h',
+  'syslog.h',
+  'sys/param.h',
+  'sys/resource.h',
+  'sys/socket.h',
+  'sys/time.h',
+  'sys/types.h',
+  'sys/ucred.h',
+  'sys/un.h',
+  'ucred.h',
+  'unistd.h',
+]
+
+foreach header : header_checks
+  varname = 'HAVE_' + header.underscorify().to_upper()
+
+  found = cc.has_header(header)
+  cdata.set(varname, found ? 1 : false,
+            description: 'Define to 1 if you have the <@0@> header file.'.format(header))
+endforeach
+
+cdata.set('OPENSSL_API_COMPAT', '0x00908000L',
+          description: 'Define to the OpenSSL API version in use. This avoids deprecation warnings from newer OpenSSL versions.')
+cdata.set('USUAL_LIBSSL_FOR_TLS', 1)
+cdata.set_quoted('USUAL_TLS_CA_FILE', get_option('root-ca-file'))
+
+cdata.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/pgbouncer/pgbouncer/issues',
+                 description: 'Define to the address where bug reports for this package should be sent.')
+cdata.set_quoted('PACKAGE_NAME', meson.project_name(),
+                 description: 'Define to the full name of this package.')
+cdata.set_quoted('PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), meson.project_version()),
+                 description: 'Define to the full name and version of this package.')
+cdata.set_quoted('PACKAGE_URL', 'https://www.pgbouncer.org/',
+                 description: 'Define to the home page for this package.')
+cdata.set_quoted('PACKAGE_VERSION', meson.project_version(),
+                 description: 'Define to the version of this package.')
+
+cdata.set('USE_CARES', 1)
+
+
+# FIXME: cannot write 'lib/usual/config.h' here
+config_h = configure_file(output: 'test_config.h',
+                          configuration: cdata,
+                         )
+add_project_arguments('-DUSUAL_TEST_CONFIG', language: ['c'])
+
+
+cc = meson.get_compiler('c')
+
+libusual_sources = files(
+  'lib/usual/aatree.c',
+  'lib/usual/base.c',
+  'lib/usual/cbtree.c',
+  'lib/usual/cfparser.c',
+  'lib/usual/cxalloc.c',
+  'lib/usual/cxextra.c',
+  'lib/usual/err.c',
+  'lib/usual/fileutil.c',
+  'lib/usual/logging.c',
+  'lib/usual/mbuf.c',
+  'lib/usual/pgutil.c',
+  'lib/usual/safeio.c',
+  'lib/usual/slab.c',
+  'lib/usual/socket.c',
+  'lib/usual/string.c',
+  'lib/usual/strpool.c',
+  'lib/usual/time.c',
+  'lib/usual/crypto/csrandom.c',
+  'lib/usual/crypto/keccak.c',
+  'lib/usual/crypto/keccak_prng.c',
+  'lib/usual/tls/tls.c',
+  'lib/usual/tls/tls_cert.c',
+  'lib/usual/tls/tls_client.c',
+  'lib/usual/tls/tls_compat.c',
+  'lib/usual/tls/tls_config.c',
+  'lib/usual/tls/tls_conninfo.c',
+  'lib/usual/tls/tls_ocsp.c',
+  'lib/usual/tls/tls_peer.c',
+  'lib/usual/tls/tls_server.c',
+  'lib/usual/tls/tls_util.c',
+  'lib/usual/tls/tls_verify.c',
+)
+
+pgbouncer = executable('pgbouncer',
+           'src/admin.c',
+           'src/client.c',
+           'src/dnslookup.c',
+           'src/hba.c',
+           'src/janitor.c',
+           'src/ldapauth.c',
+           'src/loader.c',
+           'src/messages.c',
+           'src/main.c',
+           'src/objects.c',
+           'src/pam.c',
+           'src/pktbuf.c',
+           'src/pooler.c',
+           'src/proto.c',
+           'src/prepare.c',
+           'src/sbuf.c',
+           'src/scram.c',
+           'src/server.c',
+           'src/stats.c',
+           'src/system.c',
+           'src/takeover.c',
+           'src/util.c',
+           'src/varcache.c',
+           'src/common/base64.c',
+           'src/common/bool.c',
+           'src/common/cryptohash.c',
+           'src/common/hmac.c',
+           'src/common/pgstrcasecmp.c',
+           'src/common/saslprep.c',
+           'src/common/scram-common.c',
+           'src/common/sha2.c',
+           'src/common/string.c',
+           'src/common/unicode_norm.c',
+           'src/common/wchar.c',
+           libusual_sources,
+           config_h,
+
+           include_directories: ['include', 'lib'],
+           install: true,
+           dependencies: [libcares, libevent, openssl, systemd],
+)
+
+pandoc = find_program('pandoc', required: true, native: true)
+python = find_program('python3', 'python', required: true, native: true)
+
+subdir('doc')
+
+pkgdocdir = get_option('datadir') / 'doc' / 'pgbouncer'
+
+install_data('README.md',
+             'NEWS.md',
+             'etc/pgbouncer-minimal.ini',
+             'etc/pgbouncer.ini',
+             'etc/pgbouncer.service',
+             'etc/pgbouncer.socket',
+             'etc/userlist.txt',
+             install_dir: pkgdocdir)
+
+test('optscan',
+     files('etc/optscan.sh'),
+     workdir: meson.project_source_root())
+
+test('pytest',
+     python,
+     args: ['-m', 'pytest', '-n', 'auto', '-v', '..'],
+     env: {
+            'BOUNCER_EXE': pgbouncer.full_path(),
+            'PYTHONIOENCODING': 'utf8',
+            'TEST_USE_LDAP': '',
+            'TEST_USE_TLS': '1',
+          },
+     depends: [pgbouncer],
+     timeout: 1000,
+    )
+
+subdir('test')

--- a/meson.build
+++ b/meson.build
@@ -608,8 +608,11 @@ endif
 if windows
   pgbouncer_sources += files('win32/win32support.c')
   win = import('windows')
+  # win32ver.rc includes the generated config, so windres needs the same
+  # USUAL_TEST_CONFIG define the C sources get.
   pgbouncer_sources += win.compile_resources('win32/win32ver.rc',
-                                             include_directories: pgbouncer_incdirs)
+                                             include_directories: pgbouncer_incdirs,
+                                             args: ['-DUSUAL_TEST_CONFIG'])
 endif
 
 pgbouncer = executable('pgbouncer',

--- a/meson.build
+++ b/meson.build
@@ -18,8 +18,7 @@ project('pgbouncer',
 
 cc = meson.get_compiler('c')
 fs = import('fs')
-host_system = host_machine.system()
-windows = host_system == 'windows'
+windows = host_machine.system() == 'windows'
 
 # ----------------------------------------------------------------------
 # Require a C11-capable compiler (mirrors AC_USUAL_C11).
@@ -53,12 +52,11 @@ int main(void) {
 c11_flag = ''
 c11_ok = false
 foreach flag : ['', '-std=gnu11', '-std=c11']
-  if not c11_ok
-    label = flag == '' ? 'C11 support (compiler default)' : 'C11 support (@0@)'.format(flag)
-    if cc.compiles(c11_probe, args: flag == '' ? [] : [flag], name: label)
-      c11_ok = true
-      c11_flag = flag
-    endif
+  label = flag == '' ? 'C11 support (compiler default)' : 'C11 support (@0@)'.format(flag)
+  if cc.compiles(c11_probe, args: flag == '' ? [] : [flag], name: label)
+    c11_ok = true
+    c11_flag = flag
+    break
   endif
 endforeach
 
@@ -102,7 +100,6 @@ cdata.set('PACKAGE_VERSION_4B', ','.join(version_parts),
 
 cdata.set('_GNU_SOURCE', 1,
           description: 'Define to get some GNU functions in headers.')
-cdata.set('STDC_HEADERS', 1)
 # Always request a 64-bit off_t. Harmless on 64-bit platforms and required on
 # 32-bit ones (replaces autoconf's AC_SYS_LARGEFILE).
 cdata.set('_FILE_OFFSET_BITS', 64)
@@ -130,16 +127,10 @@ endforeach
 # Header checks (mirrors AC_USUAL_HEADER_CHECK + pgbouncer extras)
 # ----------------------------------------------------------------------
 
-# ucred.h / sys/ucred.h have prerequisites on some platforms.
-ucred_prefix = '''
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_PARAM_H
-#include <sys/param.h>
-#endif
-'''
-
+# The C89/C99 headers (stdio.h, string.h, stdint.h, ...) are guaranteed by the
+# C11 requirement and their HAVE_ macros are no longer consulted anywhere, so
+# only the genuinely platform-specific headers are probed, matching what
+# configure's AC_USUAL_HEADER_CHECK still checks.
 header_checks = [
   'arpa/inet.h',
   'byteswap.h',
@@ -149,7 +140,6 @@ header_checks = [
   'fnmatch.h',
   'getopt.h',
   'grp.h',
-  'inttypes.h',
   'langinfo.h',
   'linux/random.h',
   'malloc.h',
@@ -160,20 +150,13 @@ header_checks = [
   'pthread.h',
   'pwd.h',
   'regex.h',
-  'stdint.h',
-  'stdio.h',
-  'stdlib.h',
-  'string.h',
-  'strings.h',
   'syslog.h',
   'sys/endian.h',
   'sys/mman.h',
   'sys/param.h',
   'sys/resource.h',
   'sys/socket.h',
-  'sys/stat.h',
   'sys/time.h',
-  'sys/types.h',
   'sys/uio.h',
   'sys/un.h',
   'sys/wait.h',
@@ -186,6 +169,13 @@ foreach header : header_checks
   cdata.set(varname, cc.has_header(header) ? 1 : false,
             description: 'Define to 1 if you have the <@0@> header file.'.format(header))
 endforeach
+
+# ucred.h / sys/ucred.h have prerequisites on some platforms (sys/param.h on
+# the BSDs, guarded by its check above since it does not exist everywhere).
+ucred_prefix = '#include <sys/types.h>'
+if cdata.get('HAVE_SYS_PARAM_H') == 1
+  ucred_prefix += '\n#include <sys/param.h>'
+endif
 
 foreach header : ['ucred.h', 'sys/ucred.h']
   varname = 'HAVE_' + header.underscorify().to_upper()
@@ -261,11 +251,8 @@ foreach func : check_funcs
             description: 'Define to 1 if you have the `@0@\' function.'.format(func))
 endforeach
 
-# strerror_r: is it declared, and does it return char * (GNU) or int (XSI)?
-cdata.set('HAVE_STRERROR_R',
-          cc.has_function('strerror_r', args: '-D_GNU_SOURCE') ? 1 : false)
-cdata.set('HAVE_DECL_STRERROR_R',
-          cc.has_header_symbol('string.h', 'strerror_r', args: '-D_GNU_SOURCE') ? 1 : 0)
+# strerror_r: does it return char * (GNU) or int (XSI)? Only the return-type
+# question matters; lib/usual/string.c assumes strerror_r itself exists.
 strerror_r_char_p = cc.compiles('''
 #define _GNU_SOURCE
 #include <string.h>
@@ -609,11 +596,8 @@ pgbouncer_deps = [
 ] + dns_deps + net_deps
 
 # '.' brings in the build root (where the generated test_config.h lives).
-if windows
-  pgbouncer_incdirs = include_directories('.', 'include', 'lib', 'win32')
-else
-  pgbouncer_incdirs = include_directories('.', 'include', 'lib')
-endif
+incdir_names = ['.', 'include', 'lib'] + (windows ? ['win32'] : [])
+pgbouncer_incdirs = include_directories(incdir_names)
 
 if windows
   pgbouncer_sources += files('win32/win32support.c')
@@ -639,7 +623,6 @@ pgbouncer = executable('pgbouncer',
 # ----------------------------------------------------------------------
 
 if windows
-  win = import('windows')
   pgbevent_res = win.compile_resources('win32/eventmsg.rc',
                                        include_directories: pgbouncer_incdirs)
   shared_library('pgbevent',

--- a/meson.build
+++ b/meson.build
@@ -582,6 +582,15 @@ pgbouncer_sources = files(
   'src/common/wchar.c',
 )
 
+# Winsock and the IP helper API (linked via LIBS in the autoconf build). Needed
+# by anything that pulls in libusual's socket/tls code, including the test
+# binaries in test/meson.build, so keep it in a shared variable.
+net_deps = []
+if windows
+  net_deps += cc.find_library('ws2_32')
+  net_deps += cc.find_library('iphlpapi')
+endif
+
 pgbouncer_deps = [
   libcares,
   libevent,
@@ -590,13 +599,7 @@ pgbouncer_deps = [
   pam,
   ldap,
   threads,
-] + dns_deps
-
-if windows
-  # Winsock and the IP helper API, linked via LIBS in the autoconf build.
-  pgbouncer_deps += cc.find_library('ws2_32')
-  pgbouncer_deps += cc.find_library('iphlpapi')
-endif
+] + dns_deps + net_deps
 
 # '.' brings in the build root (where the generated test_config.h lives).
 if windows

--- a/meson.build
+++ b/meson.build
@@ -678,9 +678,38 @@ test('optscan',
      files('etc/optscan.sh'),
      workdir: meson.project_source_root())
 
+# Pick the command used to run the test suite. An explicit -Dpytest=... wins
+# (its first element is the program, the rest are leading arguments); otherwise
+# prefer the `pytest` console script and fall back to `python -m pytest`. This is
+# resolved at configure time, so CI puts the test dependencies (its venv) on PATH
+# before running `meson setup`.
+pytest_opt = get_option('pytest')
+if pytest_opt.length() > 0
+  pytest_exe = find_program(pytest_opt[0])
+  pytest_args = []
+  is_first = true
+  foreach a : pytest_opt
+    if is_first
+      is_first = false
+    else
+      pytest_args += a
+    endif
+  endforeach
+else
+  pytest = find_program('pytest', required: false)
+  if pytest.found()
+    pytest_exe = pytest
+    pytest_args = []
+  else
+    pytest_exe = python
+    pytest_args = ['-m', 'pytest']
+  endif
+endif
+pytest_args += ['-n', 'auto', '-r', 's']
+
 test('pytest',
-     python,
-     args: ['-m', 'pytest', '-n', 'auto', '-r', 's'],
+     pytest_exe,
+     args: pytest_args,
      env: {
        'BOUNCER_EXE': pgbouncer.full_path(),
        'PYTHONIOENCODING': 'utf8',

--- a/meson.build
+++ b/meson.build
@@ -1,74 +1,107 @@
-project('PgBouncer',
+project('pgbouncer',
         ['c'],
-        version: '1.24.1',
+        version: '1.25.2',
         license: 'ISC',
+        meson_version: '>= 0.60',
+        default_options: [
+          # We manage the warning flags explicitly below to match the set the
+          # autoconf build used, so keep meson from injecting its own. The C
+          # standard is deliberately left at the compiler default (as the
+          # autoconf build did): forcing an older -std would make clang flag
+          # the code's typedef redefinitions as a "C11 feature".
+          'warning_level=0',
+        ],
 )
 
 cc = meson.get_compiler('c')
+fs = import('fs')
+host_system = host_machine.system()
+windows = host_system == 'windows'
 
 not_found_dep = dependency('', required: false)
 
 cdata = configuration_data()
 
+# ----------------------------------------------------------------------
+# Package metadata (mirrors AC_INIT / config.mak.in)
+# ----------------------------------------------------------------------
 
-libcares = dependency('libcares', required: false)
-libevent = dependency('libevent', required: true)
-openssl = dependency('openssl', required: false)
+cdata.set_quoted('PACKAGE_NAME', 'PgBouncer')
+cdata.set_quoted('PACKAGE_TARNAME', 'pgbouncer')
+cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+cdata.set_quoted('PACKAGE_STRING', 'PgBouncer @0@'.format(meson.project_version()))
+cdata.set_quoted('PACKAGE_URL', 'https://www.pgbouncer.org/')
+cdata.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/pgbouncer/pgbouncer/issues')
 
-#
-# cares option
-#
-libcares = not_found_dep
-caresopt = get_option('cares')
-libcares = dependency('libcares', required: caresopt, version: '>= 1.6.0')
-cdata.set('USE_CARES', libcares.found() ? 1 : false,
-          description: 'Use c-ares for name resolution.')
+# Windows resource files want the version as a comma separated 4-tuple.
+version_parts = meson.project_version().split('.')
+if version_parts.length() == 1
+  version_parts += ['0', '0', '0']
+elif version_parts.length() == 2
+  version_parts += ['0', '0']
+elif version_parts.length() == 3
+  version_parts += ['0']
+endif
+cdata.set('PACKAGE_VERSION_4B', ','.join(version_parts),
+          description: 'Version of this package for the Windows resource file (1,2,3,4).')
 
-#
-# systemd option
-#
-systemd = not_found_dep
-systemdopt = get_option('systemd')
-systemdopt = systemdopt.disable_auto_if(host_machine.system() != 'linux')
-systemd = dependency('libsystemd', required: systemdopt)
-cdata.set('USE_SYSTEMD', systemd.found() ? 1 : false,
-          description: 'Define to build with systemd support. (-Dsystemd=enabled)')
-
+# ----------------------------------------------------------------------
+# Basic environment defines (mirrors AC_USUAL_INIT / AC_USUAL_TYPE_CHECK)
+# ----------------------------------------------------------------------
 
 cdata.set('_GNU_SOURCE', 1,
           description: 'Define to get some GNU functions in headers.')
+cdata.set('STDC_HEADERS', 1)
+# Always request a 64-bit off_t. Harmless on 64-bit platforms and required on
+# 32-bit ones (replaces autoconf's AC_SYS_LARGEFILE).
+cdata.set('_FILE_OFFSET_BITS', 64)
 
-cdata.set('CASSERT', get_option('cassert') ? 1 : false,
-          description: 'Define to enable assert checking')
+if windows
+  cdata.set('WIN32_LEAN_AND_MEAN', 1,
+            description: 'Define to request cleaner win32 headers.')
+  cdata.set('WINVER', '0x0600',
+            description: 'Define to max win32 API version (0x0600=Vista).')
+endif
 
-check_funcs = [
-  'arc4random_buf',
-  'getentropy',
-  'getopt',
-  'getopt_long',
-  'getrandom',
-  'inet_ntop',
-  'inet_pton',
-  'lstat',
-  'poll',
-  'regcomp',
-  'sigaction',
-  'strerror_r',
-  'strlcpy',
-]
+if host_machine.endian() == 'big'
+  cdata.set('WORDS_BIGENDIAN', 1,
+            description: 'Define to 1 on big-endian hosts.')
+endif
 
-foreach func : check_funcs
-  found = cc.has_function(func)
-  cdata.set('HAVE_' + func.to_upper(), found ? 1 : false,
-           description: 'Define to 1 if you have the `@0@\' function.'.format(func))
+# pid_t/uid_t/gid_t fall back to int when the platform lacks them.
+foreach t : [['pid_t', 'int'], ['uid_t', 'int'], ['gid_t', 'int']]
+  if not cc.has_type(t[0], prefix: '#include <sys/types.h>')
+    cdata.set(t[0], t[1])
+  endif
 endforeach
 
-cdata.set('HAVE_PTHREAD', 1)
+# ----------------------------------------------------------------------
+# Header checks (mirrors AC_USUAL_HEADER_CHECK + pgbouncer extras)
+# ----------------------------------------------------------------------
+
+# ucred.h / sys/ucred.h have prerequisites on some platforms.
+ucred_prefix = '''
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+'''
 
 header_checks = [
   'arpa/inet.h',
+  'byteswap.h',
+  'dlfcn.h',
+  'endian.h',
+  'err.h',
+  'fnmatch.h',
   'getopt.h',
   'grp.h',
+  'inttypes.h',
+  'langinfo.h',
+  'linux/random.h',
+  'malloc.h',
   'netdb.h',
   'netinet/in.h',
   'netinet/tcp.h',
@@ -76,75 +109,381 @@ header_checks = [
   'pthread.h',
   'pwd.h',
   'regex.h',
+  'stdint.h',
+  'stdio.h',
+  'stdlib.h',
+  'string.h',
+  'strings.h',
   'syslog.h',
+  'sys/endian.h',
+  'sys/mman.h',
   'sys/param.h',
   'sys/resource.h',
   'sys/socket.h',
+  'sys/stat.h',
   'sys/time.h',
   'sys/types.h',
-  'sys/ucred.h',
+  'sys/uio.h',
   'sys/un.h',
-  'ucred.h',
+  'sys/wait.h',
   'unistd.h',
+  'xlocale.h',
 ]
 
 foreach header : header_checks
   varname = 'HAVE_' + header.underscorify().to_upper()
-
-  found = cc.has_header(header)
-  cdata.set(varname, found ? 1 : false,
+  cdata.set(varname, cc.has_header(header) ? 1 : false,
             description: 'Define to 1 if you have the <@0@> header file.'.format(header))
 endforeach
 
-cdata.set('OPENSSL_API_COMPAT', '0x00908000L',
-          description: 'Define to the OpenSSL API version in use. This avoids deprecation warnings from newer OpenSSL versions.')
-cdata.set('USUAL_LIBSSL_FOR_TLS', 1)
-cdata.set_quoted('USUAL_TLS_CA_FILE', get_option('root-ca-file'))
+foreach header : ['ucred.h', 'sys/ucred.h']
+  varname = 'HAVE_' + header.underscorify().to_upper()
+  cdata.set(varname, cc.has_header(header, prefix: ucred_prefix) ? 1 : false,
+            description: 'Define to 1 if you have the <@0@> header file.'.format(header))
+endforeach
 
-cdata.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/pgbouncer/pgbouncer/issues',
-                 description: 'Define to the address where bug reports for this package should be sent.')
-cdata.set_quoted('PACKAGE_NAME', meson.project_name(),
-                 description: 'Define to the full name of this package.')
-cdata.set_quoted('PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), meson.project_version()),
-                 description: 'Define to the full name and version of this package.')
-cdata.set_quoted('PACKAGE_URL', 'https://www.pgbouncer.org/',
-                 description: 'Define to the home page for this package.')
-cdata.set_quoted('PACKAGE_VERSION', meson.project_version(),
-                 description: 'Define to the version of this package.')
+# ----------------------------------------------------------------------
+# Function checks (mirrors AC_USUAL_FUNCTION_CHECK + pgbouncer extras)
+# ----------------------------------------------------------------------
 
-cdata.set('USE_CARES', 1)
+check_funcs = [
+  'arc4random_buf',
+  'asprintf',
+  'err',
+  'errx',
+  'explicit_bzero',
+  'ffs',
+  'ffsl',
+  'ffsll',
+  'fls',
+  'flsl',
+  'flsll',
+  'fnmatch',
+  'getentropy',
+  'getline',
+  'getopt',
+  'getopt_long',
+  'getopt_long_only',
+  'getpeereid',
+  'getpeerucred',
+  'getprogname',
+  'getrandom',
+  'getrusage',
+  'gettimeofday',
+  'inet_ntop',
+  'inet_pton',
+  'localtime_r',
+  'lstat',
+  'mbsnrtowcs',
+  'memalign',
+  'memmem',
+  'mempcpy',
+  'memrchr',
+  'memset_s',
+  'mmap',
+  'nl_langinfo',
+  'poll',
+  'posix_memalign',
+  'reallocarray',
+  'recvmsg',
+  'regcomp',
+  'sendmsg',
+  'setprogname',
+  'sigaction',
+  'sigqueue',
+  'strlcat',
+  'strlcpy',
+  'strsep',
+  'strtod_l',
+  'strtonum',
+  'syslog',
+  'timegm',
+  'usleep',
+  'valloc',
+  'vasprintf',
+  'warn',
+  'warnx',
+]
 
+foreach func : check_funcs
+  cdata.set('HAVE_' + func.to_upper(), cc.has_function(func, args: '-D_GNU_SOURCE') ? 1 : false,
+            description: 'Define to 1 if you have the `@0@\' function.'.format(func))
+endforeach
 
-# FIXME: cannot write 'lib/usual/config.h' here
-config_h = configure_file(output: 'test_config.h',
-                          configuration: cdata,
-                         )
-add_project_arguments('-DUSUAL_TEST_CONFIG', language: ['c'])
+# strerror_r: is it declared, and does it return char * (GNU) or int (XSI)?
+cdata.set('HAVE_STRERROR_R',
+          cc.has_function('strerror_r', args: '-D_GNU_SOURCE') ? 1 : false)
+cdata.set('HAVE_DECL_STRERROR_R',
+          cc.has_header_symbol('string.h', 'strerror_r', args: '-D_GNU_SOURCE') ? 1 : 0)
+strerror_r_char_p = cc.compiles('''
+#define _GNU_SOURCE
+#include <string.h>
+int main(void) {
+    char buf[100];
+    char *p = strerror_r(0, buf, sizeof(buf));
+    return !p;
+}
+''', name: 'strerror_r returns char *')
+cdata.set('STRERROR_R_CHAR_P', strerror_r_char_p ? 1 : false,
+          description: 'Define to 1 if strerror_r returns char *.')
 
+# Native be/le enc/dec helpers (be16enc, le32dec, ...).
+encdec_args = []
+if cc.has_header('endian.h')
+  encdec_args += '-DHAVE_ENDIAN_H'
+endif
+if cc.has_header('sys/endian.h')
+  encdec_args += '-DHAVE_SYS_ENDIAN_H'
+endif
+have_encdec = cc.links('''
+#include <sys/types.h>
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#endif
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#endif
+char p[] = "01234567";
+int main(void) {
+    be16enc(p, 0); be32enc(p, 1); be64enc(p, 2);
+    le16enc(p, 2); le32enc(p, 3); le64enc(p, 4);
+    return (int)(be16dec(p) + be32dec(p) + be64dec(p)) +
+           (int)(le16dec(p) + le32dec(p) + le64dec(p));
+}
+''', args: encdec_args, name: 'be/le enc/dec functions')
+cdata.set('HAVE_ENCDEC_FUNCS', have_encdec ? 1 : false,
+          description: 'Define if *enc & *dec functions are available.')
 
-cc = meson.get_compiler('c')
+# ----------------------------------------------------------------------
+# Threads (needed for PAM/LDAP and the getaddrinfo_a compat fallback)
+# ----------------------------------------------------------------------
+
+threads = dependency('threads')
+cdata.set('HAVE_PTHREAD', cc.has_header('pthread.h') ? 1 : false)
+
+# ----------------------------------------------------------------------
+# assert checking (mirrors AC_USUAL_CASSERT / --enable-cassert)
+# ----------------------------------------------------------------------
+
+cdata.set('CASSERT', get_option('cassert') ? 1 : false,
+          description: 'Define to enable assert checking.')
+
+# ----------------------------------------------------------------------
+# libevent (required)
+# ----------------------------------------------------------------------
+
+libevent = dependency('libevent')
+
+# ----------------------------------------------------------------------
+# OpenSSL / TLS (mirrors AC_USUAL_TLS)
+# ----------------------------------------------------------------------
+
+opensslopt = get_option('openssl')
+openssl = dependency('openssl', required: opensslopt)
+if openssl.found()
+  cdata.set('USUAL_LIBSSL_FOR_TLS', 1, description: 'Use libssl for TLS.')
+  cdata.set('OPENSSL_API_COMPAT', '0x00908000L',
+            description: 'OpenSSL API version in use, to silence deprecation warnings.')
+
+  # LibreSSL-only helpers, used when present.
+  foreach func : ['SSL_CTX_use_certificate_chain_mem', 'SSL_CTX_load_verify_mem', 'asn1_time_parse']
+    cdata.set('HAVE_' + func.to_upper(),
+              cc.has_function(func, dependencies: openssl) ? 1 : false)
+  endforeach
+
+  # Pick a default root CA bundle, unless one was given explicitly.
+  cafile = get_option('root_ca_file')
+  if cafile == ''
+    foreach candidate : [
+      '/etc/ssl/certs/ca-certificates.crt',
+      '/etc/pki/tls/certs/ca-bundle.crt',
+      '/etc/ssl/ca-bundle.pem',
+      '/etc/pki/tls/cacert.pem',
+      '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+      '/etc/ssl/cert.pem',
+    ]
+      if cafile == '' and fs.is_file(candidate)
+        cafile = candidate
+      endif
+    endforeach
+    if cafile == ''
+      cafile = '/etc/ssl/certs/ca-certificates.crt'
+    endif
+  endif
+  cdata.set_quoted('USUAL_TLS_CA_FILE', cafile, description: 'Path to root CA certs.')
+  message('root CA file: ' + cafile)
+endif
+
+# ----------------------------------------------------------------------
+# systemd (mirrors --with-systemd)
+# ----------------------------------------------------------------------
+
+systemdopt = get_option('systemd').disable_auto_if(host_system != 'linux')
+systemd = dependency('libsystemd', required: systemdopt)
+cdata.set('USE_SYSTEMD', systemd.found() ? 1 : false,
+          description: 'Define to build with systemd support. (-Dsystemd=enabled)')
+
+# ----------------------------------------------------------------------
+# PAM (mirrors --with-pam)
+# ----------------------------------------------------------------------
+
+pamopt = get_option('pam')
+pam = not_found_dep
+if pamopt.allowed()
+  pam = cc.find_library('pam', required: pamopt, has_headers: ['security/pam_appl.h'])
+endif
+if pam.found()
+  cdata.set('HAVE_PAM', 1, description: 'PAM support.')
+  cdata.set('HAVE_SECURITY_PAM_APPL_H', 1)
+endif
+
+# ----------------------------------------------------------------------
+# LDAP (mirrors --with-ldap)
+# ----------------------------------------------------------------------
+
+ldapopt = get_option('ldap')
+ldap = not_found_dep
+if ldapopt.allowed()
+  ldap = cc.find_library('ldap', required: ldapopt, has_headers: ['ldap.h'])
+endif
+if ldap.found()
+  cdata.set('HAVE_LDAP', 1, description: 'LDAP support.')
+  cdata.set('HAVE_LDAP_H', 1)
+endif
+
+# ----------------------------------------------------------------------
+# DNS backend selection (mirrors the DNS section of configure.ac)
+#
+# Order of preference: c-ares, then libevent's evdns, then the libc /
+# getaddrinfo_a based compat path. Exactly one USE_* macro is defined so that
+# src/dnslookup.c selects a single implementation.
+# ----------------------------------------------------------------------
+
+caresopt = get_option('cares')
+libcares = dependency('libcares', required: caresopt, version: '>= 1.9.0')
+
+adns = ''
+dns_deps = []
+if libcares.found()
+  adns = 'c-ares'
+  cdata.set('USE_CARES', 1, description: 'Use c-ares for name resolution.')
+  # Portability substitute for arpa/nameser.h, needed mainly for Windows.
+  cdata.set('HAVE_ARES_NAMESER_H',
+            cc.has_header('ares_nameser.h', dependencies: libcares) ? 1 : false)
+elif get_option('evdns')
+  adns = 'evdns'
+  cdata.set('USE_EVDNS', 1, description: 'Use libevent for DNS lookups.')
+else
+  # Compat path: prefer glibc's native getaddrinfo_a, otherwise fall back to
+  # the pthread-based implementation shipped in libusual (lib/usual/netdb.c).
+  # getaddrinfo_a lives in libanl on older glibc and in libc since glibc 2.34,
+  # so the library is optional but linked when present (AC_SEARCH_LIBS(..anl)).
+  libanl = cc.find_library('anl', required: false)
+  have_gaia = cc.links('''
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <netdb.h>
+int main(void) {
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2,9)
+    getaddrinfo_a(0, NULL, 0, NULL);
+    return 0;
+#else
+    return broken;
+#endif
+}
+''', dependencies: libanl, name: 'native getaddrinfo_a')
+  if have_gaia
+    adns = 'libc'
+    cdata.set('HAVE_GETADDRINFO_A', 1,
+              description: 'Define to 1 if you have the getaddrinfo_a() function.')
+    dns_deps = [libanl]
+  else
+    adns = 'compat (pthread)'
+  endif
+endif
+
+# ----------------------------------------------------------------------
+# Generate the config header.
+#
+# libusual normally includes <usual/config.h>; when USUAL_TEST_CONFIG is set it
+# includes "test_config.h" instead (see lib/usual/base.h). We use that hook so
+# the generated header lands in the build directory rather than the source tree.
+# ----------------------------------------------------------------------
+
+config_h = configure_file(output: 'test_config.h', configuration: cdata)
+add_project_arguments('-DUSUAL_TEST_CONFIG', language: 'c')
+
+# ----------------------------------------------------------------------
+# Warning flags (mirrors the WFLAGS antimake enables)
+# ----------------------------------------------------------------------
+
+# Exact WFLAGS set the autoconf build selected (see AC_USUAL_* in lib/m4/usual.m4).
+# Matching it matters because CI builds with -Werror (meson's -Dwerror=true), so a
+# stricter set here would fail on warnings the autoconf build deliberately silenced
+# (notably -Wno-missing-field-initializers). get_supported_arguments mirrors the
+# per-flag compile probe autoconf does.
+warning_flags = [
+  '-Wall',
+  '-Wextra',
+  # turn off noise from -Wextra
+  '-Wno-unused-parameter',
+  '-Wno-missing-field-initializers',
+  # things -Wextra does not turn on by itself
+  '-Wmissing-prototypes',
+  '-Wpointer-arith',
+  '-Wendif-labels',
+  '-Wdeclaration-after-statement',
+  '-Wold-style-definition',
+  '-Wstrict-prototypes',
+  '-Wundef',
+  '-Wformat=2',
+  '-Wuninitialized',
+  '-Wmissing-format-attribute',
+]
+add_project_arguments(cc.get_supported_arguments(warning_flags), language: 'c')
+
+# ----------------------------------------------------------------------
+# Sources
+#
+# The libusual file set matches what antimake's find_modules.sh selects for
+# pgbouncer (i.e. the modules actually reached through #include <usual/...>).
+# The TLS files are always compiled; their bodies are guarded by
+# USUAL_LIBSSL_FOR_TLS and collapse to nothing when OpenSSL is disabled.
+# ----------------------------------------------------------------------
 
 libusual_sources = files(
   'lib/usual/aatree.c',
   'lib/usual/base.c',
   'lib/usual/cbtree.c',
   'lib/usual/cfparser.c',
+  'lib/usual/crypto/chacha.c',
+  'lib/usual/crypto/csrandom.c',
+  'lib/usual/crypto/digest.c',
+  'lib/usual/crypto/entropy.c',
+  'lib/usual/crypto/keccak.c',
+  'lib/usual/crypto/keccak_prng.c',
+  'lib/usual/crypto/md5.c',
   'lib/usual/cxalloc.c',
   'lib/usual/cxextra.c',
   'lib/usual/err.c',
   'lib/usual/fileutil.c',
+  'lib/usual/getopt.c',
+  'lib/usual/list.c',
   'lib/usual/logging.c',
   'lib/usual/mbuf.c',
+  'lib/usual/mempool.c',
+  'lib/usual/netdb.c',
   'lib/usual/pgutil.c',
+  'lib/usual/regex.c',
   'lib/usual/safeio.c',
+  'lib/usual/signal.c',
   'lib/usual/slab.c',
   'lib/usual/socket.c',
+  'lib/usual/socket_ntop.c',
+  'lib/usual/socket_pton.c',
   'lib/usual/string.c',
   'lib/usual/strpool.c',
   'lib/usual/time.c',
-  'lib/usual/crypto/csrandom.c',
-  'lib/usual/crypto/keccak.c',
-  'lib/usual/crypto/keccak_prng.c',
   'lib/usual/tls/tls.c',
   'lib/usual/tls/tls_cert.c',
   'lib/usual/tls/tls_client.c',
@@ -158,64 +497,134 @@ libusual_sources = files(
   'lib/usual/tls/tls_verify.c',
 )
 
-pgbouncer = executable('pgbouncer',
-           'src/admin.c',
-           'src/client.c',
-           'src/dnslookup.c',
-           'src/hba.c',
-           'src/janitor.c',
-           'src/ldapauth.c',
-           'src/loader.c',
-           'src/messages.c',
-           'src/main.c',
-           'src/objects.c',
-           'src/pam.c',
-           'src/pktbuf.c',
-           'src/pooler.c',
-           'src/proto.c',
-           'src/prepare.c',
-           'src/sbuf.c',
-           'src/scram.c',
-           'src/server.c',
-           'src/stats.c',
-           'src/system.c',
-           'src/takeover.c',
-           'src/util.c',
-           'src/varcache.c',
-           'src/common/base64.c',
-           'src/common/bool.c',
-           'src/common/cryptohash.c',
-           'src/common/hmac.c',
-           'src/common/pgstrcasecmp.c',
-           'src/common/saslprep.c',
-           'src/common/scram-common.c',
-           'src/common/sha2.c',
-           'src/common/string.c',
-           'src/common/unicode_norm.c',
-           'src/common/wchar.c',
-           libusual_sources,
-           config_h,
-
-           include_directories: ['include', 'lib'],
-           install: true,
-           dependencies: [libcares, libevent, openssl, systemd],
+pgbouncer_sources = files(
+  'src/admin.c',
+  'src/client.c',
+  'src/dnslookup.c',
+  'src/hba.c',
+  'src/janitor.c',
+  'src/ldapauth.c',
+  'src/loader.c',
+  'src/main.c',
+  'src/messages.c',
+  'src/objects.c',
+  'src/pam.c',
+  'src/pktbuf.c',
+  'src/pooler.c',
+  'src/prepare.c',
+  'src/proto.c',
+  'src/sbuf.c',
+  'src/scram.c',
+  'src/server.c',
+  'src/stats.c',
+  'src/system.c',
+  'src/takeover.c',
+  'src/util.c',
+  'src/varcache.c',
+  'src/common/base64.c',
+  'src/common/bool.c',
+  'src/common/cryptohash.c',
+  'src/common/hmac.c',
+  'src/common/pgstrcasecmp.c',
+  'src/common/saslprep.c',
+  'src/common/scram-common.c',
+  'src/common/sha2.c',
+  'src/common/string.c',
+  'src/common/unicode_norm.c',
+  'src/common/wchar.c',
 )
 
-pandoc = find_program('pandoc', required: true, native: true)
-python = find_program('python3', 'python', required: true, native: true)
+pgbouncer_deps = [
+  libcares,
+  libevent,
+  openssl,
+  systemd,
+  pam,
+  ldap,
+  threads,
+] + dns_deps
 
-subdir('doc')
+if windows
+  # Winsock and the IP helper API, linked via LIBS in the autoconf build.
+  pgbouncer_deps += cc.find_library('ws2_32')
+  pgbouncer_deps += cc.find_library('iphlpapi')
+endif
+
+# '.' brings in the build root (where the generated test_config.h lives).
+if windows
+  pgbouncer_incdirs = include_directories('.', 'include', 'lib', 'win32')
+else
+  pgbouncer_incdirs = include_directories('.', 'include', 'lib')
+endif
+
+if windows
+  pgbouncer_sources += files('win32/win32support.c')
+  win = import('windows')
+  pgbouncer_sources += win.compile_resources('win32/win32ver.rc',
+                                             include_directories: pgbouncer_incdirs)
+endif
+
+pgbouncer = executable('pgbouncer',
+  pgbouncer_sources,
+  libusual_sources,
+  config_h,
+  include_directories: pgbouncer_incdirs,
+  dependencies: pgbouncer_deps,
+  install: true,
+)
+
+# ----------------------------------------------------------------------
+# win32 event log helper (pgbevent.dll)
+# ----------------------------------------------------------------------
+
+if windows
+  win = import('windows')
+  pgbevent_res = win.compile_resources('win32/eventmsg.rc',
+                                       include_directories: pgbouncer_incdirs)
+  shared_library('pgbevent',
+    'win32/pgbevent.c',
+    pgbevent_res,
+    name_prefix: '',
+    include_directories: pgbouncer_incdirs,
+    install: true,
+  )
+endif
+
+# ----------------------------------------------------------------------
+# Tools needed for docs and tests
+# ----------------------------------------------------------------------
+
+python = find_program('python3', 'python', required: true)
+pandoc = find_program('pandoc', required: false, native: true)
+
+# ----------------------------------------------------------------------
+# Docs and data installation
+# ----------------------------------------------------------------------
+
+if pandoc.found()
+  subdir('doc')
+else
+  message('pandoc not found: man pages will not be built or installed')
+endif
 
 pkgdocdir = get_option('datadir') / 'doc' / 'pgbouncer'
 
-install_data('README.md',
-             'NEWS.md',
-             'etc/pgbouncer-minimal.ini',
-             'etc/pgbouncer.ini',
-             'etc/pgbouncer.service',
-             'etc/pgbouncer.socket',
-             'etc/userlist.txt',
-             install_dir: pkgdocdir)
+install_data(
+  'README.md',
+  'NEWS.md',
+  'etc/pgbouncer-minimal.ini',
+  'etc/pgbouncer.ini',
+  'etc/pgbouncer.service',
+  'etc/pgbouncer.socket',
+  'etc/userlist.txt',
+  install_dir: pkgdocdir,
+)
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+subdir('test')
 
 test('optscan',
      files('etc/optscan.sh'),
@@ -223,15 +632,42 @@ test('optscan',
 
 test('pytest',
      python,
-     args: ['-m', 'pytest', '-n', 'auto', '-v', '..'],
+     args: ['-m', 'pytest', '-n', 'auto', '-r', 's'],
      env: {
-            'BOUNCER_EXE': pgbouncer.full_path(),
-            'PYTHONIOENCODING': 'utf8',
-            'TEST_USE_LDAP': '',
-            'TEST_USE_TLS': '1',
-          },
+       'BOUNCER_EXE': pgbouncer.full_path(),
+       'PYTHONIOENCODING': 'utf8',
+       'TEST_USE_LDAP': ldap.found() ? '1' : '',
+       'TEST_USE_TLS': openssl.found() ? '1' : '',
+     },
+     workdir: meson.project_source_root() / 'test',
      depends: [pgbouncer],
      timeout: 1000,
     )
 
-subdir('test')
+# ----------------------------------------------------------------------
+# Convenience developer targets (mirrors the Makefile phony targets)
+# ----------------------------------------------------------------------
+
+ruff = find_program('ruff', required: false)
+if ruff.found()
+  run_target('lint', command: [ruff, 'check'])
+endif
+
+ctags = find_program('ctags', required: false)
+if ctags.found()
+  run_target('tags',
+             command: [ctags, '-R', 'src', 'include', 'lib/usual'])
+endif
+
+# ----------------------------------------------------------------------
+# Configuration summary
+# ----------------------------------------------------------------------
+
+summary({
+  'adns': adns,
+  'ldap': ldap.found(),
+  'pam': pam.found(),
+  'systemd': systemd.found(),
+  'tls': openssl.found(),
+  'cassert': get_option('cassert'),
+}, section: 'PgBouncer')

--- a/meson.build
+++ b/meson.build
@@ -10,9 +10,9 @@ project('pgbouncer',
           # The C standard is left at the compiler default; the C11 requirement
           # is enforced by an explicit probe below (see AC_USUAL_C11), which only
           # adds a -std= flag when the default is not already C11.
-          # We manage the warning flags explicitly below to match the set the
-          # autoconf build used, so keep meson from injecting its own.
-          'warning_level=0',
+          # warning_level=2 supplies -Wall -Wextra (the rest of the autoconf
+          # WFLAGS set is added explicitly below).
+          'warning_level=2',
         ],
 )
 
@@ -479,8 +479,7 @@ add_project_arguments('-DUSUAL_TEST_CONFIG', language: 'c')
 # (notably -Wno-missing-field-initializers). get_supported_arguments mirrors the
 # per-flag compile probe autoconf does.
 warning_flags = [
-  '-Wall',
-  '-Wextra',
+  # -Wall -Wextra come from warning_level=2 above.
   # turn off noise from -Wextra
   '-Wno-unused-parameter',
   '-Wno-missing-field-initializers',

--- a/meson.build
+++ b/meson.build
@@ -726,8 +726,6 @@ test('pytest',
      env: {
        'BOUNCER_EXE': pgbouncer.full_path(),
        'PYTHONIOENCODING': 'utf8',
-       'TEST_USE_LDAP': ldap.found() ? '1' : '',
-       'TEST_USE_TLS': openssl.found() ? '1' : '',
      },
      workdir: meson.project_source_root() / 'test',
      depends: [pgbouncer],

--- a/meson.build
+++ b/meson.build
@@ -691,28 +691,17 @@ test('optscan',
      files('etc/optscan.sh'),
      workdir: meson.project_source_root())
 
-# Pick the command used to run the test suite. An explicit -Dpytest=... wins
-# (its first element is the program, the rest are leading arguments); otherwise
-# prefer the `pytest` console script and fall back to `python -m pytest`. This is
-# resolved at configure time, so CI puts the test dependencies (its venv) on PATH
-# before running `meson setup`.
+# Pick the binary used to run the test suite. An explicit -Dpytest=... wins;
+# otherwise prefer the `pytest` console script and fall back to `python -m
+# pytest`.
 pytest_opt = get_option('pytest')
-if pytest_opt.length() > 0
-  pytest_exe = find_program(pytest_opt[0])
-  pytest_args = []
-  is_first = true
-  foreach a : pytest_opt
-    if is_first
-      is_first = false
-    else
-      pytest_args += a
-    endif
-  endforeach
+pytest_args = []
+if pytest_opt != ''
+  pytest_exe = find_program(pytest_opt)
 else
   pytest = find_program('pytest', required: false)
   if pytest.found()
     pytest_exe = pytest
-    pytest_args = []
   else
     pytest_exe = python
     pytest_args = ['-m', 'pytest']

--- a/meson.build
+++ b/meson.build
@@ -4,11 +4,11 @@ project('pgbouncer',
         license: 'ISC',
         meson_version: '>= 0.60',
         default_options: [
+          # The C standard is left at the compiler default; the C11 requirement
+          # is enforced by an explicit probe below (see AC_USUAL_C11), which only
+          # adds a -std= flag when the default is not already C11.
           # We manage the warning flags explicitly below to match the set the
-          # autoconf build used, so keep meson from injecting its own. The C
-          # standard is deliberately left at the compiler default (as the
-          # autoconf build did): forcing an older -std would make clang flag
-          # the code's typedef redefinitions as a "C11 feature".
+          # autoconf build used, so keep meson from injecting its own.
           'warning_level=0',
         ],
 )
@@ -17,6 +17,54 @@ cc = meson.get_compiler('c')
 fs = import('fs')
 host_system = host_machine.system()
 windows = host_system == 'windows'
+
+# ----------------------------------------------------------------------
+# Require a C11-capable compiler (mirrors AC_USUAL_C11).
+#
+# Prefer the compiler's default mode so a newer default (e.g. gnu17) is kept;
+# only add an explicit -std= flag when the default is not already C11. A genuine
+# C11 mode is required, not just the underlying keywords: GCC accepts
+# _Static_assert/_Alignof/_Generic as extensions even in pre-C11 modes, while
+# glibc gates the <assert.h>/<stdalign.h> macros the code actually uses on
+# __STDC_VERSION__ >= 201112L. So key the probe off that macro and also exercise
+# the library macros themselves.
+# ----------------------------------------------------------------------
+
+c11_probe = '''
+#include <assert.h>
+#include <stdalign.h>
+#if __STDC_VERSION__ < 201112L
+#error "C11 mode is not enabled"
+#endif
+static_assert(1, "static assertions work");
+_Noreturn void pgb_noret(void);
+_Noreturn void pgb_noret(void) { for (;;) {} }
+int main(void) {
+    int x = 0;
+    int g = _Generic(x, int: 1, default: 0);
+    int a = (int) alignof(int);
+    return g + a - g - a;
+}
+'''
+
+c11_flag = ''
+c11_ok = false
+foreach flag : ['', '-std=gnu11', '-std=c11']
+  if not c11_ok
+    label = flag == '' ? 'C11 support (compiler default)' : 'C11 support (@0@)'.format(flag)
+    if cc.compiles(c11_probe, args: flag == '' ? [] : [flag], name: label)
+      c11_ok = true
+      c11_flag = flag
+    endif
+  endif
+endforeach
+
+if not c11_ok
+  error('a C11-capable compiler is required to build this software')
+endif
+if c11_flag != ''
+  add_project_arguments(c11_flag, language: 'c')
+endif
 
 not_found_dep = dependency('', required: false)
 
@@ -648,10 +696,13 @@ test('pytest',
 # Convenience developer targets (mirrors the Makefile phony targets)
 # ----------------------------------------------------------------------
 
-ruff = find_program('ruff', required: false)
-if ruff.found()
-  run_target('lint', command: [ruff, 'check'])
-endif
+# Formatting and linting are handled by a standalone script so they do not
+# depend on the build system (dev/format.sh builds the pinned uncrustify and
+# drives ruff). These targets mirror the old `make format`/`format-check`/`lint`.
+format_sh = find_program('dev/format.sh')
+run_target('format', command: [format_sh, 'fix'])
+run_target('format-check', command: [format_sh, 'check'])
+run_target('lint', command: [format_sh, 'lint'])
 
 ctags = find_program('ctags', required: false)
 if ctags.found()

--- a/meson.build
+++ b/meson.build
@@ -2,10 +2,10 @@ project('pgbouncer',
         ['c'],
         version: '1.25.2',
         license: 'ISC',
-        # Kept low enough for the meson shipped by the distros we build on (the
-        # oldest being Debian bullseye's 0.56), so CI can install meson from the
-        # official package repos rather than pip.
-        meson_version: '>= 0.56.0',
+        # Kept in reach of the meson shipped by the distros we build on (the
+        # oldest being RHEL 8's 0.58), so CI can install meson from the official
+        # package repos rather than pip.
+        meson_version: '>= 0.58.0',
         default_options: [
           # The C standard is left at the compiler default; the C11 requirement
           # is enforced by an explicit probe below (see AC_USUAL_C11), which only

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,10 @@ project('pgbouncer',
         ['c'],
         version: '1.25.2',
         license: 'ISC',
-        meson_version: '>= 0.60',
+        # Kept low enough for the meson shipped by the distros we build on (the
+        # oldest being Debian bullseye's 0.56), so CI can install meson from the
+        # official package repos rather than pip.
+        meson_version: '>= 0.56.0',
         default_options: [
           # The C standard is left at the compiler default; the C11 requirement
           # is enforced by an explicit probe below (see AC_USUAL_C11), which only
@@ -366,8 +369,9 @@ endif
 # systemd (mirrors --with-systemd)
 # ----------------------------------------------------------------------
 
-systemdopt = get_option('systemd').disable_auto_if(host_system != 'linux')
-systemd = dependency('libsystemd', required: systemdopt)
+# libsystemd only exists on Linux; on other systems an `auto` lookup simply
+# comes back not-found, so no special-casing is needed.
+systemd = dependency('libsystemd', required: get_option('systemd'))
 cdata.set('USE_SYSTEMD', systemd.found() ? 1 : false,
           description: 'Define to build with systemd support. (-Dsystemd=enabled)')
 
@@ -375,10 +379,14 @@ cdata.set('USE_SYSTEMD', systemd.found() ? 1 : false,
 # PAM (mirrors --with-pam)
 # ----------------------------------------------------------------------
 
+# pam/ldap are combo options ('auto'/'enabled'/'disabled') rather than meson
+# `feature`s: the feature accessors (.allowed(), and passing a feature to
+# find_library's `required`) need meson 0.59, newer than our floor. The string
+# compare below reproduces the same semantics on older meson.
 pamopt = get_option('pam')
 pam = not_found_dep
-if pamopt.allowed()
-  pam = cc.find_library('pam', required: pamopt, has_headers: ['security/pam_appl.h'])
+if pamopt != 'disabled'
+  pam = cc.find_library('pam', required: pamopt == 'enabled', has_headers: ['security/pam_appl.h'])
 endif
 if pam.found()
   cdata.set('HAVE_PAM', 1, description: 'PAM support.')
@@ -391,8 +399,8 @@ endif
 
 ldapopt = get_option('ldap')
 ldap = not_found_dep
-if ldapopt.allowed()
-  ldap = cc.find_library('ldap', required: ldapopt, has_headers: ['ldap.h'])
+if ldapopt != 'disabled'
+  ldap = cc.find_library('ldap', required: ldapopt == 'enabled', has_headers: ['ldap.h'])
 endif
 if ldap.found()
   cdata.set('HAVE_LDAP', 1, description: 'LDAP support.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,32 @@
+# Compilation options
+
+option('cassert', type: 'boolean', value: false,
+       description: 'Turn on assertion checking in code')
+
+# TODO
+option('evdns', type: 'boolean', value: false,
+       description: 'Use libevent for DNS lookups')
+
+# TODO
+option('root-ca-file', type: 'string', value: 'TODO',
+       description: 'Specify where the root CA certificates are')
+
+# External dependencies
+
+option('cares', type: 'feature', value: 'auto',
+       description: 'Build with c-ares support')
+
+# TODO
+option('ldap', type: 'feature', value: 'auto',
+       description: 'Build with LDAP support')
+
+# TODO
+option('pam', type: 'feature', value: 'auto',
+       description: 'Build with PAM support')
+
+# TODO
+option('openssl', type: 'feature', value: 'auto',
+       description: 'Build with OpenSSL support')
+
+option('systemd', type: 'feature', value: 'auto',
+       description: 'Build with systemd support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,8 +5,8 @@ option('cassert', type: 'boolean', value: false,
 
 # Test options
 
-option('pytest', type: 'array', value: [],
-       description: 'Command used to run the test suite (default: the pytest script if on PATH, else python -m pytest). Example: -Dpytest=python3,-m,pytest')
+option('pytest', type: 'string', value: '',
+       description: 'Path to the pytest binary used to run the test suite (default: the pytest script if on PATH, else python -m pytest)')
 
 option('evdns', type: 'boolean', value: true,
        description: 'Use libevent for DNS lookups (only used when c-ares is not available)')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,30 +3,25 @@
 option('cassert', type: 'boolean', value: false,
        description: 'Turn on assertion checking in code')
 
-# TODO
-option('evdns', type: 'boolean', value: false,
-       description: 'Use libevent for DNS lookups')
+option('evdns', type: 'boolean', value: true,
+       description: 'Use libevent for DNS lookups (only used when c-ares is not available)')
 
-# TODO
-option('root-ca-file', type: 'string', value: 'TODO',
-       description: 'Specify where the root CA certificates are')
+option('root_ca_file', type: 'string', value: '',
+       description: 'Path to the root CA certificates (empty = autodetect a system bundle)')
 
 # External dependencies
 
 option('cares', type: 'feature', value: 'auto',
-       description: 'Build with c-ares support')
+       description: 'Build with c-ares support (preferred DNS backend when available)')
 
-# TODO
 option('ldap', type: 'feature', value: 'auto',
-       description: 'Build with LDAP support')
+       description: 'Build with LDAP authentication support')
 
-# TODO
 option('pam', type: 'feature', value: 'auto',
-       description: 'Build with PAM support')
+       description: 'Build with PAM authentication support')
 
-# TODO
 option('openssl', type: 'feature', value: 'auto',
-       description: 'Build with OpenSSL support')
+       description: 'Build with OpenSSL (TLS) support')
 
 option('systemd', type: 'feature', value: 'auto',
        description: 'Build with systemd support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,11 @@
 option('cassert', type: 'boolean', value: false,
        description: 'Turn on assertion checking in code')
 
+# Test options
+
+option('pytest', type: 'array', value: [],
+       description: 'Command used to run the test suite (default: the pytest script if on PATH, else python -m pytest). Example: -Dpytest=python3,-m,pytest')
+
 option('evdns', type: 'boolean', value: true,
        description: 'Use libevent for DNS lookups (only used when c-ares is not available)')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,13 +19,10 @@ option('root_ca_file', type: 'string', value: '',
 option('cares', type: 'feature', value: 'auto',
        description: 'Build with c-ares support (preferred DNS backend when available)')
 
-# Off by default, matching autoconf where LDAP/PAM were opt-in (--with-ldap /
-# --with-pam). Both spawn a background thread, whose stack valgrind reports as a
-# "possibly lost" block, so auto-enabling them would break the valgrind job.
-option('ldap', type: 'feature', value: 'disabled',
+option('ldap', type: 'feature', value: 'auto',
        description: 'Build with LDAP authentication support')
 
-option('pam', type: 'feature', value: 'disabled',
+option('pam', type: 'feature', value: 'auto',
        description: 'Build with PAM authentication support')
 
 option('openssl', type: 'feature', value: 'auto',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,10 +19,12 @@ option('root_ca_file', type: 'string', value: '',
 option('cares', type: 'feature', value: 'auto',
        description: 'Build with c-ares support (preferred DNS backend when available)')
 
-option('ldap', type: 'feature', value: 'auto',
+# combo rather than feature: these are probed with find_library, and passing a
+# feature to find_library's `required` needs meson 0.59 (newer than our floor).
+option('ldap', type: 'combo', choices: ['auto', 'enabled', 'disabled'], value: 'auto',
        description: 'Build with LDAP authentication support')
 
-option('pam', type: 'feature', value: 'auto',
+option('pam', type: 'combo', choices: ['auto', 'enabled', 'disabled'], value: 'auto',
        description: 'Build with PAM authentication support')
 
 option('openssl', type: 'feature', value: 'auto',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,10 +19,13 @@ option('root_ca_file', type: 'string', value: '',
 option('cares', type: 'feature', value: 'auto',
        description: 'Build with c-ares support (preferred DNS backend when available)')
 
-option('ldap', type: 'feature', value: 'auto',
+# Off by default, matching autoconf where LDAP/PAM were opt-in (--with-ldap /
+# --with-pam). Both spawn a background thread, whose stack valgrind reports as a
+# "possibly lost" block, so auto-enabling them would break the valgrind job.
+option('ldap', type: 'feature', value: 'disabled',
        description: 'Build with LDAP authentication support')
 
-option('pam', type: 'feature', value: 'auto',
+option('pam', type: 'feature', value: 'disabled',
        description: 'Build with PAM authentication support')
 
 option('openssl', type: 'feature', value: 'auto',

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,26 @@
+hba_test = executable('hba_test',
+                      'hba_test.c',
+                      '../src/hba.c',
+                      '../src/util.c',
+                      libusual_sources,
+                      config_h,
+                      build_by_default: false,
+                      include_directories: ['..', '../include', '../lib'],
+                      dependencies: [libevent, openssl, systemd],
+                     )
+
+libpq = dependency('libpq', required: false, disabler: true)
+
+asynctest = executable('asynctest',
+                       'asynctest.c',
+                       libusual_sources,
+                       config_h,
+                       build_by_default: false,
+                       include_directories: ['..', '../include', '../lib'],
+                       dependencies: [libevent, libpq, systemd],
+                      )
+
+test('hba_test',
+     hba_test,
+     workdir: meson.project_source_root() / 'test',
+    )

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,3 +1,7 @@
+# The '..' include dir also brings in the build root (its build-tree
+# counterpart), which is where the generated test_config.h lives.
+test_incdirs = include_directories('..', '../include', '../lib')
+
 hba_test = executable('hba_test',
                       'hba_test.c',
                       '../src/hba.c',
@@ -5,8 +9,8 @@ hba_test = executable('hba_test',
                       libusual_sources,
                       config_h,
                       build_by_default: false,
-                      include_directories: ['..', '../include', '../lib'],
-                      dependencies: [libevent, openssl, systemd],
+                      include_directories: test_incdirs,
+                      dependencies: [libevent, openssl, systemd, threads],
                      )
 
 libpq = dependency('libpq', required: false, disabler: true)
@@ -16,8 +20,8 @@ asynctest = executable('asynctest',
                        libusual_sources,
                        config_h,
                        build_by_default: false,
-                       include_directories: ['..', '../include', '../lib'],
-                       dependencies: [libevent, libpq, systemd],
+                       include_directories: test_incdirs,
+                       dependencies: [libevent, libpq, systemd, threads],
                       )
 
 test('hba_test',

--- a/test/meson.build
+++ b/test/meson.build
@@ -10,7 +10,7 @@ hba_test = executable('hba_test',
                       config_h,
                       build_by_default: false,
                       include_directories: test_incdirs,
-                      dependencies: [libevent, openssl, systemd, threads],
+                      dependencies: [libevent, openssl, systemd, threads] + net_deps,
                      )
 
 libpq = dependency('libpq', required: false, disabler: true)
@@ -21,7 +21,7 @@ asynctest = executable('asynctest',
                        config_h,
                        build_by_default: false,
                        include_directories: test_incdirs,
-                       dependencies: [libevent, libpq, systemd, threads],
+                       dependencies: [libevent, libpq, systemd, threads] + net_deps,
                       )
 
 test('hba_test',

--- a/test/utils.py
+++ b/test/utils.py
@@ -36,7 +36,7 @@ BOUNCER_INI = TEST_DIR / "test.ini"
 BOUNCER_AUTH = TEST_DIR / "userlist.txt"
 BOUNCER_PID = TEST_DIR / "test.pid"
 BOUNCER_PORT = 6667
-BOUNCER_EXE = TEST_DIR / "../pgbouncer"
+BOUNCER_EXE = os.environ.get("BOUNCER_EXE", TEST_DIR / "../pgbouncer")
 NEW_CA_SCRIPT = TEST_DIR / "ssl" / "newca.sh"
 NEW_SITE_SCRIPT = TEST_DIR / "ssl" / "newsite.sh"
 ENABLE_VALGRIND = bool(os.environ.get("ENABLE_VALGRIND"))
@@ -195,6 +195,8 @@ LIBPQ_SUPPORTS_PIPELINING = psycopg.pq.version() >= 140000
 
 
 def get_ldap_support():
+    if "TEST_USE_LDAP" in os.environ:
+        return bool(os.environ["TEST_USE_LDAP"])
     with open("../config.mak", encoding="utf-8") as f:
         match = re.search(r"ldap_support = (\w+)", f.read())
         assert match is not None
@@ -205,6 +207,8 @@ LDAP_SUPPORT = get_ldap_support()
 
 
 def get_tls_support():
+    if "TEST_USE_TLS" in os.environ:
+        return bool(os.environ["TEST_USE_TLS"])
     with open("../config.mak", encoding="utf-8") as f:
         match = re.search(r"tls_support = (\w+)", f.read())
         assert match is not None

--- a/test/utils.py
+++ b/test/utils.py
@@ -194,25 +194,40 @@ PG_SUPPORTS_SCRAM = PG_MAJOR_VERSION >= 10
 LIBPQ_SUPPORTS_PIPELINING = psycopg.pq.version() >= 140000
 
 
-def get_ldap_support():
-    if "TEST_USE_LDAP" in os.environ:
-        return bool(os.environ["TEST_USE_LDAP"])
-    with open("../config.mak", encoding="utf-8") as f:
-        match = re.search(r"ldap_support = (\w+)", f.read())
+def get_build_feature(config_mak_key, meson_define):
+    """Detect whether pgbouncer was built with a certain feature enabled.
+
+    An autotools build records this in config.mak, a meson build in the
+    generated test_config.h header. For meson we assume the conventional
+    "build" directory name, since the tests have no way of knowing where
+    the build directory actually is.
+    """
+    meson_config = Path("../build/test_config.h")
+    if meson_config.exists():
+        return (
+            re.search(rf"#define {meson_define}\b", meson_config.read_text())
+            is not None
+        )
+    config_mak = Path("../config.mak")
+    if config_mak.exists():
+        match = re.search(rf"{config_mak_key} = (\w+)", config_mak.read_text())
         assert match is not None
         return match.group(1) == "yes"
+    raise FileNotFoundError(
+        "Could not find ../config.mak (autotools) or ../build/test_config.h (meson). "
+        "Configure the project first, and for meson use 'build' as the build directory."
+    )
+
+
+def get_ldap_support():
+    return get_build_feature("ldap_support", "HAVE_LDAP")
 
 
 LDAP_SUPPORT = get_ldap_support()
 
 
 def get_tls_support():
-    if "TEST_USE_TLS" in os.environ:
-        return bool(os.environ["TEST_USE_TLS"])
-    with open("../config.mak", encoding="utf-8") as f:
-        match = re.search(r"tls_support = (\w+)", f.read())
-        assert match is not None
-        return match.group(1) == "yes"
+    return get_build_feature("tls_support", "USUAL_LIBSSL_FOR_TLS")
 
 
 TLS_SUPPORT = get_tls_support()

--- a/win32/win32ver.rc
+++ b/win32/win32ver.rc
@@ -1,5 +1,12 @@
 #include <winver.h>
+/* Match how lib/usual/base.h picks up the generated config: the meson build
+ * defines USUAL_TEST_CONFIG and generates test_config.h, while autoconf
+ * generates usual/config.h. */
+#ifdef USUAL_TEST_CONFIG
+#include "test_config.h"
+#else
 #include "usual/config.h"
+#endif
 
 // https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 


### PR DESCRIPTION
This adds support to build PgBouncer with meson. Heavily based on #1077 but with a bunch of fixes and improved CI support (it uses Github Actions now). We continue supporting autoconf builds for the time being too. At some point we should probably get rid of that, but by supporting both for a while we can iron out any issues with the meson build system.

Fixes #1077