### PR TITLE
Fix stalled TLS connection when a packet straddles pkt_buf

### DIFF
--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -60,6 +60,8 @@ struct SBufIO {
 	ssize_t (*sbufio_recv)(SBuf *sbuf, void *buf, size_t len);
 	ssize_t (*sbufio_send)(SBuf *sbuf, const void *data, size_t len);
 	int (*sbufio_close)(SBuf *sbuf);
+	/* buffered data the poller cannot see (e.g. decrypted by TLS) */
+	size_t (*sbufio_pending)(SBuf *sbuf);
 };
 
 /*
@@ -168,6 +170,11 @@ static inline ssize_t sbuf_op_recv(SBuf *sbuf, void *buf, size_t len)
 static inline ssize_t sbuf_op_send(SBuf *sbuf, const void *buf, size_t len)
 {
 	return sbuf->ops->sbufio_send(sbuf, buf, len);
+}
+
+static inline size_t sbuf_op_pending(SBuf *sbuf)
+{
+	return sbuf->ops->sbufio_pending(sbuf);
 }
 
 static inline int sbuf_op_close(SBuf *sbuf)

--- a/lib/usual/tls/tls.c
+++ b/lib/usual/tls/tls.c
@@ -695,6 +695,13 @@ out:
 	return (rv);
 }
 
+size_t tls_pending(struct tls *ctx)
+{
+	if (ctx->ssl_conn == NULL)
+		return 0;
+	return SSL_pending(ctx->ssl_conn);
+}
+
 ssize_t tls_write(struct tls *ctx, const void *buf, size_t buflen)
 {
 	ssize_t rv = -1;

--- a/lib/usual/tls/tls.h
+++ b/lib/usual/tls/tls.h
@@ -134,6 +134,7 @@ int tls_connect_socket(struct tls *_ctx, int _s, const char *_servername);
 int tls_handshake(struct tls *_ctx);
 ssize_t tls_read(struct tls *_ctx, void *_buf, size_t _buflen);
 ssize_t tls_write(struct tls *_ctx, const void *_buf, size_t _buflen);
+size_t tls_pending(struct tls *_ctx);
 int tls_close(struct tls *_ctx);
 
 int tls_peer_cert_provided(struct tls *_ctx);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -89,11 +89,13 @@ static ssize_t raw_sbufio_peek(struct SBuf *sbuf, void *buf, size_t len);
 static ssize_t raw_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len);
 static ssize_t raw_sbufio_send(struct SBuf *sbuf, const void *data, size_t len);
 static int raw_sbufio_close(struct SBuf *sbuf);
+static size_t raw_sbufio_pending(struct SBuf *sbuf);
 static const SBufIO raw_sbufio_ops = {
 	raw_sbufio_peek,
 	raw_sbufio_recv,
 	raw_sbufio_send,
-	raw_sbufio_close
+	raw_sbufio_close,
+	raw_sbufio_pending
 };
 
 /* I/O over TLS */
@@ -102,11 +104,13 @@ static ssize_t tls_sbufio_peek(struct SBuf *sbuf, void *buf, size_t len);
 static ssize_t tls_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len);
 static ssize_t tls_sbufio_send(struct SBuf *sbuf, const void *data, size_t len);
 static int tls_sbufio_close(struct SBuf *sbuf);
+static size_t tls_sbufio_pending(struct SBuf *sbuf);
 static const SBufIO tls_sbufio_ops = {
 	tls_sbufio_peek,
 	tls_sbufio_recv,
 	tls_sbufio_send,
-	tls_sbufio_close
+	tls_sbufio_close,
+	tls_sbufio_pending
 };
 static void sbuf_tls_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf);
 static void sbuf_possible_direct_tls_startup_cb(evutil_socket_t fd, short flags, void *_sbuf);
@@ -1038,8 +1042,19 @@ try_more:
 skip_recv:
 	/* now handle it */
 	ok = sbuf_process_pending(sbuf);
-	if (!ok)
+	if (!ok) {
+		/*
+		 * Handler wants more data, but on TLS the rest of the packet
+		 * may already sit decrypted inside the TLS library where the
+		 * poller cannot see it.  Waiting for a read event would then
+		 * hang, so read it now instead.
+		 */
+		if (sbuf->sock && sbuf->wait_type == W_RECV && sbuf->io
+		    && iobuf_amount_recv(sbuf->io) > 0
+		    && sbuf_op_pending(sbuf) > 0)
+			goto try_more;
 		return;
+	}
 
 	/* if the buffer is full, there can be more data available */
 	if (iobuf_amount_recv(sbuf->io) <= 0)
