### PR TITLE
Fix issue: 1509 Adding fix in fake_param_list so that extra_float_digit can be ignored while jdbc driver tries to connect to pgbouncer admin database

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -172,7 +172,7 @@ static const struct FakeParam fake_param_list[] = {
 	{ "standard_conforming_strings", "on" },
 	{ "datestyle", "ISO" },
 	{ "timezone", "GMT" },
-	{ "extra_float_digits", "2"} ,
+	{ "extra_float_digits", "2"},
 	{ NULL },
 };
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -172,6 +172,7 @@ static const struct FakeParam fake_param_list[] = {
 	{ "standard_conforming_strings", "on" },
 	{ "datestyle", "ISO" },
 	{ "timezone", "GMT" },
+	{ "extra_float_digits", "2"} ,
 	{ NULL },
 };
 


### PR DESCRIPTION
Fixing connection failures with newer pgjdbc drivers that send SET extra_float_digits unconditionally after connecting to the
pgbouncer admin database so in fake_param_list I have added a key so that it can compare and since it will get the key so that it can fake_set it

https://github.com/pgbouncer/pgbouncer/issues/1509

So before the fix:

=== Testing: pgbouncer admin ===
URL: jdbc:postgresql://127.0.0.1:6444/pgbouncer
FAILED: ERROR: SET failed
SQLState: 08P01

In pgbouncer side logs:
2026-07-06 16:07:04.426 UTC [13098] DEBUG C-0x5babc231f990: (nodb)/(nouser)@127.0.0.1:56936 using application_name: PostgreSQL JDBC Driver
2026-07-06 16:07:04.426 UTC [13098] DEBUG pktbuf_dynamic(512): 0x5babc2328c20
2026-07-06 16:07:04.426 UTC [13098] DEBUG C-0x5babc231f990: pgbouncer/pgbouncer@127.0.0.1:56936 logged in
2026-07-06 16:07:04.549 UTC [13098] DEBUG got admin query: SET extra_float_digits = 2
2026-07-06 16:07:04.550 UTC [13098] ERROR unknown parameter: pgbouncer/extra_float_digits
2026-07-06 16:07:04.550 UTC [13098] ERROR SET failed
2026-07-06 16:07:04.550 UTC [13098] WARNING C-0x5babc231f990: pgbouncer/pgbouncer@127.0.0.1:56936 pooler error: SET failed
^C2026-07-06 16:18:18.192 UTC [13098] LOG got SIGINT, shutting down, waiting for all servers connections to be released
2026-07-06 16:18:18.240 UTC [13098] LOG server connections dropped, exiting

After the fix:
=== Testing: pgbouncer admin ===
URL: jdbc:postgresql://127.0.0.1:6444/pgbouncer?preferQueryMode=simple
Jul 06, 2026 4:26:00 PM org.postgresql.jdbc.PgConnection <init>
WARNING: Unsupported Server Version: 1.25.2/bouncer
SUCCESS: Connected to pgbouncer admin
Admin version: PgBouncer 1.25.2

pgbouncer admin side

026-07-06 16:26:00.641 UTC [13173] ERROR C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55078 auth_type=any requires forced user
2026-07-06 16:26:00.641 UTC [13173] WARNING C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55078 pooler error: bouncer config error
2026-07-06 16:26:00.656 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 P: got connection: 127.0.0.1:55082 -> 127.0.0.1:6444
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 got var: user=postgres
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 got var: database=pgbouncer
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 got var: client_encoding=UTF8
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 got var: DateStyle=ISO
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 got var: TimeZone=Etc/UTC
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: (nodb)/(nouser)@127.0.0.1:55082 using application_name: PostgreSQL JDBC Driver
2026-07-06 16:26:00.659 UTC [13173] DEBUG C-0x5d88f8c1b990: pgbouncer/pgbouncer@127.0.0.1:55082 logged in
2026-07-06 16:26:00.766 UTC [13173] DEBUG got admin query: SET extra_float_digits = 2
2026-07-06 16:26:00.766 UTC [13173] DEBUG pktbuf_dynamic(256): 0x5d88f8c35e60
2026-07-06 16:26:00.766 UTC [13173] DEBUG pktbuf_send_func(9, 4, 0x5d88f8c35e60)
2026-07-06 16:26:00.766 UTC [13173] DEBUG pktbuf_free(0x5d88f8c35e60)
2026-07-06 16:26:00.864 UTC [13173] DEBUG got admin query: SHOW VERSION
2026-07-06 16:26:00.864 UTC [13173] DEBUG pktbuf_dynamic(128): 0x5d88f8c36950
2026-07-06 16:26:00.864 UTC [13173] DEBUG pktbuf_send_func(9, 4, 0x5d88f8c36950)
2026-07-06 16:26:00.864 UTC [13173] DEBUG pktbuf_free(0x5d88f8c36950)

pgbouncer.ini file sample used for testing:
[databases]
mydb = host=127.0.0.1 port=5432 dbname=postgres
[pgbouncer]
listen_port = 6444
#unix_socket_dir = /pgbouncer_socket
listen_addr = 127.0.0.1
auth_type = any
pool_mode = session
max_client_conn = 30
default_pool_size = 4
min_pool_size = 1
reserve_pool_size = 1
reserve_pool_timeout = 1
#ignore_startup_parameters = extra_float_digits

# Log settings
log_connections = 0
log_disconnections = 0
log_pooler_errors = 1
log_stats = 0
stats_period = 30
admin_users = postgres
stats_users = pgbouncer_stats

# Connection sanity checks, timeouts
server_reset_query = DISCARD ALL;