### PR TITLE
Preserve connections across host string changes

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1268,6 +1268,11 @@ of new connections are chosen.  See also the setting
 `server_round_robin` for how clients are assigned to already
 established server connections.
 
+Host list entries must not be empty.  When a configuration reload changes the
+list, existing server connections to hosts that remain in the list are
+preserved.  Connections to removed hosts are closed when they become idle.
+Connection attempts to removed hosts are canceled immediately.
+
 Examples:
 
 	host=localhost

--- a/include/objects.h
+++ b/include/objects.h
@@ -104,6 +104,7 @@ int get_active_server_count(void);
 
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
+void reconcile_database_hosts(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all);
 void tag_autodb_dirty(void);
 void tag_host_addr_dirty(const char *host, const struct sockaddr *sa);
 void for_each_server(PgPool *pool, void (*func)(PgSocket *sk));

--- a/include/objects.h
+++ b/include/objects.h
@@ -104,7 +104,7 @@ int get_active_server_count(void);
 
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);
-void reconcile_database_hosts(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all);
+void apply_database_host_change(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all);
 void tag_autodb_dirty(void);
 void tag_host_addr_dirty(const char *host, const struct sockaddr *sa);
 void for_each_server(PgPool *pool, void (*func)(PgSocket *sk));

--- a/include/util.h
+++ b/include/util.h
@@ -50,6 +50,22 @@ bool tune_socket(int sock, bool is_unix) _MUSTCHECK;
 
 bool strlist_contains(const char *liststr, const char *str);
 
