### PR TITLE
Fix SHOW USERS after forced user reload

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -522,6 +522,7 @@ struct PgCredentials {
 	char passwd[MAX_PASSWORD];
 	bool mock_auth;			/* not a real user, only for mock auth */
 	bool dynamic_passwd;		/* does the password need to be refreshed every use */
+	bool forced_user;		/* credentials were created for a database forced user */
 
 	/*
 	 * global_user points at the global user which is used for configuration

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -915,6 +915,8 @@ void janitor_setup(void)
 void kill_pool(PgPool *pool)
 {
 	const char *reason = "database removed";
+	PgCredentials *user_credentials = pool->user_credentials;
+	PgCredentials *forced_user_credentials = pool->db->forced_user_credentials;
 
 	close_client_list(&pool->active_client_list, reason);
 	close_client_list(&pool->waiting_client_list, reason);
@@ -937,6 +939,9 @@ void kill_pool(PgPool *pool)
 	varcache_clean(&pool->orig_vars);
 	slab_free(var_list_cache, pool->orig_vars.var_list);
 	slab_free(pool_cache, pool);
+
+	if (user_credentials && user_credentials->forced_user && user_credentials != forced_user_credentials)
+		slab_free(credentials_cache, user_credentials);
 }
 
 void kill_peer_pool(PgPool *pool)

--- a/src/objects.c
+++ b/src/objects.c
@@ -520,6 +520,7 @@ static PgGlobalUser *add_new_global_user(const char *name, const char *passwd)
 		return NULL;
 
 	user->credentials.global_user = user;
+	user->credentials.forced_user = false;
 
 	list_init(&user->head);
 	list_init(&user->pool_list);
@@ -556,6 +557,7 @@ PgCredentials *add_dynamic_credentials(PgDatabase *db, const char *name, const c
 			return NULL;
 
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
+		credentials->forced_user = false;
 
 		credentials->global_user = find_or_add_new_global_user(name, NULL);
 		if (!credentials->global_user) {
@@ -587,6 +589,7 @@ PgCredentials *add_pam_credentials(const char *name, const char *passwd)
 			return NULL;
 
 		safe_strcpy(credentials->name, name, sizeof(credentials->name));
+		credentials->forced_user = false;
 
 		credentials->global_user = find_or_add_new_global_user(name, NULL);
 		if (!credentials->global_user) {
@@ -601,15 +604,36 @@ PgCredentials *add_pam_credentials(const char *name, const char *passwd)
 	return credentials;
 }
 
+static bool forced_user_credentials_has_pool(PgDatabase *db, PgCredentials *credentials)
+{
+	struct List *item;
+	PgPool *pool;
+
+	list_for_each(item, &credentials->global_user->pool_list) {
+		pool = container_of(item, PgPool, map_head);
+		if (pool->db == db && pool->user_credentials == credentials)
+			return true;
+	}
+	return false;
+}
+
 /* create separate PgCredentials object for this database */
 PgCredentials *force_user_credentials(PgDatabase *db, const char *name, const char *passwd)
 {
 	PgCredentials *credentials = db->forced_user_credentials;
+	PgCredentials *old_credentials = NULL;
+
+	if (credentials && strcmp(credentials->name, name) != 0) {
+		old_credentials = credentials;
+		credentials = NULL;
+	}
+
 	if (!credentials) {
 		credentials = slab_alloc(credentials_cache);
 		if (!credentials)
 			return NULL;
 
+		credentials->forced_user = true;
 		credentials->global_user = find_or_add_new_global_user(name, NULL);
 		if (!credentials->global_user) {
 			slab_free(credentials_cache, credentials);
@@ -619,6 +643,8 @@ PgCredentials *force_user_credentials(PgDatabase *db, const char *name, const ch
 	safe_strcpy(credentials->name, name, sizeof(credentials->name));
 	safe_strcpy(credentials->passwd, passwd, sizeof(credentials->passwd));
 	db->forced_user_credentials = credentials;
+	if (old_credentials && !forced_user_credentials_has_pool(db, old_credentials))
+		slab_free(credentials_cache, old_credentials);
 	return credentials;
 }
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -5,7 +5,7 @@ import psycopg
 import pytest
 from psycopg.rows import dict_row
 
-from .utils import Bouncer, capture, run
+from .utils import Bouncer, capture, run, wait_until
 
 
 def test_reload_error(bouncer):
@@ -73,6 +73,45 @@ def test_show_user(bouncer):
         assert ["1", ""] == [
             user["reserve_pool_size"].lstrip().rstrip() for user in users
         ]
+
+
+def test_show_users_after_forced_user_reload(bouncer):
+    config_template = f"""
+    [databases]
+    db1 = host={bouncer.pg.host} port={bouncer.pg.port} dbname=p0 user={{forced_user}}
+
+    [pgbouncer]
+    auth_file = {bouncer.auth_path}
+    auth_type = trust
+    listen_addr = {bouncer.host}
+    listen_port = {bouncer.port}
+    admin_users = pgbouncer
+    pool_mode = session
+    logfile = {bouncer.log_path}
+    """
+
+    def get_user_connections(username):
+        users = bouncer.admin("SHOW USERS", row_factory=dict_row)
+        return [user for user in users if user["name"] == username][0][
+            "current_connections"
+        ]
+
+    with bouncer.run_with_config(config_template.format(forced_user="someuser")):
+        with bouncer.conn(dbname="db1", user="postgres") as conn:
+            assert conn.execute("SELECT current_user").fetchone() == ("someuser",)
+            assert get_user_connections("someuser") == 1
+            assert get_user_connections("pswcheck") == 0
+
+        with bouncer.ini_path.open("w") as f:
+            f.write(config_template.format(forced_user="pswcheck"))
+        bouncer.admin("RELOAD")
+
+        with bouncer.conn(dbname="db1", user="postgres") as conn:
+            assert conn.execute("SELECT current_user").fetchone() == ("pswcheck",)
+            for _ in wait_until("old forced user connection count was not cleared"):
+                if get_user_connections("someuser") == 0:
+                    break
+            assert get_user_connections("pswcheck") == 1
 
 
 def test_show(bouncer):


### PR DESCRIPTION
Fixes #1115

I reproduced the issue by configuring a database with a forced user, connecting to it, changing the forced user in the config, running `RELOAD`, and then reconnecting. The new connection used the new forced user correctly, but `SHOW USERS` still showed the old user's `current_connections` as non-zero.

The problem was that PgBouncer reused the same forced-user credentials object when the configured forced user changed. Old pools could still reference that object, so changing its `global_user` confused the per-user connection accounting.

This change creates a new forced-user credentials object when the forced user changes, while keeping the old one alive until old pools no longer reference it. That keeps the existing pool/user accounting model intact and lets old pools decrement the old user's counters correctly.

Changed files:

- `include/bouncer.h`: mark credentials that belong to a database forced user
- `src/objects.c`: create separate forced-user credentials when the forced user changes
- `src/janitor.c`: free old forced-user credentials after the old pool is removed
- `test/test_admin.py`: add a regression test for `SHOW USERS` after `RELOAD`

Tested with:

- `pytest -q test/test_admin.py::test_show_users_after_forced_user_reload`
- `pytest -q test/test_admin.py`
- `pytest -q test/test_limits.py -k 'show_users or user_connection or user_client'`
- full pytest run from `make check`: `265 passed, 12 skipped`
- `make -C test check`
- `make lint`
- `make format-check`