@@ -1127,6 +1142,12 @@ static ssize_t raw_sbufio_peek(struct SBuf *sbuf, void *buf, size_t len)
 static ssize_t raw_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len)
 {
 	return safe_recv(sbuf->sock, dst, len, 0);
+}
+
+static size_t raw_sbufio_pending(struct SBuf *sbuf)
+{
+	/* unread data stays in the kernel, the poller sees it */
+	return 0;
 }
 
 static ssize_t raw_sbufio_send(struct SBuf *sbuf, const void *data, size_t len)
@@ -1510,6 +1531,13 @@ static ssize_t tls_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len)
 		errno = EIO;
 	}
 	return -1;
+}
+
+static size_t tls_sbufio_pending(struct SBuf *sbuf)
+{
+	if (sbuf->tls_state != SBUF_TLS_OK)
+		return 0;
+	return tls_pending(sbuf->tls);
 }
 
 static ssize_t tls_sbufio_send(struct SBuf *sbuf, const void *data, size_t len)

--- a/test/test_ssl_pending.py
+++ b/test/test_ssl_pending.py
@@ -1,0 +1,98 @@
+"""Regression test for the lost wakeup on TLS sockets (GH #1530).
+
+When PgBouncer needs a whole packet before it can handle it, but only part of
+that packet fits in the sbuf, sbuf_process_pending() bails out and PgBouncer
+waits for a read event on the socket. On a TLS connection the rest of that
+packet may already have been decrypted into OpenSSL's own buffer by the
+SSL_read() that filled the sbuf, leaving the kernel socket empty. The
+level-triggered read event then never fires again and the connection stalls.
+
+Postgres sends its whole login response in a single write, so a role with a
+long enough search_path both pushes that response past pkt_buf and provides
+the large packet across the boundary that is needed to reach this path.
+"""
+
+import pytest
+
+from .utils import PG_MAJOR_VERSION, TEST_DIR, TLS_SUPPORT, WINDOWS, Bouncer
+
+if not TLS_SUPPORT:
+    pytest.skip(allow_module_level=True)
+
+# The pkt_buf the bouncer_tls fixture below runs with, which is the size of a
+# single sbuf and thus the offset at which PgBouncer cuts the login response in
+# half. Deliberately much smaller than the 4096 default: the packet across the
+# boundary has to fit in one sbuf, so a small pkt_buf keeps the search_path
+# this test needs small too.
+PKT_BUF = 1024
+
+# SBUF_SMALL_PKT in include/sbuf.h. When a full buffer ends with no more than
+# this many unparsed bytes, sbuf_process_pending() leaves them alone instead of
+# handing a partial packet to the protocol handler, and the buffer-is-full path
+# then reads again by itself. So the packet across the boundary has to be
+# bigger than this to reach the path that stalls.
+SBUF_SMALL_PKT = 64
+
+# A ParameterStatus is a type byte, a 4 byte length, and the key and the value
+# each terminated by a NUL.
+PARAMETER_STATUS_OVERHEAD = len("search_path") + 7
+
+# Make the search_path packet 8 bytes shorter than an sbuf. That is what lines
+# it up across the boundary without having to know where in the login response
+# Postgres puts it:
+#
+#   - it ends past the boundary as long as it starts after byte 8, and it
+#     always does, because AuthenticationOk alone takes up the first 9 bytes
+#   - it still fits in one sbuf, so PgBouncer takes the path that stalls
+#     instead of the one that buffers oversized packets whole
+#   - the rest of the login response is a few hundred bytes of small
+#     ParameterStatus packets, far less than PKT_BUF - SBUF_SMALL_PKT, so the
+#     part of the packet before the boundary is comfortably over SBUF_SMALL_PKT
+SEARCH_PATH_LEN = PKT_BUF - 8 - PARAMETER_STATUS_OVERHEAD
+
+
+@pytest.fixture
+async def bouncer_tls(pg, tmp_path):
+    bouncer_tls = Bouncer(
+        pg, tmp_path / "bouncer", base_ini_path=TEST_DIR / "ssl" / "test.ini"
+    )
+    # pkt_buf cannot be changed with RELOAD, so it has to be set before start.
+    bouncer_tls.write_ini(f"pkt_buf = {PKT_BUF}")
+    await bouncer_tls.start()
+    yield bouncer_tls
+    await bouncer_tls.cleanup()
+
+
+def test_tls_login_packet_across_sbuf_boundary(pg, bouncer_tls, cert_dir):
+    """A packet split across the sbuf boundary must not stall a TLS connection.
+
+    Without the SSL_pending() check the bytes after the boundary stay inside
+    OpenSSL, the read event never fires again, and the server login hangs until
+    server_connect_timeout kicks in.
+    """
+    pg.ssl_access("all", "trust")
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{cert_dir / 'TestCA1' / 'ca.crt'}'")
+    if PG_MAJOR_VERSION < 10 or WINDOWS:
+        pg.restart()
+    else:
+        pg.reload()
+
+    bouncer_tls.admin("set server_tls_sslmode = require")
+
+    try:
+        pg.sql(f"alter role bouncer set search_path = '{'a' * SEARCH_PATH_LEN}'")
+
+        # Guard against this test silently passing because Postgres reported
+        # something other than the value we set, which would change the size of
+        # the packet and could move it off the boundary.
+        with pg.conn(dbname="p0", user="bouncer") as conn:
+            reported = conn.pgconn.parameter_status(b"search_path")
+        assert len(reported) == SEARCH_PATH_LEN
+
+        # PgBouncer only answers once the server login this triggers has
+        # completed, so a stalled server connection shows up as a timeout
+        # rather than as a wrong answer.
+        assert bouncer_tls.sql_value("select 1", connect_timeout=8) == 1
+    finally:
+        pg.sql("alter role bouncer reset search_path")