+struct HostListIter {
+	const char *next;
+};
+
+struct HostListEntry {
+	const char *str;
+	size_t len;
+};
+
+void host_list_iter_init(struct HostListIter *iter, const char *host_list);
+bool host_list_iter_next(struct HostListIter *iter, struct HostListEntry *entry);
+bool host_list_is_valid(const char *host_list);
+bool host_list_contains(const char *host_list, const char *host);
+bool host_lists_overlap(const char *left, const char *right);
+bool host_lists_have_same_members(const char *left, const char *right);
+
 void fill_remote_addr(PgSocket *sk, int fd, bool is_unix);
 void fill_local_addr(PgSocket *sk, int fd, bool is_unix);
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -129,21 +129,22 @@ static char * cstr_get_pair(char *p,
  */
 static bool set_param_value(char **old_value, const char *new_value)
 {
+	char *value = NULL;
+
 	if (strcmpeq(*old_value, new_value))
 		return true;
 
-	if (*old_value)
-		free(*old_value);
-
 	if (new_value) {
-		*old_value = strdup(new_value);
-		if (!(*old_value)) {
+		value = strdup(new_value);
+		if (!value) {
 			log_error("out of memory");
 			return false;
 		}
-	} else {
-		*old_value = NULL;
 	}
+
+	/* Keep the old value authoritative until the replacement is allocated. */
+	free(*old_value);
+	*old_value = value;
 
 	return true;
 }
@@ -201,6 +202,10 @@ bool parse_peer(void *base, const char *name, const char *connstr)
 		}
 
 		if (strcmp("host", key) == 0) {
+			if (!host_list_is_valid(val)) {
+				log_error("invalid host list: empty host entry");
+				goto fail;
+			}
 			if (!set_param_value(&host, val))
 				goto fail;
 		} else if (strcmp("port", key) == 0) {
@@ -310,6 +315,10 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		if (strcmp("dbname", key) == 0) {
 			dbname = val;
 		} else if (strcmp("host", key) == 0) {
+			if (!host_list_is_valid(val)) {
+				log_error("invalid host list: empty host entry");
+				goto fail;
+			}
 			if (!set_param_value(&host, val))
 				goto fail;
 		} else if (strcmp("port", key) == 0) {
@@ -384,29 +393,30 @@ bool parse_database(void *base, const char *name, const char *connstr)
 
 	/* if updating old db, check if anything changed */
 	if (db->dbname) {
-		bool changed = false;
+		bool reconnect_all = false;
+		bool host_membership_changed = !host_lists_have_same_members(db->host, host);
+
 		if (strcmp(db->dbname, dbname) != 0) {
-			changed = true;
-		} else if (!strcmpeq(host, db->host)) {
-			changed = true;
+			reconnect_all = true;
 		} else if (port != db->port) {
-			changed = true;
+			reconnect_all = true;
 		} else if (username && !db->forced_user_credentials) {
-			changed = true;
+			reconnect_all = true;
 		} else if (username && strcmp(username, db->forced_user_credentials->name) != 0) {
-			changed = true;
+			reconnect_all = true;
 		} else if (!username && db->forced_user_credentials) {
-			changed = true;
+			reconnect_all = true;
 		} else if (!strcmpeq(connect_query, db->connect_query)) {
-			changed = true;
+			reconnect_all = true;
 		} else if (!strcmpeq(db->auth_dbname, auth_dbname)) {
-			changed = true;
+			reconnect_all = true;
 		} else if (!strcmpeq(db->auth_query, auth_query)) {
-			changed = true;
-		} else if (load_balance_hosts != db->load_balance_hosts) {
-			changed = true;
+			reconnect_all = true;
 		}
-		if (changed)
+
+		if (host_membership_changed)
+			reconcile_database_hosts(db, db->host, host, reconnect_all);
+		else if (reconnect_all)
 			tag_database_dirty(db);
 	}
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -415,7 +415,7 @@ bool parse_database(void *base, const char *name, const char *connstr)
 		}
 
 		if (host_membership_changed)
-			reconcile_database_hosts(db, db->host, host, reconnect_all);
+			apply_database_host_change(db, db->host, host, reconnect_all);
 		else if (reconnect_all)
 			tag_database_dirty(db);
 	}

--- a/src/objects.c
+++ b/src/objects.c
@@ -1333,7 +1333,12 @@ static void unlink_server(PgSocket *server, const char *reason)
  * The latter is for protocol and communication errors where a normal
  * protocol termination is not possible.
  */
-static void disconnect_server_impl(PgSocket *server, bool send_term, bool record_login_failure, const char *reason)
+enum DisconnectFailureState {
+	DISCONNECT_UPDATE_FAILURE_STATE,
+	DISCONNECT_PRESERVE_FAILURE_STATE,
+};
+
+static void disconnect_server_impl(PgSocket *server, bool send_term, enum DisconnectFailureState failure_state, const char *reason)
 {
 	usec_t now = get_cached_time();
 	struct List *cancel_item, *tmp;
@@ -1362,7 +1367,7 @@ static void disconnect_server_impl(PgSocket *server, bool send_term, bool record
 		 * usually disconnect means problems in startup phase,
 		 * except when sending cancel packet
 		 */
-		if (!server->ready && record_login_failure) {
+		if (!server->ready && failure_state == DISCONNECT_UPDATE_FAILURE_STATE) {
 			server->pool->last_login_failed = true;
 			server->pool->last_connect_failed = true;
 			safe_strcpy(server->pool->last_connect_failed_message, reason, sizeof(server->pool->last_connect_failed_message));
@@ -1372,7 +1377,7 @@ static void disconnect_server_impl(PgSocket *server, bool send_term, bool record
 			 * cancellation, so to the best of our knowledge we can connect to
 			 * the server, reset last_connect_failed accordingly.
 			 */
-			if (record_login_failure)
+			if (failure_state == DISCONNECT_UPDATE_FAILURE_STATE)
 				server->pool->last_connect_failed = false;
 			send_term = false;
 		}
@@ -1423,7 +1428,7 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	vsnprintf(buf, sizeof(buf), reason, ap);
 	va_end(ap);
 
-	disconnect_server_impl(server, send_term, true, buf);
+	disconnect_server_impl(server, send_term, DISCONNECT_UPDATE_FAILURE_STATE, buf);
 }
 
 static void disconnect_server_for_reconnect(PgSocket *server, const char *reason)
@@ -1435,7 +1440,7 @@ static void disconnect_server_for_reconnect(PgSocket *server, const char *reason
 	 * whether the server is reachable. Publishing it as a failed login would
 	 * suppress the replacement attempt for server_login_retry.
 	 */
-	disconnect_server_impl(server, true, false, reason);
+	disconnect_server_impl(server, true, DISCONNECT_PRESERVE_FAILURE_STATE, reason);
 }
 
 /*
@@ -2610,7 +2615,7 @@ static void clear_pool_host_failure(PgPool *pool, const char *old_host_list)
 	pool->last_connect_failed_message[0] = '\0';
 }
 
-void reconcile_database_hosts(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all)
+void apply_database_host_change(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all)
 {
 	struct List *pool_item, *server_item, *tmp;
 	PgPool *pool;
@@ -2629,8 +2634,10 @@ void reconcile_database_hosts(PgDatabase *db, const char *old_host_list, const c
 			continue;
 		}
 
+		/* Mark removed hosts so established connections drain on release. */
 		for_each_server_filtered(pool, tag_dirty, server_host_was_removed, (void *)new_host_list);
 
+		/* In-progress logins have no release point, so cancel them now. */
 		statlist_for_each_safe(server_item, &pool->new_server_list, tmp) {
 			server = container_of(server_item, PgSocket, head);
 			if (server_host_was_removed(server, (void *)new_host_list))

--- a/src/objects.c
+++ b/src/objects.c
@@ -1333,21 +1333,14 @@ static void unlink_server(PgSocket *server, const char *reason)
  * The latter is for protocol and communication errors where a normal
  * protocol termination is not possible.
  */
-void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...)
+static void disconnect_server_impl(PgSocket *server, bool send_term, bool record_login_failure, const char *reason)
 {
 	usec_t now = get_cached_time();
-	char buf[128];
-	va_list ap;
 	struct List *cancel_item, *tmp;
 
 	if (server == NULL) {
 		return;
 	}
-
-	va_start(ap, reason);
-	vsnprintf(buf, sizeof(buf), reason, ap);
-	va_end(ap);
-	reason = buf;
 
 	if (cf_log_disconnections) {
 		slog_info(server, "closing because: %s (age=%" PRIu64 "s)", reason,
@@ -1369,18 +1362,18 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 		 * usually disconnect means problems in startup phase,
 		 * except when sending cancel packet
 		 */
-		if (!server->ready) {
+		if (!server->ready && record_login_failure) {
 			server->pool->last_login_failed = true;
 			server->pool->last_connect_failed = true;
 			safe_strcpy(server->pool->last_connect_failed_message, reason, sizeof(server->pool->last_connect_failed_message));
-		} else
-		{
+		} else if (server->ready) {
 			/*
 			 * We did manage to connect and used the connection for query
 			 * cancellation, so to the best of our knowledge we can connect to
 			 * the server, reset last_connect_failed accordingly.
 			 */
-			server->pool->last_connect_failed = false;
+			if (record_login_failure)
+				server->pool->last_connect_failed = false;
 			send_term = false;
 		}
 		if (server->replication)
@@ -1419,6 +1412,30 @@ void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...
 	change_server_state(server, SV_JUSTFREE);
 	if (!sbuf_close(&server->sbuf))
 		log_noise("sbuf_close failed, retry later");
+}
+
+void disconnect_server(PgSocket *server, bool send_term, const char *reason, ...)
+{
+	char buf[128];
+	va_list ap;
+
+	va_start(ap, reason);
+	vsnprintf(buf, sizeof(buf), reason, ap);
+	va_end(ap);
+
+	disconnect_server_impl(server, send_term, true, buf);
+}
+
+static void disconnect_server_for_reconnect(PgSocket *server, const char *reason)
+{
+	Assert(server->state == SV_LOGIN);
+
+	/*
+	 * An administrative reconnect canceled this attempt; it says nothing about
+	 * whether the server is reachable. Publishing it as a failed login would
+	 * suppress the replacement attempt for server_login_retry.
+	 */
+	disconnect_server_impl(server, true, false, reason);
 }
 
 /*
@@ -1671,34 +1688,43 @@ static void dns_connect(struct PgSocket *server)
 	const char *host;
 	int sa_len;
 	int res;
-	char *host_copy = NULL;
 
 	/* host list? */
 	if (db->host && strchr(db->host, ',')) {
-		int count = 1;
-		int n;
+		struct HostListIter iter;
+		struct HostListEntry entry;
+		int count = 0;
+		int n = 0;
 
 		if (server->pool->db->load_balance_hosts == LOAD_BALANCE_HOSTS_DISABLE && server->pool->last_connect_failed)
 			server->pool->rrcounter++;
 
-		for (const char *p = db->host; *p; p++)
-			if (*p == ',')
-				count++;
+		host_list_iter_init(&iter, db->host);
+		while (host_list_iter_next(&iter, &entry))
+			count++;
+		Assert(count > 1);
 
-		host_copy = xstrdup(db->host);
-		for (host = strtok(host_copy, ","), n = 0; host; host = strtok(NULL, ","), n++)
-			if (server->pool->rrcounter % count == n)
+		host_list_iter_init(&iter, db->host);
+		while (host_list_iter_next(&iter, &entry)) {
+			if (server->pool->rrcounter % count == n) {
+				server->host = xmalloc(entry.len + 1);
+				memcpy(server->host, entry.str, entry.len);
+				server->host[entry.len] = '\0';
 				break;
-		Assert(host);
+			}
+			n++;
+		}
+		Assert(server->host);
+		host = server->host;
 
 		if (server->pool->db->load_balance_hosts == LOAD_BALANCE_HOSTS_ROUND_ROBIN)
 			server->pool->rrcounter++;
 	} else {
 		host = db->host;
-	}
-
-	if (host) {
-		server->host = xstrdup(host);
+		if (host) {
+			server->host = xstrdup(host);
+			host = server->host;
+		}
 	}
 
 	if (!host || host[0] == '/' || host[0] == '@') {
@@ -1710,7 +1736,7 @@ static void dns_connect(struct PgSocket *server)
 		if (!unix_dir || !*unix_dir) {
 			log_error("unix socket dir not configured: %s", db->name);
 			disconnect_server(server, false, "cannot connect");
-			goto cleanup;
+			return;
 		}
 		snprintf(sa_un.sun_path, sizeof(sa_un.sun_path),
 			 "%s/.s.PGSQL.%d", unix_dir, db->port);
@@ -1754,12 +1780,10 @@ static void dns_connect(struct PgSocket *server)
 		tk = adns_resolve(adns, host, dns_callback, server);
 		if (tk)
 			server->dns_token = tk;
-		goto cleanup;
+		return;
 	}
 
 	connect_server(server, sa, sa_len);
-cleanup:
-	free(host_copy);
 }
 
 PgSocket *compare_connections_by_time(PgSocket *lhs, PgSocket *rhs)
@@ -2511,6 +2535,15 @@ static void tag_dirty(PgSocket *sk)
 	sk->close_needed = true;
 }
 
+static void reset_pool_welcome(PgPool *pool)
+{
+	if (pool->welcome_msg) {
+		pktbuf_free(pool->welcome_msg);
+		pool->welcome_msg = NULL;
+	}
+	pool->welcome_msg_ready = false;
+}
+
 void tag_pool_dirty(PgPool *pool)
 {
 	struct List *item, *tmp;
@@ -2525,11 +2558,7 @@ void tag_pool_dirty(PgPool *pool)
 		return;
 
 	/* reset welcome msg */
-	if (pool->welcome_msg) {
-		pktbuf_free(pool->welcome_msg);
-		pool->welcome_msg = NULL;
-	}
-	pool->welcome_msg_ready = false;
+	reset_pool_welcome(pool);
 
 	/* drop all existing servers ASAP */
 	for_each_server(pool, tag_dirty);
@@ -2537,7 +2566,7 @@ void tag_pool_dirty(PgPool *pool)
 	/* drop servers login phase immediately */
 	statlist_for_each_safe(item, &pool->new_server_list, tmp) {
 		server = container_of(item, PgSocket, head);
-		disconnect_server(server, true, "connect string changed");
+		disconnect_server_for_reconnect(server, "connect string changed");
 	}
 }
 
@@ -2550,6 +2579,63 @@ void tag_database_dirty(PgDatabase *db)
 		pool = container_of(item, PgPool, head);
 		if (pool->db == db)
 			tag_pool_dirty(pool);
+	}
+}
+
+static bool server_host_was_removed(PgSocket *server, void *arg)
+{
+	const char *new_host_list = arg;
+
+	return !host_list_contains(new_host_list, server->host);
+}
+
+static void clear_pool_host_failure(PgPool *pool, const char *old_host_list)
+{
+	/*
+	 * The cached failure belongs to the old host set. Clear it so the updated set
+	 * gets one immediate attempt instead of inheriting the old set's
+	 * server_login_retry delay. Do this only for membership changes so ordinary
+	 * reloads cannot repeatedly bypass the backoff.
+	 */
+	/*
+	 * Preserve the host-selection step that dns_connect() would have performed
+	 * on the next retry before we erase last_connect_failed.
+	 */
+	if (pool->last_connect_failed
+	    && old_host_list
+	    && (!strchr(old_host_list, ',') || pool->db->load_balance_hosts == LOAD_BALANCE_HOSTS_DISABLE))
+		pool->rrcounter++;
+	pool->last_login_failed = false;
+	pool->last_connect_failed = false;
+	pool->last_connect_failed_message[0] = '\0';
+}
+
+void reconcile_database_hosts(PgDatabase *db, const char *old_host_list, const char *new_host_list, bool reconnect_all)
+{
+	struct List *pool_item, *server_item, *tmp;
+	PgPool *pool;
+	PgSocket *server;
+	bool overlap = host_lists_overlap(old_host_list, new_host_list);
+
+	statlist_for_each(pool_item, &pool_list) {
+		pool = container_of(pool_item, PgPool, head);
+		if (pool->db != db)
+			continue;
+
+		clear_pool_host_failure(pool, old_host_list);
+
+		if (reconnect_all || !overlap) {
+			tag_pool_dirty(pool);
+			continue;
+		}
+
+		for_each_server_filtered(pool, tag_dirty, server_host_was_removed, (void *)new_host_list);
+
+		statlist_for_each_safe(server_item, &pool->new_server_list, tmp) {
+			server = container_of(server_item, PgSocket, head);
+			if (server_host_was_removed(server, (void *)new_host_list))
+				disconnect_server_for_reconnect(server, "host removed from connect string");
+		}
 	}
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -272,6 +272,117 @@ loop:
 	return true;
 }
 
+void host_list_iter_init(struct HostListIter *iter, const char *host_list)
+{
+	iter->next = host_list;
+}
+
+bool host_list_iter_next(struct HostListIter *iter, struct HostListEntry *entry)
+{
+	const char *comma;
+
+	if (!iter->next)
+		return false;
+
+	entry->str = iter->next;
+	comma = strchr(iter->next, ',');
+	if (comma) {
+		entry->len = comma - iter->next;
+		iter->next = comma + 1;
+	} else {
+		entry->len = strlen(iter->next);
+		iter->next = NULL;
+	}
+
+	return true;
+}
+
+bool host_list_is_valid(const char *host_list)
+{
+	struct HostListIter iter;
+	struct HostListEntry entry;
+
+	if (!host_list)
+		return true;
+
+	host_list_iter_init(&iter, host_list);
+	while (host_list_iter_next(&iter, &entry)) {
+		if (entry.len == 0)
+			return false;
+	}
+
+	return true;
+}
+
+static bool host_list_contains_entry(const char *host_list, const struct HostListEntry *target)
+{
+	struct HostListIter iter;
+	struct HostListEntry entry;
+
+	if (!host_list)
+		return false;
+
+	host_list_iter_init(&iter, host_list);
+	while (host_list_iter_next(&iter, &entry)) {
+		if (entry.len == target->len && memcmp(entry.str, target->str, entry.len) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+bool host_list_contains(const char *host_list, const char *host)
+{
+	struct HostListEntry target;
+
+	if (!host_list || !host)
+		return host_list == host;
+
+	target.str = host;
+	target.len = strlen(host);
+	return host_list_contains_entry(host_list, &target);
+}
+
+bool host_lists_overlap(const char *left, const char *right)
+{
+	struct HostListIter iter;
+	struct HostListEntry entry;
+
+	if (!left || !right)
+		return left == right;
+
+	host_list_iter_init(&iter, left);
+	while (host_list_iter_next(&iter, &entry)) {
+		if (host_list_contains_entry(right, &entry))
+			return true;
+	}
+
+	return false;
+}
+
+bool host_lists_have_same_members(const char *left, const char *right)
+{
+	struct HostListIter iter;
+	struct HostListEntry entry;
+
+	if (!left || !right)
+		return left == right;
+
+	host_list_iter_init(&iter, left);
+	while (host_list_iter_next(&iter, &entry)) {
+		if (!host_list_contains_entry(right, &entry))
+			return false;
+	}
+
+	host_list_iter_init(&iter, right);
+	while (host_list_iter_next(&iter, &entry)) {
+		if (!host_list_contains_entry(left, &entry))
+			return false;
+	}
+
+	return true;
+}
+
 void fill_remote_addr(PgSocket *sk, int fd, bool is_unix)
 {
 	PgAddr *dst = &sk->remote_addr;

--- a/test/test_load_balance_hosts.py
+++ b/test/test_load_balance_hosts.py
@@ -1,7 +1,77 @@
+import asyncio
 import re
 
 import psycopg
 import pytest
+from psycopg.rows import dict_row
+
+HOST_RELOAD_DB = "host_reload"
+
+
+def host_reload_config(
+    bouncer,
+    hosts,
+    *,
+    connect_query=None,
+    load_balance_hosts="round-robin",
+    pool_mode="session",
+    port=None,
+    query_timeout=0,
+    server_login_retry=15,
+):
+    database_settings = [
+        f"host={hosts}",
+        f"port={bouncer.pg.port if port is None else port}",
+        "dbname=p0",
+        "user=bouncer",
+        f"load_balance_hosts={load_balance_hosts}",
+    ]
+    if connect_query is not None:
+        database_settings.append(f"connect_query='{connect_query}'")
+
+    return f"""
+    [databases]
+    {HOST_RELOAD_DB} = {" ".join(database_settings)}
+
+    [pgbouncer]
+    listen_addr = {bouncer.host}
+    listen_port = {bouncer.port}
+    auth_type = trust
+    admin_users = pgbouncer
+    auth_file = {bouncer.auth_path}
+    logfile = {bouncer.log_path}
+    pool_mode = {pool_mode}
+    query_timeout = {query_timeout}
+    server_lifetime = 3600
+    server_login_retry = {server_login_retry}
+    """
+
+
+def reload_host_config(bouncer, hosts, **kwargs):
+    with bouncer.ini_path.open("w") as config_file:
+        config_file.write(host_reload_config(bouncer, hosts, **kwargs))
+    bouncer.admin("RELOAD")
+
+
+def host_reload_servers(bouncer):
+    return [
+        server
+        for server in bouncer.admin("SHOW SERVERS", row_factory=dict_row)
+        if server["database"] == HOST_RELOAD_DB
+    ]
+
+
+async def wait_for_host_reload_pool(bouncer, **expected):
+    for _ in range(100):
+        pools = [
+            pool
+            for pool in bouncer.admin("SHOW POOLS", row_factory=dict_row)
+            if pool["database"] == HOST_RELOAD_DB
+        ]
+        if pools and all(pools[0][key] == value for key, value in expected.items()):
+            return
+        await asyncio.sleep(0.05)
+    pytest.fail(f"pool did not reach expected state: {expected}")
 
 
 async def test_load_balance_hosts_disable_good_first(bouncer):
@@ -45,3 +115,280 @@ def test_load_balance_hosts_reload(bouncer):
         results = cur.execute("show databases").fetchall()
         result = [r for r in results if r[0] == "load_balance_hosts_update"][0]
         assert "round-robin" in result
+
+
+@pytest.mark.parametrize(
+    ("old_hosts", "new_hosts", "expected_close_needed"),
+    [
+        pytest.param("{primary}", "{primary}", 0, id="unchanged"),
+        pytest.param(
+            "{primary}",
+            "{primary},{other}",
+            0,
+            id="host-added",
+        ),
+        pytest.param(
+            "{primary},{other}",
+            "{other},{primary}",
+            0,
+            id="hosts-reordered",
+        ),
+        pytest.param(
+            "{primary},{other}",
+            "{primary},{other},{other}",
+            0,
+            id="duplicate-weight-changed",
+        ),
+        pytest.param(
+            "{primary},{other}",
+            "{primary}",
+            0,
+            id="unused-host-removed",
+        ),
+        pytest.param(
+            "{primary},{other}",
+            "{other}",
+            1,
+            id="connected-host-removed",
+        ),
+        pytest.param(
+            "{primary}",
+            "{other}",
+            1,
+            id="hosts-replaced",
+        ),
+    ],
+)
+def test_host_list_reload_only_dirties_connections_to_removed_hosts(
+    bouncer, old_hosts, new_hosts, expected_close_needed
+):
+    hosts = {
+        "primary": bouncer.pg.host,
+        # The tests always select the first host for their one backend connection,
+        # so this address does not need to accept connections.
+        "other": "127.0.0.2",
+    }
+    old_hosts = old_hosts.format_map(hosts)
+    new_hosts = new_hosts.format_map(hosts)
+
+    with bouncer.run_with_config(host_reload_config(bouncer, old_hosts)):
+        with bouncer.cur(dbname=HOST_RELOAD_DB) as cur:
+            backend_pid = cur.execute("SELECT pg_backend_pid()").fetchone()[0]
+            servers_before = host_reload_servers(bouncer)
+            assert len(servers_before) == 1
+            server_id = servers_before[0]["id"]
+
+            reload_host_config(bouncer, new_hosts)
+
+            servers_after = host_reload_servers(bouncer)
+            assert len(servers_after) == 1
+            assert servers_after[0]["id"] == server_id
+            assert servers_after[0]["close_needed"] == expected_close_needed
+
+            if not expected_close_needed:
+                assert (
+                    cur.execute("SELECT pg_backend_pid()").fetchone()[0] == backend_pid
+                )
+
+
+def test_load_balance_hosts_change_does_not_dirty_existing_connections(bouncer):
+    hosts = f"{bouncer.pg.host},127.0.0.2"
+    initial_config = host_reload_config(bouncer, hosts, load_balance_hosts="disable")
+
+    with bouncer.run_with_config(initial_config):
+        with bouncer.cur(dbname=HOST_RELOAD_DB) as cur:
+            cur.execute("SELECT 1")
+            server_id = host_reload_servers(bouncer)[0]["id"]
+
+            reload_host_config(bouncer, hosts, load_balance_hosts="round-robin")
+
+            servers = host_reload_servers(bouncer)
+            assert len(servers) == 1
+            assert servers[0]["id"] == server_id
+            assert servers[0]["close_needed"] == 0
+
+
+def test_non_host_connection_change_still_dirties_existing_connections(bouncer):
+    initial_config = host_reload_config(bouncer, bouncer.pg.host)
+
+    with bouncer.run_with_config(initial_config):
+        with bouncer.cur(dbname=HOST_RELOAD_DB) as cur:
+            cur.execute("SELECT 1")
+
+            reload_host_config(
+                bouncer,
+                bouncer.pg.host,
+                connect_query="SELECT 1",
+            )
+
+            servers = host_reload_servers(bouncer)
+            assert len(servers) == 1
+            assert servers[0]["close_needed"] == 1
+
+
+def test_invalid_host_reload_keeps_last_applied_host_state(bouncer):
+    initial_config = host_reload_config(bouncer, bouncer.pg.host)
+
+    with bouncer.run_with_config(initial_config):
+        with bouncer.cur(dbname=HOST_RELOAD_DB) as cur:
+            backend_pid = cur.execute("SELECT pg_backend_pid()").fetchone()[0]
+            server_id = host_reload_servers(bouncer)[0]["id"]
+
+            with bouncer.ini_path.open("w") as config_file:
+                config_file.write(
+                    host_reload_config(
+                        bouncer,
+                        f"{bouncer.pg.host},127.0.0.2",
+                        port="not-a-port",
+                    )
+                )
+
+            with pytest.raises(psycopg.errors.ConfigFileError):
+                bouncer.admin("RELOAD")
+
+            servers = host_reload_servers(bouncer)
+            assert len(servers) == 1
+            assert servers[0]["id"] == server_id
+            assert servers[0]["close_needed"] == 0
+            assert cur.execute("SELECT pg_backend_pid()").fetchone()[0] == backend_pid
+
+
+@pytest.mark.parametrize(
+    "invalid_hosts",
+    [
+        pytest.param(",127.0.0.1", id="leading-empty-entry"),
+        pytest.param("127.0.0.1,,127.0.0.2", id="middle-empty-entry"),
+        pytest.param("127.0.0.1,", id="trailing-empty-entry"),
+    ],
+)
+def test_empty_host_entry_reload_keeps_last_applied_host_state(bouncer, invalid_hosts):
+    initial_config = host_reload_config(bouncer, bouncer.pg.host)
+
+    with bouncer.run_with_config(initial_config):
+        with bouncer.cur(dbname=HOST_RELOAD_DB) as cur:
+            backend_pid = cur.execute("SELECT pg_backend_pid()").fetchone()[0]
+            server_id = host_reload_servers(bouncer)[0]["id"]
+
+            with bouncer.ini_path.open("w") as config_file:
+                config_file.write(host_reload_config(bouncer, invalid_hosts))
+
+            with pytest.raises(psycopg.errors.ConfigFileError):
+                bouncer.admin("RELOAD")
+
+            servers = host_reload_servers(bouncer)
+            assert len(servers) == 1
+            assert servers[0]["id"] == server_id
+            assert servers[0]["close_needed"] == 0
+            assert cur.execute("SELECT pg_backend_pid()").fetchone()[0] == backend_pid
+
+
+def test_host_membership_change_clears_cached_connect_failure(bouncer):
+    bad_host = "unresolvable-hostname"
+    initial_config = host_reload_config(
+        bouncer,
+        bad_host,
+        query_timeout=3,
+        server_login_retry=10,
+    )
+
+    with bouncer.run_with_config(initial_config):
+        with bouncer.log_contains(r"closing because: server DNS lookup failed"):
+            with pytest.raises(psycopg.OperationalError):
+                bouncer.test(dbname=HOST_RELOAD_DB, connect_timeout=5)
+
+        reload_host_config(
+            bouncer,
+            f"{bad_host},{bouncer.pg.host}",
+            query_timeout=3,
+            server_login_retry=10,
+        )
+
+        # The old failure must not impose its ten-second retry delay on the
+        # updated host set. Selection advances past the failed single host.
+        bouncer.test(dbname=HOST_RELOAD_DB, connect_timeout=5)
+
+
+@pytest.mark.parametrize(
+    ("reload_kind", "expected_canceled_logins"),
+    [
+        pytest.param("host-added", 0, id="host-added"),
+        pytest.param("connect-query-changed", 1, id="connection-identity-changed"),
+    ],
+)
+async def test_reload_during_login_does_not_trigger_server_login_retry(
+    pg, bouncer, reload_kind, expected_canceled_logins
+):
+    initial_config = host_reload_config(
+        bouncer,
+        bouncer.pg.host,
+        pool_mode="transaction",
+        query_timeout=6,
+        server_login_retry=10,
+    )
+
+    with bouncer.run_with_config(initial_config):
+        # Establish the pool's welcome message and leave one reusable backend.
+        bouncer.test(dbname=HOST_RELOAD_DB)
+
+        # Keep a client connected before reload so it already has the cached
+        # welcome message. Its next query exercises check_fast_fail().
+        async with await bouncer.aconn(
+            dbname=HOST_RELOAD_DB, connect_timeout=12
+        ) as existing_client:
+            async with existing_client.cursor() as existing_cursor:
+                await existing_cursor.execute("SELECT 1")
+
+                # Keep the established backend busy while a second backend
+                # remains in the login phase. The reload either preserves that
+                # attempt (host addition) or intentionally cancels it (a full
+                # connection-identity change).
+                pg.configure("pre_auth_delay to '5s'")
+                pg.reload()
+
+                first_query = bouncer.asql(
+                    "SELECT pg_sleep(2)",
+                    dbname=HOST_RELOAD_DB,
+                    connect_timeout=12,
+                )
+                await wait_for_host_reload_pool(bouncer, sv_active=1)
+
+                second_query = bouncer.asql(
+                    "SELECT 1", dbname=HOST_RELOAD_DB, connect_timeout=12
+                )
+                await wait_for_host_reload_pool(bouncer, sv_active=1, sv_login=1)
+
+                if reload_kind == "host-added":
+                    reloaded_hosts = f"{bouncer.pg.host},127.0.0.2"
+                    reload_kwargs = {}
+                else:
+                    reloaded_hosts = bouncer.pg.host
+                    reload_kwargs = {"connect_query": "SELECT 1"}
+
+                with bouncer.log_contains(
+                    rf"{HOST_RELOAD_DB}.*closing because: connect string changed",
+                    times=expected_canceled_logins,
+                ):
+                    with bouncer.log_contains(
+                        r"server login has been failing, cached error: "
+                        r"connect string changed \(server_login_retry\)",
+                        times=0,
+                    ):
+                        reload_host_config(
+                            bouncer,
+                            reloaded_hosts,
+                            pool_mode="transaction",
+                            query_timeout=6,
+                            server_login_retry=10,
+                            **reload_kwargs,
+                        )
+
+                        await first_query
+                        existing_client_query = existing_cursor.execute("SELECT 1")
+                        results = await asyncio.gather(
+                            second_query,
+                            existing_client_query,
+                            return_exceptions=True,
+                        )
+
+        assert not [result for result in results if isinstance(result, BaseException)]
+        assert results[0] == [(1,)]

--- a/test/test_load_balance_hosts.py
+++ b/test/test_load_balance_hosts.py
@@ -5,6 +5,8 @@ import psycopg
 import pytest
 from psycopg.rows import dict_row
 
+from .utils import WINDOWS
+
 HOST_RELOAD_DB = "host_reload"
 
 
@@ -333,6 +335,7 @@ def test_host_membership_change_clears_cached_connect_failure(bouncer):
         pytest.param("connect-query-changed", 1, id="connection-identity-changed"),
     ],
 )
+@pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
 async def test_reload_during_login_does_not_trigger_server_login_retry(
     pg, bouncer, reload_kind, expected_canceled_logins
 ):

--- a/test/test_load_balance_hosts.py
+++ b/test/test_load_balance_hosts.py
@@ -91,6 +91,24 @@ async def test_load_balance_hosts_disable_bad_first(bouncer):
             await bouncer.asleep(dbname="hostlist_bad_first", duration=0.5, times=2)
 
 
+async def test_round_robin_preserves_duplicate_host_weighting(bouncer):
+    hosts = f"{bouncer.pg.host},{bouncer.pg.host},unresolvable-hostname"
+
+    with bouncer.run_with_config(
+        host_reload_config(bouncer, hosts, server_login_retry=1)
+    ):
+        with bouncer.log_contains(r"127.0.0.1:\d+ new connection to server", 2):
+            with bouncer.log_contains(r"closing because: server DNS lookup failed", 1):
+                # Keeping the first two backends busy forces a third attempt.
+                # The duplicate healthy entry is a deliberate weight, so the
+                # selected sequence must be healthy, healthy, unresolvable.
+                await bouncer.asleep(
+                    dbname=HOST_RELOAD_DB,
+                    duration=0.5,
+                    times=3,
+                )
+
+
 def test_load_balance_hosts_reload(bouncer):
     with bouncer.admin_runner.cur() as cur:
         results = cur.execute("show databases").fetchall()


### PR DESCRIPTION
PgBouncer currently treats any change to a comma-separated host value as a change to the entire connection identity. This closes established connections and in-progress logins even when their selected host remains in the new list.

This preserves connections and login attempts to retained hosts, drains connections to removed hosts, and avoids recording administratively canceled logins as backend failures. Changes to other connection-identity fields still invalidate the full pool.

Related to #872 and #882. This is the explicit host-list reload equivalent of the DNS churn in #882, and administrative login cancellations can unnecessarily trigger the pool-wide server_login_retry behavior in #872.

Tests cover additions, removals, reordering, replacement, duplicate weighting, invalid reloads, cached failures, and in-progress logins.

Closes #1536.