### PR TITLE
fix: PS stall — always use CB_WANT_COMPLETE_PACKET for incomplete named Parse

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1545,26 +1545,31 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 	}
 
 	if (ps_action == PS_HANDLE_FULL_PACKET && incomplete_pkt(pkt)) {
-		if (pkt->len > (unsigned) cf_sbuf_len) {
-			/*
-			 * We need to handle the complete packet, but it is too
-			 * large to fit into our sbuf buffer size (determined
-			 * by the pkt_buf config). So now we need to fetch the
-			 * whole packet using our dynamically sized packet
-			 * buffering logic.
-			 */
-			client->packet_cb_state.flag = CB_WANT_COMPLETE_PACKET;
-			sbuf_prepare_fetch(sbuf, pkt->len);
-			return true;
-		} else {
-			/*
-			 * We need to handle the complete packet, but it fits
-			 * in our sbuf buffer, so we can simply return false to
-			 * indicate to sbuf to retry once it has received more
-			 * data
-			 */
-			return false;
-		}
+		/*
+		 * Always use the dynamic reassembly path for named prepared
+		 * statement packets that haven't been fully received yet,
+		 * regardless of whether they fit in pkt_buf.
+		 *
+		 * The previous code returned false (inline retry) when
+		 * pkt->len <= cf_sbuf_len, relying on sbuf to call us again
+		 * once the full packet arrived. However, this causes a
+		 * prepared-statement accounting corruption: inspect_parse_packet()
+		 * succeeds on the partial packet (statement name fits in the
+		 * initial bytes), then the inline retry fires handle_parse_command()
+		 * which adds RA_FAKE to outstanding_requests. When the next Bind
+		 * in the pipeline arrives on a freshly-assigned server backend,
+		 * handle_bind_command() injects RA_SKIP(Parse) behind that RA_FAKE.
+		 * pop_outstanding_request() refuses to pop an RA_FAKE head, so
+		 * RA_SKIP is never consumed, leaving the server permanently pinned
+		 * with outstanding_requests > 0 (active/ClientRead stall).
+		 *
+		 * The reassembly path (CB_WANT_COMPLETE_PACKET) buffers the entire
+		 * packet before any queue entries are written, preventing the
+		 * RA_FAKE/RA_SKIP ordering corruption entirely.
+		 */
+		client->packet_cb_state.flag = CB_WANT_COMPLETE_PACKET;
+		sbuf_prepare_fetch(sbuf, pkt->len);
+		return true;
 	}
 
 	if (ps_action == PS_INSPECT_FAILED) {


### PR DESCRIPTION
## Problem

When transaction pooling is enabled with `max_prepared_statements > 0`, a client that pipelines `Parse/Bind/Execute/Sync` bursts can permanently stall a server backend in `active/ClientRead` state.

**Trigger condition:** A named Parse packet whose size fits within `pkt_buf` but arrives incomplete (i.e. `incomplete_pkt(pkt)` is true but `pkt->len <= cf_sbuf_len`). This is common on any connection where TCP segments don't align with message boundaries — TLS, high-latency links, large prepared statement texts.

### Stall mechanism

1. `inspect_parse_packet()` fires on the **partial** packet. The statement name sits in the first few bytes, so inspection succeeds and the packet is identified as a named Parse.
2. The previous code returned `false` (inline retry) since `pkt->len <= cf_sbuf_len`, telling sbuf to retry once more data arrives.
3. On retry, `handle_parse_command()` runs on the now-complete packet and writes `RA_FAKE` into `outstanding_requests`.
4. The transaction ends; the server backend is released to the pool. The next `Bind` in the pipeline is assigned to a **different** backend (transaction pooling).
5. `ensure_statement_is_prepared_on_server()` injects `RA_SKIP(Parse)` on the new backend **behind** the `RA_FAKE` written in step 3, producing queue: `[RA_FAKE, RA_SKIP, …]`.
6. `pop_outstanding_request()` refuses to pop an `RA_FAKE` head. `RA_SKIP` is never consumed. The `Sync` response is never forwarded. The backend is permanently pinned with `outstanding_requests > 0` — a deadlock until the process is killed.

Note: the bug is independent of `pkt_buf` size — it triggers whenever a named Parse fits *within* the buffer but arrives split across reads. Counterintuitively, setting `pkt_buf` *smaller* than the Parse packet avoids it by forcing the `CB_WANT_COMPLETE_PACKET` path, but this is not a real fix.

## Fix

Remove the `pkt->len > cf_sbuf_len` branch and unconditionally use the `CB_WANT_COMPLETE_PACKET` dynamic reassembly path for all `PS_HANDLE_FULL_PACKET` incomplete packets.

This ensures the entire packet is buffered before any queue entry is written, so `inspect_parse_packet()` and `handle_parse_command()` always operate on a consistent, complete packet. The `RA_FAKE`/`RA_SKIP` ordering corruption cannot occur.

The `CB_WANT_COMPLETE_PACKET` path is already used for packets larger than `pkt_buf` with no issues; this change extends it to the remaining case.

## Related

PR #1531 (`joncwong:fix-tls-parameterstatus-stall`) addresses a separate but related stall on TLS connections where `SSL_pending` data is not visible to the event poller. Both bugs involve the `need_more_data` / incomplete packet path and can coexist.