--- a/test/test_ssl_pending.py
+++ b/test/test_ssl_pending.py
@@ -83,11 +83,18 @@ def test_tls_login_packet_across_sbuf_boundary(pg, bouncer_tls, cert_dir):
     try:
         pg.sql(f"alter role bouncer set search_path = '{'a' * SEARCH_PATH_LEN}'")
 
+        with pg.conn(dbname="p0", user="bouncer") as conn:
+            reported = conn.pgconn.parameter_status(b"search_path")
+
+        # Only newer Postgres versions mark search_path as GUC_REPORT, and
+        # without a ParameterStatus for it there is no oversized packet in the
+        # login response to put across the boundary.
+        if reported is None:
+            pytest.skip("this Postgres does not report search_path")
+
         # Guard against this test silently passing because Postgres reported
         # something other than the value we set, which would change the size of
         # the packet and could move it off the boundary.
-        with pg.conn(dbname="p0", user="bouncer") as conn:
-            reported = conn.pgconn.parameter_status(b"search_path")
         assert len(reported) == SEARCH_PATH_LEN
 
         # PgBouncer only answers once the server login this triggers has


### PR DESCRIPTION
## Overview
Addresses https://github.com/pgbouncer/pgbouncer/issues/1530.

When a packet the proto handler needs to read whole straddles the pkt_buf boundary on a TLS connection, sbuf_process_pending() takes the need_more_data path and sbuf_main_loop() returns to wait for a read event. But SSL_read() has already pulled the entire TLS record out of the kernel into OpenSSL's own buffer, so the rest of that packet is decrypted and sitting there while the kernel socket is empty. With level-triggered polling the read event never fires again, and the connection stalls until unrelated traffic happens to wake the socket.

This is reachable via ParameterStatus: a SET application_name with a long value produces a message larger than SBUF_SMALL_PKT, which load_parameter() must see in full.

Add an sbufio_pending op (SSL_pending() for TLS, 0 for raw sockets) and, on the need_more_data path, re-read instead of waiting when the TLS layer still has buffered decrypted data. No change for non-TLS sockets.

## Testing 
I couldn't fit this into the existing `test_ssl.py` suite. Those tests run pgbouncer against a real Postgres, and the bug depends on TLS record framing: Postgres over loopback flushes the `ParameterStatus` in its own TLS record, so it never straddles the `pkt_buf` boundary and the stall doesn't happen. I believe triggering it deterministically needs something that emits the response as a single TLS record like a mock TLS server in place of Postgres, or a re-framing TLS proxy in front of it.

I verified it locally with a small mock TLS server (a crafted response with an oversized `ParameterStatus` sitting across the boundary). It successfully reproduces it on master and passes with this change. Happy to contribute that as a test case if desired.