### PR TITLE
Fix lint

### DIFF
--- a/doc/filter.py
+++ b/doc/filter.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import fileinput
 import os
 import sys

--- a/doc/filter.py
+++ b/doc/filter.py
@@ -2,17 +2,18 @@ import fileinput
 import os
 import sys
 
-for line in fileinput.input():
-    # substitute package version
-    if line.startswith("% "):
-        line = line.replace("@PACKAGE_VERSION@", os.environ["PACKAGE_VERSION"])
-    # drop level-1 header
-    if line.startswith("# "):
-        continue
-    # decrease level of all headers by 1
-    if line.startswith("##"):
-        line = line.replace("#", "", 1)
-    # convert level-1 headers to uppercase
-    if line.startswith("# "):
-        line = line.upper()
-    sys.stdout.write(line)
+with fileinput.input() as fi:
+    for line in fi:
+        # substitute package version
+        if line.startswith("% "):
+            line = line.replace("@PACKAGE_VERSION@", os.environ["PACKAGE_VERSION"])
+        # drop level-1 header
+        if line.startswith("# "):
+            continue
+        # decrease level of all headers by 1
+        if line.startswith("##"):
+            line = line.replace("#", "", 1)
+        # convert level-1 headers to uppercase
+        if line.startswith("# "):
+            line = line.upper()
+        sys.stdout.write(line)

--- a/etc/mkauth.py
+++ b/etc/mkauth.py
@@ -15,7 +15,7 @@ fn = sys.argv[1]
 if fn != "-":
     try:
         old = open(fn).read()
-    except IOError:
+    except OSError:
         old = ""
 
 # create new file data

--- a/etc/mkauth.py
+++ b/etc/mkauth.py
@@ -14,7 +14,8 @@ if len(sys.argv) != 3:
 fn = sys.argv[1]
 if fn != "-":
     try:
-        old = open(fn).read()
+        with open(fn) as fd:
+            old = fd.read()
     except OSError:
         old = ""
 

--- a/etc/mkauth.py
+++ b/etc/mkauth.py
@@ -30,7 +30,7 @@ for user, psw in curs.fetchall():
     if not psw:
         psw = ""
     psw = psw.replace('"', '""')
-    lines.append('"%s" "%s"\n' % (user, psw))
+    lines.append('"{}" "{}"\n').format(user, psw)
 db.commit()
 cur = "".join(lines)
 

--- a/etc/mkauth.py
+++ b/etc/mkauth.py
@@ -14,7 +14,7 @@ if len(sys.argv) != 3:
 fn = sys.argv[1]
 if fn != "-":
     try:
-        old = open(fn, "r").read()
+        old = open(fn).read()
     except IOError:
         old = ""
 

--- a/test/stress.py
+++ b/test/stress.py
@@ -48,10 +48,7 @@ class WorkThread(threading.Thread):
         return val
 
     def run(self):
-        try:
-            time.sleep(random.random() * 10.0)
-        except Exception:
-            pass
+        time.sleep(random.random() * 10.0)
         while 1:
             try:
                 self.main_loop()
@@ -59,12 +56,9 @@ class WorkThread(threading.Thread):
                 break
             except SystemExit:
                 break
-            except Exception as d:
+            except psycopg2.Error as d:
                 print(d)
-                try:
-                    time.sleep(5)
-                except Exception:
-                    pass
+                time.sleep(5)
 
     def main_loop(self):
         db = psycopg2.connect(get_connstr())

--- a/test/stress.py
+++ b/test/stress.py
@@ -86,7 +86,7 @@ class WorkThread(threading.Thread):
 
 
 def main():
-    print("connstr %s" % get_connstr())
+    print(f"connstr {get_connstr()}")
 
     thread_list = []
     while len(thread_list) < n_thread:
@@ -94,7 +94,7 @@ def main():
         t.start()
         thread_list.append(t)
 
-    print("started %d threads" % len(thread_list))
+    print(f"started {len(thread_list)} threads")
 
     last = time.time()
     while 1:
@@ -107,7 +107,7 @@ def main():
             for t in thread_list:
                 cnt += t.fetch_cnt()
             avg = cnt / dur
-            print("avg %s" % avg)
+            print(f"avg {avg}")
 
 
 if __name__ == "__main__":

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -145,7 +145,7 @@ def test_socket_id(bouncer) -> None:
                         initial_id + i * 2 - 1,
                         initial_id + i * 2,
                     ]
-                ) == set([client["id"] for client in clients])
+                ) == {client["id"] for client in clients}
                 conn_2.close()
                 time.sleep(2)
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -215,11 +215,11 @@ def test_client_states(bouncer):
     conn_1 = bouncer.conn(dbname="p3x", user="clientstate")
 
     clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
-    client_id = [
+    client_id = next(
         client
         for client in clients
         if client["database"] == "p3x" and client["user"] == "clientstate"
-    ][0]["state"]
+    )["state"]
     assert client_id == "idle"
 
     cur_1 = conn_1.cursor()
@@ -244,11 +244,11 @@ def test_client_states(bouncer):
     time.sleep(1)
 
     clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
-    client_id = [
+    client_id = next(
         client
         for client in clients
         if client["database"] == "p3x" and client["user"] == "clientstate"
-    ][0]["state"]
+    )["state"]
     assert client_id == "waiting"
 
     bouncer.admin("RESUME p3x")
@@ -261,11 +261,11 @@ def test_client_states(bouncer):
     cur_1.execute("BEGIN; SELECT pg_sleep(5);")
 
     clients = bouncer.admin("SHOW CLIENTS", row_factory=dict_row)
-    client_id = [
+    client_id = next(
         client
         for client in clients
         if client["database"] == "p3x" and client["user"] == "clientstate"
-    ][0]["state"]
+    )["state"]
     assert client_id == "active"
 
     # Rollback/commit to end the long-running transaction
@@ -395,7 +395,7 @@ def test_kill_client(bouncer):
     assert len(clients) == 2
 
     # Get clients id
-    client_id = [client for client in clients if client["database"] == "p0"][0]["id"]
+    client_id = next(client for client in clients if client["database"] == "p0")["id"]
 
     # Issue kill client command
     clients = bouncer.admin(f"KILL_CLIENT {client_id}")

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -139,13 +139,11 @@ def test_socket_id(bouncer) -> None:
                 time.sleep(2)
                 clients = admin_cursor.execute("SHOW SOCKETS").fetchall()
                 assert len(clients) == 3
-                assert set(
-                    [
+                assert {
                         initial_id,
                         initial_id + i * 2 - 1,
                         initial_id + i * 2,
-                    ]
-                ) == {client["id"] for client in clients}
+                    } == {client["id"] for client in clients}
                 conn_2.close()
                 time.sleep(2)
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -124,28 +124,30 @@ def test_socket_id(bouncer) -> None:
     server_lifetime = 0
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.cur(
+    with (
+        bouncer.run_with_config(config),
+        bouncer.cur(
             dbname="pgbouncer", user="pgbouncer", row_factory=dict_row
-        ) as admin_cursor:
-            admin_cursor.execute("SHOW SOCKETS")
-            servers = admin_cursor.fetchall()
-            initial_id = max([i["id"] for i in servers])
+        ) as admin_cursor,
+    ):
+        admin_cursor.execute("SHOW SOCKETS")
+        servers = admin_cursor.fetchall()
+        initial_id = max([i["id"] for i in servers])
 
-            for i in range(1, 4):
-                conn_2 = bouncer.conn(dbname="p1")
-                curr = conn_2.cursor()
-                _ = curr.execute("SELECT 1")
-                time.sleep(2)
-                clients = admin_cursor.execute("SHOW SOCKETS").fetchall()
-                assert len(clients) == 3
-                assert {
-                        initial_id,
-                        initial_id + i * 2 - 1,
-                        initial_id + i * 2,
-                    } == {client["id"] for client in clients}
-                conn_2.close()
-                time.sleep(2)
+        for i in range(1, 4):
+            conn_2 = bouncer.conn(dbname="p1")
+            curr = conn_2.cursor()
+            _ = curr.execute("SELECT 1")
+            time.sleep(2)
+            clients = admin_cursor.execute("SHOW SOCKETS").fetchall()
+            assert len(clients) == 3
+            assert {
+                initial_id,
+                initial_id + i * 2 - 1,
+                initial_id + i * 2,
+            } == {client["id"] for client in clients}
+            conn_2.close()
+            time.sleep(2)
 
 
 def test_server_id(bouncer) -> None:
@@ -164,25 +166,27 @@ def test_server_id(bouncer) -> None:
     server_lifetime = 0
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.cur(
+    with (
+        bouncer.run_with_config(config),
+        bouncer.cur(
             dbname="pgbouncer", user="pgbouncer", row_factory=dict_row
-        ) as admin_cursor:
-            admin_cursor.execute("SHOW SOCKETS")
-            servers = admin_cursor.fetchall()
-            initial_id = max([i["id"] for i in servers])
+        ) as admin_cursor,
+    ):
+        admin_cursor.execute("SHOW SOCKETS")
+        servers = admin_cursor.fetchall()
+        initial_id = max([i["id"] for i in servers])
 
-            for i in range(1, 4):
-                conn_2 = bouncer.conn(dbname="p1")
-                curr = conn_2.cursor()
-                _ = curr.execute("SELECT 1")
-                time.sleep(2)
-                clients = admin_cursor.execute("SHOW SERVERS").fetchall()
-                assert [
-                    initial_id + i * 2,
-                ] == [client["id"] for client in clients]
-                conn_2.close()
-                time.sleep(2)
+        for i in range(1, 4):
+            conn_2 = bouncer.conn(dbname="p1")
+            curr = conn_2.cursor()
+            _ = curr.execute("SELECT 1")
+            time.sleep(2)
+            clients = admin_cursor.execute("SHOW SERVERS").fetchall()
+            assert [
+                initial_id + i * 2,
+            ] == [client["id"] for client in clients]
+            conn_2.close()
+            time.sleep(2)
 
 
 def test_client_id(bouncer) -> None:

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -105,11 +105,13 @@ def test_auth_dbname_global_invalid(bouncer):
     bouncer.admin(f"set auth_dbname='p_unconfigured_auth_dbname'")
     bouncer.admin(f"set auth_type='md5'")
 
-    with bouncer.log_contains(
-        'authentication database "p_unconfigured_auth_dbname" is not configured'
+    with (
+        bouncer.log_contains(
+            'authentication database "p_unconfigured_auth_dbname" is not configured'
+        ),
+        pytest.raises(psycopg.OperationalError, match="bouncer config error"),
     ):
-        with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
-            bouncer.test(dbname="authdb", user="someuser", password="anypasswd")
+        bouncer.test(dbname="authdb", user="someuser", password="anypasswd")
 
     # test if auth_dbname specified in connection string takes precedence over
     # global setting. This automatically tests that the local logic works.
@@ -407,35 +409,35 @@ def test_auth_dbname_usage(
     """
 
     # We expect that stats user does not exist in userlist.txt
-    with bouncer.log_contains(
-        'cannot use the reserved "pgbouncer" database as an auth_dbname', 3
+    with (
+        bouncer.log_contains(
+            'cannot use the reserved "pgbouncer" database as an auth_dbname', 3
+        ),
+        bouncer.run_with_config(config),
     ):
-        with bouncer.run_with_config(config):
-            #     Check the pgbouncer does not crash when we connect to pgbouncer admin db
-            with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
-                bouncer.sql(
-                    query="show stats",
-                    user="stats",
-                    password="stats",
-                    dbname="pgbouncer",
-                )
+        #     Check the pgbouncer does not crash when we connect to pgbouncer admin db
+        with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
+            bouncer.sql(
+                query="show stats",
+                user="stats",
+                password="stats",
+                dbname="pgbouncer",
+            )
 
-            #     Check the pgbouncer does not crash when explicitly pgbouncer database
-            #     (admin DB) was set in auth_dbname in the databases definition section
-            with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
-                bouncer.sql(
-                    query="show stats",
-                    user="stats",
-                    password="stats",
-                    dbname="pgbouncer_test",
-                )
+        #     Check the pgbouncer does not crash when explicitly pgbouncer database
+        #     (admin DB) was set in auth_dbname in the databases definition section
+        with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
+            bouncer.sql(
+                query="show stats",
+                user="stats",
+                password="stats",
+                dbname="pgbouncer_test",
+            )
 
-            #     Check the pgbouncer does not crash when explicitly pgbouncer database
-            #     (admin DB) was set in auth_dbname in the autodb definition
-            with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
-                bouncer.sql(
-                    query="show stats", user="stats", password="stats", dbname="p4"
-                )
+        #     Check the pgbouncer does not crash when explicitly pgbouncer database
+        #     (admin DB) was set in auth_dbname in the autodb definition
+        with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
+            bouncer.sql(query="show stats", user="stats", password="stats", dbname="p4")
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
@@ -463,12 +465,14 @@ def test_auth_dbname_usage_global_setting(
         auth_dbname = pgbouncer
     """
 
-    with bouncer.log_contains(
-        'cannot use the reserved "pgbouncer" database as an auth_dbname', 1
+    with (
+        bouncer.log_contains(
+            'cannot use the reserved "pgbouncer" database as an auth_dbname', 1
+        ),
+        pytest.raises(psycopg.DatabaseError),
+        bouncer.run_with_config(config),
     ):
-        with pytest.raises(psycopg.DatabaseError):
-            with bouncer.run_with_config(config):
-                pass
+        pass
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
@@ -496,14 +500,13 @@ def test_auth_query_database_setting(
         auth_dbname = postgres
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.run_with_config(config):
-            bouncer.sql(
-                query="select version()",
-                user="stats",
-                password="stats",
-                dbname="postgres",
-            )
+    with bouncer.run_with_config(config), bouncer.run_with_config(config):
+        bouncer.sql(
+            query="select version()",
+            user="stats",
+            password="stats",
+            dbname="postgres",
+        )
 
     config = f"""
         [databases]
@@ -522,17 +525,17 @@ def test_auth_query_database_setting(
         auth_dbname = postgres
     """
 
-    with bouncer.run_with_config(config):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            with bouncer.run_with_config(config):
-                bouncer.sql(
-                    query="select version()",
-                    user="stats",
-                    password="stats",
-                    dbname="postgres",
-                )
+    with (
+        bouncer.run_with_config(config),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+        bouncer.run_with_config(config),
+    ):
+        bouncer.sql(
+            query="select version()",
+            user="stats",
+            password="stats",
+            dbname="postgres",
+        )
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
@@ -563,17 +566,19 @@ def test_auth_query_works_with_configured_users(bouncer):
 
     # As a sanity check, make sure that a user with a password in auth_file cannot run transactions
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with pytest.raises(psycopg.OperationalError):
-            with bouncer.log_contains(
-                "closing because: transaction blocks not allowed in statement pooling mode"
-            ):
-                bouncer.sql(
-                    query="begin",
-                    user="puser1",
-                    password="foo",
-                    dbname="postgres",
-                )
+    with (
+        bouncer.run_with_config(config),
+        pytest.raises(psycopg.OperationalError),
+        bouncer.log_contains(
+            "closing because: transaction blocks not allowed in statement pooling mode"
+        ),
+    ):
+        bouncer.sql(
+            query="begin",
+            user="puser1",
+            password="foo",
+            dbname="postgres",
+        )
 
     config = f"""
         [databases]
@@ -598,17 +603,19 @@ def test_auth_query_works_with_configured_users(bouncer):
     # is set to use statement pooling. pgBouncer should fail to allow a begin
     # statement while in statement pooling mode, but still be able to authenticate
     # using auth_query.
-    with bouncer.run_with_config(config):
-        with pytest.raises(psycopg.OperationalError):
-            with bouncer.log_contains(
-                "closing because: transaction blocks not allowed in statement pooling mode"
-            ):
-                bouncer.sql(
-                    query="begin",
-                    user="stats",
-                    password="stats",
-                    dbname="postgres",
-                )
+    with (
+        bouncer.run_with_config(config),
+        pytest.raises(psycopg.OperationalError),
+        bouncer.log_contains(
+            "closing because: transaction blocks not allowed in statement pooling mode"
+        ),
+    ):
+        bouncer.sql(
+            query="begin",
+            user="stats",
+            password="stats",
+            dbname="postgres",
+        )
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
@@ -637,15 +644,17 @@ def test_auth_query_logs_server_error(
         auth_dbname = postgres
     """
 
-    with bouncer.log_contains('"not_pg_shadow" does not exist'):
-        with bouncer.run_with_config(config):
-            with pytest.raises(psycopg.OperationalError, match="bouncer config error"):
-                bouncer.sql(
-                    query="select version()",
-                    user="stats",
-                    password="stats",
-                    dbname="postgres",
-                )
+    with (
+        bouncer.log_contains('"not_pg_shadow" does not exist'),
+        bouncer.run_with_config(config),
+        pytest.raises(psycopg.OperationalError, match="bouncer config error"),
+    ):
+        bouncer.sql(
+            query="select version()",
+            user="stats",
+            password="stats",
+            dbname="postgres",
+        )
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")
@@ -896,21 +905,23 @@ def test_client_hba_cert(bouncer, cert_dir):
     #    test            pgbouncer.acme.org      anotheruser
     # the username 'bouncer' does not match any mapped pg-username.
     # hence the test fails.
-    with pytest.raises(
-        subprocess.CalledProcessError,
-    ):
-        with bouncer.log_contains(
+    with (
+        pytest.raises(
+            subprocess.CalledProcessError,
+        ),
+        bouncer.log_contains(
             "p0x/bouncer@127.0.0.1:43544 ident map: test does not have a match"
-        ):
-            bouncer.psql_test(
-                dbname="p0x",
-                host="localhost",
-                user="bouncer",
-                sslmode="verify-full",
-                sslkey=client_key,
-                sslcert=client_cert,
-                sslrootcert=root,
-            )
+        ),
+    ):
+        bouncer.psql_test(
+            dbname="p0x",
+            host="localhost",
+            user="bouncer",
+            sslmode="verify-full",
+            sslkey=client_key,
+            sslcert=client_cert,
+            sslrootcert=root,
+        )
 
     client_key = cert_dir / "TestCA1" / "sites" / "02-bouncer.key"
     client_cert = cert_dir / "TestCA1" / "sites" / "02-bouncer.crt"
@@ -959,21 +970,23 @@ def test_client_hba_cert(bouncer, cert_dir):
     #   test2           pgbouncer.acme.org      "anotheruser"
     # for CN=pgbouncer.acme.org, test2 allows to use anotheruser. Hence the test fails.
 
-    with pytest.raises(
-        subprocess.CalledProcessError,
-    ):
-        with bouncer.log_contains(
+    with (
+        pytest.raises(
+            subprocess.CalledProcessError,
+        ),
+        bouncer.log_contains(
             "p0y/someuser@127.0.0.1:39712 ident map: test2 does not have a match"
-        ):
-            bouncer.psql_test(
-                dbname="p0y",
-                host="localhost",
-                user="someuser",
-                sslmode="verify-full",
-                sslkey=client_key,
-                sslcert=client_cert,
-                sslrootcert=root,
-            )
+        ),
+    ):
+        bouncer.psql_test(
+            dbname="p0y",
+            host="localhost",
+            user="someuser",
+            sslmode="verify-full",
+            sslkey=client_key,
+            sslcert=client_cert,
+            sslrootcert=root,
+        )
 
     # The client connects to p0y using a client certificate with CN=pgbouncer.acme.org.
     # hba_eval returns the following line:
@@ -1031,17 +1044,19 @@ def test_peer_auth_ident_map(bouncer):
         user="someuser",
     )
 
-    with pytest.raises(
-        subprocess.CalledProcessError,
-    ):
-        with bouncer.log_contains(
+    with (
+        pytest.raises(
+            subprocess.CalledProcessError,
+        ),
+        bouncer.log_contains(
             "p0y/bouncer@unix(6202):10202 ident map mymap cannot be matched"
-        ):
-            bouncer.psql_test(
-                dbname="p0y",
-                host=f"{bouncer.admin_host}",
-                user="bouncer",
-            )
+        ),
+    ):
+        bouncer.psql_test(
+            dbname="p0y",
+            host=f"{bouncer.admin_host}",
+            user="bouncer",
+        )
 
     with open(ident_conf_file, "w") as f:
         f.write(f"mymap {cur_user} all")
@@ -1061,12 +1076,14 @@ async def test_auth_user_trust_auth_without_auth_file_set(bouncer) -> None:
     """
     bouncer.admin("set auth_user='pswcheck_not_in_auth_file'")
     bouncer.admin("set auth_type='trust'")
-    with bouncer.conn(
-        dbname="p7a",
-        user="pswcheck_not_in_auth_file",
-    ) as cn:
-        with cn.cursor() as cur:
-            cur.execute("select 1")
+    with (
+        bouncer.conn(
+            dbname="p7a",
+            user="pswcheck_not_in_auth_file",
+        ) as cn,
+        cn.cursor() as cur,
+    ):
+        cur.execute("select 1")
 
 
 def test_auth_user_trust_auth_without_auth_file_reload(bouncer) -> None:
@@ -1088,13 +1105,15 @@ def test_auth_user_trust_auth_without_auth_file_reload(bouncer) -> None:
         auth_file = {bouncer.auth_path}
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.conn(
+    with (
+        bouncer.run_with_config(config),
+        bouncer.conn(
             dbname="postgres",
             user="postgres",
-        ) as cn:
-            with cn.cursor() as cur:
-                cur.execute("select 1")
+        ) as cn,
+        cn.cursor() as cur,
+    ):
+        cur.execute("select 1")
 
 
 def test_auth_user_at_db_level_trust_auth_without_auth_file_reload(bouncer) -> None:
@@ -1116,13 +1135,15 @@ def test_auth_user_at_db_level_trust_auth_without_auth_file_reload(bouncer) -> N
         auth_file = {bouncer.auth_path}
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.conn(
+    with (
+        bouncer.run_with_config(config),
+        bouncer.conn(
             dbname="postgres",
             user="pswcheck_not_in_auth_file",
-        ) as cn:
-            with cn.cursor() as cur:
-                cur.execute("select 1")
+        ) as cn,
+        cn.cursor() as cur,
+    ):
+        cur.execute("select 1")
 
 
 def test_auth_user_with_same_forced_user(bouncer):
@@ -1152,9 +1173,11 @@ def test_auth_user_with_same_forced_user(bouncer):
         # Let's wait a few seconds for the janitor to kick in and crash pgbouncer
         time.sleep(2)
         # Now we will try to connect with OK parameters
-        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
-            with cn.cursor() as cur:
-                cur.execute("select 1")
+        with (
+            bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn,
+            cn.cursor() as cur,
+        ):
+            cur.execute("select 1")
 
 
 def test_auth_user_at_db_level_with_same_forced_user(bouncer):
@@ -1183,9 +1206,11 @@ def test_auth_user_at_db_level_with_same_forced_user(bouncer):
         # Let's wait a few seconds for the janitor to kick in and crash pgbouncer
         time.sleep(2)
         # Now we will try to connect with OK parameters
-        with bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn:
-            with cn.cursor() as cur:
-                cur.execute("select 1")
+        with (
+            bouncer.conn(dbname="p3", user="postgres", password="asdasd") as cn,
+            cn.cursor() as cur,
+        ):
+            cur.execute("select 1")
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows does not have SIGHUP")

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import getpass
 import re
 import subprocess
@@ -793,7 +794,7 @@ async def test_change_server_password_reconnect(bouncer, pg):
                     psycopg.OperationalError, match="password authentication failed"
                 ):
                     await result3
-                time.sleep(3)
+                await asyncio.sleep(3)
     finally:
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
 
@@ -808,7 +809,7 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
         bouncer.test()
         pg.sql("ALTER USER puser1 PASSWORD 'bar'")
         # wait until server disconnect
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         # Because of our fast client closure on server auth failures (see
         # kill_pool_logins), we should only have one connection failing at
@@ -830,7 +831,7 @@ async def test_change_server_password_server_lifetime(bouncer, pg):
                 await result2
             with pytest.raises(psycopg.OperationalError):
                 await result3
-            time.sleep(3)
+            await asyncio.sleep(3)
     finally:
         pg.sql("ALTER USER puser1 PASSWORD 'foo'")
 

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -6,18 +6,15 @@ import pytest
 
 
 def test_cancel(bouncer):
-    with bouncer.cur(dbname="p3") as cur:
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            query = pool.submit(cur.execute, "select pg_sleep(5)")
+    with bouncer.cur(dbname="p3") as cur, ThreadPoolExecutor(max_workers=2) as pool:
+        query = pool.submit(cur.execute, "select pg_sleep(5)")
 
-            time.sleep(1)
+        time.sleep(1)
 
-            cancel = pool.submit(cur.connection.cancel)
-            cancel.result()
-            with pytest.raises(
-                psycopg.errors.QueryCanceled, match="due to user request"
-            ):
-                query.result()
+        cancel = pool.submit(cur.connection.cancel)
+        cancel.result()
+        with pytest.raises(psycopg.errors.QueryCanceled, match="due to user request"):
+            query.result()
 
 
 # Test for waiting connections handling for cancel requests.
@@ -30,20 +27,17 @@ def test_cancel_wait(bouncer):
     # default_pool_size=5
     bouncer.admin(f"set server_idle_timeout=2")
 
-    with bouncer.cur(dbname="p3") as cur:
-        with ThreadPoolExecutor(max_workers=6) as pool:
-            q1 = pool.submit(cur.execute, "select pg_sleep(5)")
-            others = [pool.submit(bouncer.sleep, 2, dbname="p3") for _ in range(4)]
+    with bouncer.cur(dbname="p3") as cur, ThreadPoolExecutor(max_workers=6) as pool:
+        q1 = pool.submit(cur.execute, "select pg_sleep(5)")
+        others = [pool.submit(bouncer.sleep, 2, dbname="p3") for _ in range(4)]
 
-            cancel = pool.submit(cur.connection.cancel)
-            cancel.result()
-            with pytest.raises(
-                psycopg.errors.QueryCanceled, match="due to user request"
-            ):
-                q1.result()
+        cancel = pool.submit(cur.connection.cancel)
+        cancel.result()
+        with pytest.raises(psycopg.errors.QueryCanceled, match="due to user request"):
+            q1.result()
 
-            for q in others:
-                q.result()
+        for q in others:
+            q.result()
 
 
 # Test that cancel requests can exceed the pool size

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -496,9 +496,11 @@ def test_min_pool_size_with_lower_max_user_connections(bouncer):
 
     # Running a query for sufficient time for us to reach the final
     # connection count in the pool and detect any evictions.
-    with bouncer.log_contains(r"new connection to server \(from", times=2):
-        with bouncer.log_contains("closing because: evicted", times=0):
-            bouncer.sleep(2, dbname="p0x", user="maxedout2")
+    with (
+        bouncer.log_contains(r"new connection to server \(from", times=2),
+        bouncer.log_contains("closing because: evicted", times=0),
+    ):
+        bouncer.sleep(2, dbname="p0x", user="maxedout2")
 
 
 def test_min_pool_size_with_lower_max_db_connections(bouncer):
@@ -509,9 +511,11 @@ def test_min_pool_size_with_lower_max_db_connections(bouncer):
 
     # Running a query for sufficient time for us to reach the final
     # connection count in the pool and detect any evictions.
-    with bouncer.log_contains(r"new connection to server \(from", times=2):
-        with bouncer.log_contains("closing because: evicted", times=0):
-            bouncer.sleep(2, dbname="p0y", user="puser1")
+    with (
+        bouncer.log_contains(r"new connection to server \(from", times=2),
+        bouncer.log_contains("closing because: evicted", times=0),
+    ):
+        bouncer.sleep(2, dbname="p0y", user="puser1")
 
 
 async def test_reserve_pool_size(pg, bouncer):

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -28,7 +28,7 @@ def test_max_db_client_connections_local_override_global(bouncer):
     connect_args = {"dbname": test_db, "user": "muser1"}
     conns = [bouncer.conn(**connect_args) for _ in range(2)]
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 2
     assert db["max_client_connections"] == 2
     with pytest.raises(psycopg.OperationalError, match=r"max_db_client_connections"):
@@ -60,7 +60,7 @@ def test_max_db_client_connections_global_negative(
     connect_args = {"dbname": test_db, "user": test_user}
     conns = [bouncer.conn(**connect_args) for _ in range(2)]
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 2 if test_db == "p0" else 3
     assert db["max_client_connections"] == 2
 
@@ -98,7 +98,7 @@ def test_max_db_client_connections_global_positive(
     conn = bouncer.conn(**connect_args)
     # should still be allowed, since it's the last allowed connection
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 1 if test_db == "p0" else 2
     assert db["max_client_connections"] == 2
     _ = bouncer.conn(**connect_args)
@@ -124,12 +124,12 @@ def test_max_db_client_connections_decrement(
     connect_args = {"dbname": test_db, "user": test_user}
     [conn_1, conn_2] = [bouncer.conn(**connect_args) for _ in range(2)]
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 2 if test_db == "p0" else 3
 
     conn_2.close()
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 1 if test_db == "p0" else 2
 
 
@@ -148,7 +148,7 @@ def test_max_db_client_connections_negative(
     # with bouncer.run_with_config(config):
     conns = [bouncer.conn(**connect_args) for _ in range(2)]
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 2 if test_db == "p0" else 3
     assert db["max_client_connections"] == 2
 
@@ -173,7 +173,7 @@ def test_max_db_client_connections_positive(bouncer, test_db: str, test_user) ->
     conn = bouncer.conn(**connect_args)
     # should still be allowed, since it's the last allowed connection
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
-    db = [db for db in dbs if db["name"] == test_db][0]
+    db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 1 if test_db == "p0" else 2
     assert db["max_client_connections"] == 2
     _ = bouncer.conn(**connect_args)

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -122,7 +122,7 @@ def test_max_db_client_connections_decrement(
     bouncer.admin("SET admin_users = 'pgbouncer'")
 
     connect_args = {"dbname": test_db, "user": test_user}
-    [conn_1, conn_2] = [bouncer.conn(**connect_args) for _ in range(2)]
+    [_conn_1, conn_2] = [bouncer.conn(**connect_args) for _ in range(2)]
     dbs = bouncer.admin("SHOW DATABASES", row_factory=dict_row)
     db = next(db for db in dbs if db["name"] == test_db)
     assert db["current_client_connections"] == 2 if test_db == "p0" else 3

--- a/test/test_load_balance_hosts.py
+++ b/test/test_load_balance_hosts.py
@@ -11,14 +11,16 @@ async def test_load_balance_hosts_disable_good_first(bouncer):
 
 async def test_load_balance_hosts_disable_bad_first(bouncer):
     bouncer.admin(f"set server_login_retry=1")
-    with bouncer.log_contains(r"closing because: server DNS lookup failed", 1):
-        with bouncer.log_contains(r"127.0.0.1:\d+ new connection to server", 2):
-            # Execute two concurrent sleeps to force two backend connections.
-            # The first connection will attempt the "bad" host and retry on
-            # the "good" host.
-            # The second connection will honor `load_balance_hosts` and use the
-            # `disable` host.
-            await bouncer.asleep(dbname="hostlist_bad_first", duration=0.5, times=2)
+    with (
+        bouncer.log_contains(r"closing because: server DNS lookup failed", 1),
+        bouncer.log_contains(r"127.0.0.1:\d+ new connection to server", 2),
+    ):
+        # Execute two concurrent sleeps to force two backend connections.
+        # The first connection will attempt the "bad" host and retry on
+        # the "good" host.
+        # The second connection will honor `load_balance_hosts` and use the
+        # `disable` host.
+        await bouncer.asleep(dbname="hostlist_bad_first", duration=0.5, times=2)
 
 
 def test_load_balance_hosts_reload(bouncer):

--- a/test/test_load_balance_hosts.py
+++ b/test/test_load_balance_hosts.py
@@ -24,7 +24,7 @@ async def test_load_balance_hosts_disable_bad_first(bouncer):
 def test_load_balance_hosts_reload(bouncer):
     with bouncer.admin_runner.cur() as cur:
         results = cur.execute("show databases").fetchall()
-        result = [r for r in results if r[0] == "load_balance_hosts_update"][0]
+        result = next(r for r in results if r[0] == "load_balance_hosts_update")
         assert "disable" in result
 
     with bouncer.ini_path.open() as f:
@@ -43,5 +43,5 @@ def test_load_balance_hosts_reload(bouncer):
 
     with bouncer.admin_runner.cur() as cur:
         results = cur.execute("show databases").fetchall()
-        result = [r for r in results if r[0] == "load_balance_hosts_update"][0]
+        result = next(r for r in results if r[0] == "load_balance_hosts_update")
         assert "round-robin" in result

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -677,7 +677,7 @@ async def test_repeated_sigterm(bouncer):
         bouncer.sigterm()
 
         # Single sigterm should wait for clients
-        time.sleep(1)
+        await asyncio.sleep(1)
         cur.execute("SELECT 1")
         assert bouncer.running()
 
@@ -700,7 +700,7 @@ async def test_repeated_sigint(bouncer):
         bouncer.sigint()
 
         # Single sigint should wait for servers to be released
-        time.sleep(1)
+        await asyncio.sleep(1)
         cur.execute("SELECT 1")
         assert bouncer.running()
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -107,13 +107,15 @@ def test_scram_server(bouncer, test_auth_type):
     [users]
     puser1 = max_user_connections = 1
     """
-    with bouncer.run_with_config(config):
-        # good password from ini
-        with pytest.raises(psycopg.errors.ConnectionTimeout):
-            if test_auth_type == "trust":
-                bouncer.test(dbname="p6")
-            else:
-                bouncer.test(dbname="p6", password="foo", user="scramuser1")
+    # good password from ini
+    with (
+        bouncer.run_with_config(config),
+        pytest.raises(psycopg.errors.ConnectionTimeout),
+    ):
+        if test_auth_type == "trust":
+            bouncer.test(dbname="p6")
+        else:
+            bouncer.test(dbname="p6", password="foo", user="scramuser1")
 
 
 async def test_notify_queue_negative(bouncer):
@@ -270,9 +272,11 @@ def test_server_check_query_default_negative(pg, bouncer, proxy):
         pg.sql(f"SELECT pg_terminate_backend({pid});")
         proxy.start()
 
-        with bouncer.cur(dbname="postgres", user="puser1") as cur:
-            with pg.log_contains(" LOG:  statement: \n", times=0):
-                new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+        with (
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+            pg.log_contains(" LOG:  statement: \n", times=0),
+        ):
+            new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
     assert new_pid != pid
     pg.configure(config="log_statement = 'none'")
@@ -318,9 +322,11 @@ def test_server_check_query_negative(pg, bouncer, proxy):
         pg.sql(f"SELECT pg_terminate_backend({pid});")
         proxy.start()
 
-        with bouncer.cur(dbname="postgres", user="puser1") as cur:
-            with pg.log_contains(" LOG:  statement: SELECT 2\n", times=0):
-                new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+        with (
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+            pg.log_contains(" LOG:  statement: SELECT 2\n", times=0),
+        ):
+            new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
     assert new_pid != pid
     pg.configure(config="log_statement = 'none'")
@@ -361,9 +367,11 @@ def test_server_check_query_default(
         with bouncer.cur(dbname="postgres", user="puser1") as cur:
             pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
-        with bouncer.cur(dbname="postgres", user="puser1") as cur:
-            with pg.log_contains(" LOG:  statement: \n", times=1):
-                new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+        with (
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+            pg.log_contains(" LOG:  statement: \n", times=1),
+        ):
+            new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
     assert new_pid == pid
     pg.configure(config="log_statement = 'none'")
@@ -402,9 +410,11 @@ def test_server_check_query(pg, bouncer):
         with bouncer.cur(dbname="postgres", user="puser1") as cur:
             pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
-        with bouncer.cur(dbname="postgres", user="puser1") as cur:
-            with pg.log_contains(" LOG:  statement: SELECT 2\n", times=1):
-                new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+        with (
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+            pg.log_contains(" LOG:  statement: SELECT 2\n", times=1),
+        ):
+            new_pid = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
 
     assert new_pid == pid
     pg.configure(config="log_statement = 'none'")
@@ -463,23 +473,22 @@ def test_track_extra_parameters(bouncer):
     if not WINDOWS:
         test_expected["client_encoding"] = ["LATIN1", "LATIN5"]
 
-    with bouncer.cur(dbname="p1") as cur1:
-        with bouncer.cur(dbname="p1") as cur2:
-            for key in test_set:
-                stmt1 = "SET " + key + " TO " + test_set[key][0]
-                stmt2 = "SET " + key + " TO " + test_set[key][1]
-                cur1.execute(stmt1)
-                cur2.execute(stmt2)
+    with bouncer.cur(dbname="p1") as cur1, bouncer.cur(dbname="p1") as cur2:
+        for key in test_set:
+            stmt1 = "SET " + key + " TO " + test_set[key][0]
+            stmt2 = "SET " + key + " TO " + test_set[key][1]
+            cur1.execute(stmt1)
+            cur2.execute(stmt2)
 
-                stmt = "SHOW " + key
-                cur1.execute(stmt)
-                cur2.execute(stmt)
+            stmt = "SHOW " + key
+            cur1.execute(stmt)
+            cur2.execute(stmt)
 
-                result1 = cur1.fetchone()
-                assert result1[0] == test_expected[key][0]
+            result1 = cur1.fetchone()
+            assert result1[0] == test_expected[key][0]
 
-                result2 = cur2.fetchone()
-                assert result2[0] == test_expected[key][1]
+            result2 = cur2.fetchone()
+            assert result2[0] == test_expected[key][1]
 
 
 async def test_wait_close(bouncer):
@@ -518,9 +527,11 @@ def test_auto_database(bouncer):
 # non-empty.
 @pytest.mark.skipif("not HAVE_IPV6_LOCALHOST")
 async def test_host_list(bouncer):
-    with bouncer.log_contains(r"new connection to server \(from 127.0.0.1", times=1):
-        with bouncer.log_contains(r"new connection to server \(from \[::1\]", times=1):
-            await bouncer.asleep(1, dbname="hostlist1", times=2)
+    with (
+        bouncer.log_contains(r"new connection to server \(from 127.0.0.1", times=1),
+        bouncer.log_contains(r"new connection to server \(from \[::1\]", times=1),
+    ):
+        await bouncer.asleep(1, dbname="hostlist1", times=2)
 
 
 # This is the same test as above, except it doesn't use any IPv6
@@ -647,16 +658,16 @@ def test_equivalent_startup_param(bouncer):
     bouncer.admin("set verbose=2")
 
     canonical_expected_times = 1 if PG_MAJOR_VERSION >= 14 else 0
-    with bouncer.cur(options="-c DateStyle=ISO") as cur:
-        with (
-            bouncer.log_contains("varcache_apply: .*SET DateStyle='ISO'", times=1),
-            bouncer.log_contains(
-                "varcache_set_canonical: setting DateStyle to its canonical version ISO -> ISO, MDY",
-                times=canonical_expected_times,
-            ),
-        ):
-            cur.execute("SELECT 1")
-            cur.execute("SELECT 1")
+    with (
+        bouncer.cur(options="-c DateStyle=ISO") as cur,
+        bouncer.log_contains("varcache_apply: .*SET DateStyle='ISO'", times=1),
+        bouncer.log_contains(
+            "varcache_set_canonical: setting DateStyle to its canonical version ISO -> ISO, MDY",
+            times=canonical_expected_times,
+        ),
+    ):
+        cur.execute("SELECT 1")
+        cur.execute("SELECT 1")
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows doesn't support sending SIGTERM")
@@ -717,9 +728,11 @@ def test_newly_paused_client_during_wait_for_servers_shutdown(bouncer):
         # Still in the same transaction, so this should work
         cur1.execute("SELECT 1")
         # New transaction so this should fail
-        with bouncer.log_contains(r"closing because: server shutting down"):
-            with pytest.raises(psycopg.OperationalError):
-                cur2.execute("SELECT 1")
+        with (
+            bouncer.log_contains(r"closing because: server shutting down"),
+            pytest.raises(psycopg.OperationalError),
+        ):
+            cur2.execute("SELECT 1")
 
 
 async def test_already_paused_client_during_wait_for_servers_shutdown(bouncer):

--- a/test/test_no_database.py
+++ b/test/test_no_database.py
@@ -5,30 +5,30 @@ import pytest
 
 
 def test_no_database(bouncer):
-    with bouncer.log_contains(r"closing because: no such database: nosuchdb"):
-        with pytest.raises(
-            psycopg.OperationalError, match="no such database: nosuchdb"
-        ):
-            bouncer.test(dbname="nosuchdb")
+    with (
+        bouncer.log_contains(r"closing because: no such database: nosuchdb"),
+        pytest.raises(psycopg.OperationalError, match="no such database: nosuchdb"),
+    ):
+        bouncer.test(dbname="nosuchdb")
 
 
 def test_no_database_authfail(bouncer):
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="nosuchdb", password="wrong")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="nosuchdb", password="wrong")
 
 
 def test_no_database_auth_user(bouncer):
     bouncer.admin(f"set auth_user='pswcheck'")
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="nosuchdb", user="someuser", password="wrong")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="nosuchdb", user="someuser", password="wrong")
 
 
 def test_no_database_pg(bouncer):
@@ -39,12 +39,12 @@ def test_no_database_pg(bouncer):
         bouncer.log_contains(
             r'closing because: database "non_existing_pg_db" does not exist'
         ),
-    ):
-        with pytest.raises(
+        pytest.raises(
             psycopg.OperationalError,
             match='database "non_existing_pg_db" does not exist',
-        ):
-            bouncer.test(dbname="non_existing_pg_db")
+        ),
+    ):
+        bouncer.test(dbname="non_existing_pg_db")
 
 
 def test_no_database_auto_database(bouncer):
@@ -61,11 +61,11 @@ def test_no_database_auto_database(bouncer):
             r'server login failed: FATAL database "nosuchdb" does not exist'
         ),
         bouncer.log_contains(r'closing because: database "nosuchdb" does not exist'),
-    ):
-        with pytest.raises(
+        pytest.raises(
             psycopg.OperationalError, match='database "nosuchdb" does not exist'
-        ):
-            bouncer.test(dbname="nosuchdb")
+        ),
+    ):
+        bouncer.test(dbname="nosuchdb")
 
 
 def test_no_database_auto_database_auth_user(bouncer):
@@ -84,11 +84,11 @@ def test_no_database_auto_database_auth_user(bouncer):
             r'server login failed: FATAL database "nosuchdb" does not exist'
         ),
         bouncer.log_contains(r'closing because: database "nosuchdb" does not exist'),
-    ):
-        with pytest.raises(
+        pytest.raises(
             psycopg.OperationalError, match='database "nosuchdb" does not exist'
-        ):
-            bouncer.test(dbname="nosuchdb", user="nonexistinguser")
+        ),
+    ):
+        bouncer.test(dbname="nosuchdb", user="nonexistinguser")
 
 
 def test_no_database_md5_auth_scram_pw_success(bouncer):
@@ -97,11 +97,11 @@ def test_no_database_md5_auth_scram_pw_success(bouncer):
     # with md5 auth and a scram PW when saving SCRAM credentials. Including
     # this test to check for the condition repeating.
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: no such database: nosuchdb"):
-        with pytest.raises(
-            psycopg.OperationalError, match="no such database: nosuchdb"
-        ):
-            bouncer.test(dbname="nosuchdb", user="scramuser1", password="foo")
+    with (
+        bouncer.log_contains(r"closing because: no such database: nosuchdb"),
+        pytest.raises(psycopg.OperationalError, match="no such database: nosuchdb"),
+    ):
+        bouncer.test(dbname="nosuchdb", user="scramuser1", password="foo")
 
 
 def test_no_database_scram_auth_scram_pw_success(bouncer):
@@ -110,11 +110,11 @@ def test_no_database_scram_auth_scram_pw_success(bouncer):
     # was put in place with md5 auth and a scram PW. Including this test for
     # completeness.
     bouncer.admin(f"set auth_type='scram-sha-256'")
-    with bouncer.log_contains(r"closing because: no such database: nosuchdb"):
-        with pytest.raises(
-            psycopg.OperationalError, match="no such database: nosuchdb"
-        ):
-            bouncer.test(dbname="nosuchdb", user="scramuser1", password="foo")
+    with (
+        bouncer.log_contains(r"closing because: no such database: nosuchdb"),
+        pytest.raises(psycopg.OperationalError, match="no such database: nosuchdb"),
+    ):
+        bouncer.test(dbname="nosuchdb", user="scramuser1", password="foo")
 
 
 @pytest.mark.md5
@@ -124,8 +124,8 @@ def test_no_database_md5_auth_md5_pw_success(bouncer):
     # put in place with md5 auth and a scram PW. Including this test for
     # completeness.
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: no such database: nosuchdb"):
-        with pytest.raises(
-            psycopg.OperationalError, match="no such database: nosuchdb"
-        ):
-            bouncer.test(dbname="nosuchdb", user="muser1", password="foo")
+    with (
+        bouncer.log_contains(r"closing because: no such database: nosuchdb"),
+        pytest.raises(psycopg.OperationalError, match="no such database: nosuchdb"),
+    ):
+        bouncer.test(dbname="nosuchdb", user="muser1", password="foo")

--- a/test/test_no_user.py
+++ b/test/test_no_user.py
@@ -9,74 +9,74 @@ import pytest
 
 def test_no_user_trust(bouncer):
     bouncer.admin(f"set auth_type='trust'")
-    with bouncer.log_contains(r'closing because: "trust" authentication failed'):
-        with pytest.raises(
-            psycopg.OperationalError, match='"trust" authentication failed'
-        ):
-            bouncer.test(dbname="p2", user="nosuchuser")
+    with (
+        bouncer.log_contains(r'closing because: "trust" authentication failed'),
+        pytest.raises(psycopg.OperationalError, match='"trust" authentication failed'),
+    ):
+        bouncer.test(dbname="p2", user="nosuchuser")
 
 
 def test_no_user_trust_forced_user(bouncer):
     bouncer.admin(f"set auth_type='trust'")
-    with bouncer.log_contains(r'closing because: "trust" authentication failed'):
-        with pytest.raises(
-            psycopg.OperationalError, match='"trust" authentication failed'
-        ):
-            bouncer.test(dbname="p1", user="nosuchuser")
+    with (
+        bouncer.log_contains(r'closing because: "trust" authentication failed'),
+        pytest.raises(psycopg.OperationalError, match='"trust" authentication failed'),
+    ):
+        bouncer.test(dbname="p1", user="nosuchuser")
 
 
 def test_no_user_password(bouncer):
     bouncer.admin(f"set auth_type='plain'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
 
 
 def test_no_user_password_forced_user(bouncer):
     bouncer.admin(f"set auth_type='plain'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
 
 
 def test_no_user_md5(bouncer):
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
 
 
 def test_no_user_md5_forced_user(bouncer):
     bouncer.admin(f"set auth_type='md5'")
-    with bouncer.log_contains(r"closing because: password authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="password authentication failed"
-        ):
-            bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: password authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="password authentication failed"),
+    ):
+        bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
 
 
 def test_no_user_scram(bouncer):
     bouncer.admin(f"set auth_type='scram-sha-256'")
-    with bouncer.log_contains(r"closing because: SASL authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="SASL authentication failed"
-        ):
-            bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: SASL authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="SASL authentication failed"),
+    ):
+        bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
 
 
 def test_no_user_scram_forced_user(bouncer):
     bouncer.admin(f"set auth_type='scram-sha-256'")
-    with bouncer.log_contains(r"closing because: SASL authentication failed"):
-        with pytest.raises(
-            psycopg.OperationalError, match="SASL authentication failed"
-        ):
-            bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: SASL authentication failed"),
+        pytest.raises(psycopg.OperationalError, match="SASL authentication failed"),
+    ):
+        bouncer.test(dbname="p1", user="nosuchuser", password="whatever")
 
 
 def test_no_user_auth_user(bouncer):
@@ -84,6 +84,8 @@ def test_no_user_auth_user(bouncer):
     # Currently no mock authentication when using
     # auth_query/auth_user.  See TODO in
     # handle_auth_query_response().
-    with bouncer.log_contains(r"closing because: no such user \(age"):
-        with pytest.raises(psycopg.OperationalError, match="no such user"):
-            bouncer.test(dbname="authdb", user="nosuchuser", password="whatever")
+    with (
+        bouncer.log_contains(r"closing because: no such user \(age"),
+        pytest.raises(psycopg.OperationalError, match="no such user"),
+    ):
+        bouncer.test(dbname="authdb", user="nosuchuser", password="whatever")

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -78,7 +78,7 @@ async def test_rolling_restart_admin(peers):
         # Trigger a shutdown, but the process should keep running until we
         # close the connection
         peers[1].admin("shutdown wait_for_clients")
-        time.sleep(1)
+        await asyncio.sleep(1)
         assert peers[1].running()
 
         # New connection attempts are now expected to fail, because no process
@@ -113,7 +113,7 @@ async def test_rolling_restart_sigterm(peers):
         # Trigger a shutdown, but the process should keep running until we
         # close the connection
         peers[1].sigterm()
-        time.sleep(1)
+        await asyncio.sleep(1)
         assert peers[1].running()
 
         # New connection attempts are now expected to fail, because no process

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict
 
 import psycopg
 import pytest
@@ -14,7 +13,7 @@ if not LINUX:
 
 @pytest.fixture
 async def peers(pg, tmp_path):
-    peers: Dict[int, Bouncer] = {}
+    peers: dict[int, Bouncer] = {}
     peers[1] = Bouncer(pg, tmp_path / "bouncer1")
 
     peers[2] = Bouncer(pg, tmp_path / "bouncer2", port=peers[1].port)

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -38,17 +38,16 @@ async def peers(pg, tmp_path):
 
 
 def test_peering_without_own_index(peers):
-    with peers[1].cur() as cur:
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            for _ in range(10):
-                query = pool.submit(cur.execute, "select pg_sleep(5)")
-                time.sleep(0.5)
-                cancel = pool.submit(cur.connection.cancel)
-                cancel.result()
-                with pytest.raises(
-                    psycopg.errors.QueryCanceled, match="due to user request"
-                ):
-                    query.result()
+    with peers[1].cur() as cur, ThreadPoolExecutor(max_workers=2) as pool:
+        for _ in range(10):
+            query = pool.submit(cur.execute, "select pg_sleep(5)")
+            time.sleep(0.5)
+            cancel = pool.submit(cur.connection.cancel)
+            cancel.result()
+            with pytest.raises(
+                psycopg.errors.QueryCanceled, match="due to user request"
+            ):
+                query.result()
 
 
 def test_peering_with_own_index(peers):
@@ -57,17 +56,16 @@ def test_peering_with_own_index(peers):
             f.write(f"{own_index} = host={bouncer.admin_host} port={bouncer.port}\n")
         bouncer.admin("reload")
 
-    with peers[1].cur() as cur:
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            for _ in range(10):
-                query = pool.submit(cur.execute, "select pg_sleep(5)")
-                time.sleep(0.5)
-                cancel = pool.submit(cur.connection.cancel)
-                cancel.result()
-                with pytest.raises(
-                    psycopg.errors.QueryCanceled, match="due to user request"
-                ):
-                    query.result()
+    with peers[1].cur() as cur, ThreadPoolExecutor(max_workers=2) as pool:
+        for _ in range(10):
+            query = pool.submit(cur.execute, "select pg_sleep(5)")
+            time.sleep(0.5)
+            cancel = pool.submit(cur.connection.cancel)
+            cancel.result()
+            with pytest.raises(
+                psycopg.errors.QueryCanceled, match="due to user request"
+            ):
+                query.result()
 
 
 async def test_rolling_restart_admin(peers):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -12,101 +12,101 @@ from .utils import LIBPQ_SUPPORTS_PIPELINING, LINUX, PKT_BUF_SIZE, USE_SUDO
 def test_prepared_statement(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1:
-        with bouncer.cur() as cur2:
-            # prepare query on server 1 and client 1
-            cur1.execute(prepared_query, prepare=True)
-            # Run the prepared query again on same server and client
+    with bouncer.cur() as cur1, bouncer.cur() as cur2:
+        # prepare query on server 1 and client 1
+        cur1.execute(prepared_query, prepare=True)
+        # Run the prepared query again on same server and client
+        cur1.execute(prepared_query)
+        with cur2.connection.transaction():
+            # Claim server 1 with client 2
+            cur2.execute("SELECT 2")
+            # Client 1 now runs the prepared query, and it's automatically
+            # prepared on server 2
             cur1.execute(prepared_query)
-            with cur2.connection.transaction():
-                # Claim server 1 with client 2
-                cur2.execute("SELECT 2")
-                # Client 1 now runs the prepared query, and it's automatically
-                # prepared on server 2
-                cur1.execute(prepared_query)
-                # Client 2 now prepares the same query that was already
-                # prepared on server 1. And PgBouncer reuses that already
-                # prepared query for this different client.
-                cur2.execute(prepared_query, prepare=True)
+            # Client 2 now prepares the same query that was already
+            # prepared on server 1. And PgBouncer reuses that already
+            # prepared query for this different client.
+            cur2.execute(prepared_query, prepare=True)
 
 
 def test_prepared_statement_params(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT %s"
-    with bouncer.cur() as cur1:
-        with bouncer.cur() as cur2:
-            # prepare query on server 1 and client 1
-            cur1.execute(prepared_query, params=(1,), prepare=True)
-            # Run the prepared query again on same server and client
+    with bouncer.cur() as cur1, bouncer.cur() as cur2:
+        # prepare query on server 1 and client 1
+        cur1.execute(prepared_query, params=(1,), prepare=True)
+        # Run the prepared query again on same server and client
+        cur1.execute(prepared_query, params=(1,))
+        with cur2.connection.transaction():
+            # Claim server 1 with client 2
+            cur2.execute("SELECT 2")
+            # Client 1 now runs the prepared query, and it's automatically
+            # prepared on server 2
             cur1.execute(prepared_query, params=(1,))
-            with cur2.connection.transaction():
-                # Claim server 1 with client 2
-                cur2.execute("SELECT 2")
-                # Client 1 now runs the prepared query, and it's automatically
-                # prepared on server 2
-                cur1.execute(prepared_query, params=(1,))
-                # Client 2 now prepares the same query that was already
-                # prepared on server 1. And PgBouncer reuses that already
-                # prepared query for this different client.
-                cur2.execute(prepared_query, params=(1,), prepare=True)
+            # Client 2 now prepares the same query that was already
+            # prepared on server 1. And PgBouncer reuses that already
+            # prepared query for this different client.
+            cur2.execute(prepared_query, params=(1,), prepare=True)
 
 
 def test_deallocate_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1:
-        with bouncer.cur() as cur2:
-            # prepare query on client 1
-            cur1.execute(prepared_query, prepare=True)
-            # Run the prepared query again on same server and client
+    with bouncer.cur() as cur1, bouncer.cur() as cur2:
+        # prepare query on client 1
+        cur1.execute(prepared_query, prepare=True)
+        # Run the prepared query again on same server and client
+        cur1.execute(prepared_query)
+
+        # prepared query for client 2
+        cur2.execute(prepared_query, prepare=True)
+
+        # execute DEALLOCATE ALL on client 1
+        cur1.execute("DEALLOCATE ALL")
+
+        # Run the prepared query again on server 2 and client 2
+        cur2.execute(prepared_query)
+
+        # Confirm that the prepared query is not available anymore on
+        # client 1
+        with (
+            bouncer.log_contains("prepared statement did not exist"),
+            pytest.raises(
+                psycopg.OperationalError,
+                match="prepared statement did not exist|server closed the connection unexpectedly",
+            ),
+        ):
             cur1.execute(prepared_query)
-
-            # prepared query for client 2
-            cur2.execute(prepared_query, prepare=True)
-
-            # execute DEALLOCATE ALL on client 1
-            cur1.execute("DEALLOCATE ALL")
-
-            # Run the prepared query again on server 2 and client 2
-            cur2.execute(prepared_query)
-
-            # Confirm that the prepared query is not available anymore on
-            # client 1
-            with bouncer.log_contains("prepared statement did not exist"):
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match="prepared statement did not exist|server closed the connection unexpectedly",
-                ):
-                    cur1.execute(prepared_query)
 
 
 def test_discard_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1:
-        with bouncer.cur() as cur2:
-            # prepare query on client 1
-            cur1.execute(prepared_query, prepare=True)
-            # Run the prepared query again on same server and client
+    with bouncer.cur() as cur1, bouncer.cur() as cur2:
+        # prepare query on client 1
+        cur1.execute(prepared_query, prepare=True)
+        # Run the prepared query again on same server and client
+        cur1.execute(prepared_query)
+
+        # prepared query for client 2
+        cur2.execute(prepared_query, prepare=True)
+
+        # execute DISCARD ALL on client 1
+        cur1.execute("DISCARD ALL")
+
+        # Run the prepared query again on server 2 and client 2
+        cur2.execute(prepared_query)
+
+        # Confirm that the prepared query is not available anymore on
+        # client 1
+        with (
+            bouncer.log_contains("prepared statement did not exist"),
+            pytest.raises(
+                psycopg.OperationalError,
+                match="prepared statement did not exist|server closed the connection unexpectedly",
+            ),
+        ):
             cur1.execute(prepared_query)
-
-            # prepared query for client 2
-            cur2.execute(prepared_query, prepare=True)
-
-            # execute DISCARD ALL on client 1
-            cur1.execute("DISCARD ALL")
-
-            # Run the prepared query again on server 2 and client 2
-            cur2.execute(prepared_query)
-
-            # Confirm that the prepared query is not available anymore on
-            # client 1
-            with bouncer.log_contains("prepared statement did not exist"):
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match="prepared statement did not exist|server closed the connection unexpectedly",
-                ):
-                    cur1.execute(prepared_query)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):
@@ -223,17 +223,16 @@ def test_evict_statement_cache(bouncer):
 def test_evict_statement_cache_pipeline_failure(bouncer):
     bouncer.admin(f"set max_prepared_statements=1")
 
-    with bouncer.conn() as conn:
-        with conn.pipeline() as p:
-            curs = [conn.cursor() for _ in range(4)]
-            curs[0].execute("SELECT 1", prepare=True)
-            curs[1].execute("bad query", prepare=True)
-            with pytest.raises(psycopg.errors.SyntaxError):
-                p.sync()
-            assert curs[0].fetchall() == [(1,)]
-            curs[0].execute("SELECT 1", prepare=True)
+    with bouncer.conn() as conn, conn.pipeline() as p:
+        curs = [conn.cursor() for _ in range(4)]
+        curs[0].execute("SELECT 1", prepare=True)
+        curs[1].execute("bad query", prepare=True)
+        with pytest.raises(psycopg.errors.SyntaxError):
             p.sync()
-            assert curs[0].fetchall() == [(1,)]
+        assert curs[0].fetchall() == [(1,)]
+        curs[0].execute("SELECT 1", prepare=True)
+        p.sync()
+        assert curs[0].fetchall() == [(1,)]
 
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
@@ -245,30 +244,28 @@ def test_prepared_statement_pipeline(bouncer):
         assert result == 1
 
     # Try with a prepared query first and a unprepared query second
-    with bouncer.conn() as conn:
-        with conn.pipeline():
-            curs = [conn.cursor() for _ in range(4)]
-            curs[0].execute("SELECT 2", prepare=True)
-            curs[1].execute(prepared_query, prepare=True)
-            curs[2].execute("SELECT 3")
-            curs[3].execute(prepared_query, prepare=True)
-            assert curs[0].fetchall() == [(2,)]
-            assert curs[1].fetchall() == [(1,)]
-            assert curs[2].fetchall() == [(3,)]
-            assert curs[3].fetchall() == [(1,)]
+    with bouncer.conn() as conn, conn.pipeline():
+        curs = [conn.cursor() for _ in range(4)]
+        curs[0].execute("SELECT 2", prepare=True)
+        curs[1].execute(prepared_query, prepare=True)
+        curs[2].execute("SELECT 3")
+        curs[3].execute(prepared_query, prepare=True)
+        assert curs[0].fetchall() == [(2,)]
+        assert curs[1].fetchall() == [(1,)]
+        assert curs[2].fetchall() == [(3,)]
+        assert curs[3].fetchall() == [(1,)]
 
     # Try with a unprepared query first and a prepared query second
-    with bouncer.conn() as conn:
-        with conn.pipeline(), conn.cursor() as cur:
-            curs = [conn.cursor() for _ in range(4)]
-            curs[0].execute("SELECT 2", prepare=True)
-            curs[1].execute(prepared_query, prepare=True)
-            curs[2].execute("SELECT 3")
-            curs[3].execute(prepared_query, prepare=True)
-            assert curs[0].fetchall() == [(2,)]
-            assert curs[1].fetchall() == [(1,)]
-            assert curs[2].fetchall() == [(3,)]
-            assert curs[3].fetchall() == [(1,)]
+    with bouncer.conn() as conn, conn.pipeline(), conn.cursor() as cur:
+        curs = [conn.cursor() for _ in range(4)]
+        curs[0].execute("SELECT 2", prepare=True)
+        curs[1].execute(prepared_query, prepare=True)
+        curs[2].execute("SELECT 3")
+        curs[3].execute(prepared_query, prepare=True)
+        assert curs[0].fetchall() == [(2,)]
+        assert curs[1].fetchall() == [(1,)]
+        assert curs[2].fetchall() == [(3,)]
+        assert curs[3].fetchall() == [(1,)]
 
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
@@ -283,21 +280,20 @@ def test_prepared_statement_pipeline_stress(bouncer):
 
     for pipeline_length in range(max_pipeline_length):
         # Try with a prepared query first and a unprepared query second
-        with bouncer.conn() as conn:
-            with conn.pipeline():
-                curs = [conn.cursor() for _ in range(pipeline_length)]
-                for _ in range(n_iterations):
-                    for i in range(pipeline_length):
-                        stmt_id = random.randint(1, max_prepared_stmt)
-                        curs[i].execute(
-                            sql.SQL("SELECT %s, %s::text as {}").format(
-                                sql.Identifier(f"s{stmt_id}")
-                            ),
-                            params=(i, str(i).zfill(size_of_param)),
-                            prepare=True,
-                        )
-                    for i in range(pipeline_length):
-                        assert curs[i].fetchall() == [(i, str(i).zfill(size_of_param))]
+        with bouncer.conn() as conn, conn.pipeline():
+            curs = [conn.cursor() for _ in range(pipeline_length)]
+            for _ in range(n_iterations):
+                for i in range(pipeline_length):
+                    stmt_id = random.randint(1, max_prepared_stmt)
+                    curs[i].execute(
+                        sql.SQL("SELECT %s, %s::text as {}").format(
+                            sql.Identifier(f"s{stmt_id}")
+                        ),
+                        params=(i, str(i).zfill(size_of_param)),
+                        prepare=True,
+                    )
+                for i in range(pipeline_length):
+                    assert curs[i].fetchall() == [(i, str(i).zfill(size_of_param))]
 
 
 def test_describe_non_existent_prepared_statement(bouncer):
@@ -361,15 +357,14 @@ def test_prepared_statement_pipeline_error(bouncer):
         assert result == 1
 
     # Make sure queue is cleared after error
-    with bouncer.conn() as conn:
-        with conn.pipeline() as p, conn.cursor() as cur:
-            cur.execute("SELECT aaaa")
-            with pytest.raises(
-                psycopg.errors.UndefinedColumn, match='column "aaaa" does not exist'
-            ):
-                p.sync()
-            cur.execute(prepared_query, prepare=True)
-            assert cur.fetchall() == [(1,)]
+    with bouncer.conn() as conn, conn.pipeline() as p, conn.cursor() as cur:
+        cur.execute("SELECT aaaa")
+        with pytest.raises(
+            psycopg.errors.UndefinedColumn, match='column "aaaa" does not exist'
+        ):
+            p.sync()
+        cur.execute(prepared_query, prepare=True)
+        assert cur.fetchall() == [(1,)]
 
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
@@ -383,23 +378,22 @@ def test_prepared_statement_pipeline_error_delayed_sync(bouncer):
     # Make sure queue is fully cleared until Sync on error, even future
     # messages that have not yet been received by PgBouncer (including the Sync
     # itself)
-    with bouncer.conn() as conn:
-        with conn.pipeline() as p, conn.cursor() as cur:
-            cur.execute("SELECT aaaa")
-            time.sleep(0.1)
+    with bouncer.conn() as conn, conn.pipeline() as p, conn.cursor() as cur:
+        cur.execute("SELECT aaaa")
+        time.sleep(0.1)
 
-            with pytest.raises(
-                psycopg.errors.UndefinedColumn, match='column "aaaa" does not exist'
-            ):
-                cur.execute("SELECT 123")
+        with pytest.raises(
+            psycopg.errors.UndefinedColumn, match='column "aaaa" does not exist'
+        ):
+            cur.execute("SELECT 123")
 
-            with pytest.raises(psycopg.errors.PipelineAborted):
-                cur.fetchall()
+        with pytest.raises(psycopg.errors.PipelineAborted):
+            cur.fetchall()
 
-            p.sync()
+        p.sync()
 
-            cur.execute(prepared_query, prepare=True)
-            assert cur.fetchall() == [(1,)]
+        cur.execute(prepared_query, prepare=True)
+        assert cur.fetchall() == [(1,)]
 
 
 def test_prepared_failed_prepare(bouncer):
@@ -413,26 +407,25 @@ def test_prepared_failed_prepare(bouncer):
 
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_failed_prepare_pipeline(bouncer):
-    with bouncer.conn() as conn:
-        with conn.pipeline() as p, conn.cursor() as cur:
-            cur.execute("SELECT 1", prepare=True)
-            cur.execute("SELECT * FROM doesnotexistyet", prepare=True)
-            with pytest.raises(psycopg.errors.UndefinedTable):
-                # Either of these two commands might fail due to timing
-                # differences, usually it's the sync. If the execute fails we
-                # still want it to sync though.
-                try:
-                    cur.execute("SELECT 2", prepare=True)
-                finally:
-                    p.sync()
-            cur.execute("SELECT 1", prepare=True)
-            p.sync()
-            cur.execute("SELECT 2", prepare=True)
-            p.sync()
-            cur.execute("CREATE TABLE doesnotexistyet (a int)")
-            cur.execute("SELECT * FROM doesnotexistyet", prepare=True)
-            p.sync()
-            cur.execute("DROP TABLE doesnotexistyet")
+    with bouncer.conn() as conn, conn.pipeline() as p, conn.cursor() as cur:
+        cur.execute("SELECT 1", prepare=True)
+        cur.execute("SELECT * FROM doesnotexistyet", prepare=True)
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            # Either of these two commands might fail due to timing
+            # differences, usually it's the sync. If the execute fails we
+            # still want it to sync though.
+            try:
+                cur.execute("SELECT 2", prepare=True)
+            finally:
+                p.sync()
+        cur.execute("SELECT 1", prepare=True)
+        p.sync()
+        cur.execute("SELECT 2", prepare=True)
+        p.sync()
+        cur.execute("CREATE TABLE doesnotexistyet (a int)")
+        cur.execute("SELECT * FROM doesnotexistyet", prepare=True)
+        p.sync()
+        cur.execute("DROP TABLE doesnotexistyet")
 
 
 def test_prepared_disallow_name_reuse(bouncer):
@@ -559,27 +552,25 @@ def test_pause_before_last_sync(bouncer):
 @pytest.mark.skipif("not USE_SUDO")
 @pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
 def test_prepared_statement_pipeline_latency(bouncer, pg):
-    with bouncer.conn() as conn1:
-        with conn1.pipeline() as p1:
-            with pg.add_latency():
-                start = time.time()
-                num_queries = 7
-                curs = [conn1.cursor() for _ in range(num_queries)]
-                for i in range(num_queries):
-                    curs[i].execute(f"SELECT '{i}'", prepare=True)
-                p1.sync()
+    with bouncer.conn() as conn1, conn1.pipeline() as p1, pg.add_latency():
+        start = time.time()
+        num_queries = 7
+        curs = [conn1.cursor() for _ in range(num_queries)]
+        for i in range(num_queries):
+            curs[i].execute(f"SELECT '{i}'", prepare=True)
+        p1.sync()
 
-                # Each query takes at least 1 second due to the latency
-                # introduced by the add_latency contextmanager. But because of
-                # pipelining the latency the whole series of queries should be
-                # a lot less.
-                end = time.time()
-                duration = end - start
-                assert duration < num_queries
+        # Each query takes at least 1 second due to the latency
+        # introduced by the add_latency contextmanager. But because of
+        # pipelining the latency the whole series of queries should be
+        # a lot less.
+        end = time.time()
+        duration = end - start
+        assert duration < num_queries
 
-                # The results should be correct too
-                for i in range(num_queries):
-                    assert curs[i].fetchone()[0] == str(i)
+        # The results should be correct too
+        for i in range(num_queries):
+            assert curs[i].fetchone()[0] == str(i)
 
 
 def test_prepared_statement_counters(bouncer):
@@ -611,23 +602,22 @@ def test_prepared_statement_counters(bouncer):
     # Explicitly enable prepared statement support
     bouncer.admin(f"set max_prepared_statements=10")
     prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1:
-        with bouncer.cur() as cur2:
-            # prepare query on server 1 and client 1
-            cur1.execute(prepared_query, prepare=True)
-            # Run the prepared query twice on same server and client
+    with bouncer.cur() as cur1, bouncer.cur() as cur2:
+        # prepare query on server 1 and client 1
+        cur1.execute(prepared_query, prepare=True)
+        # Run the prepared query twice on same server and client
+        cur1.execute(prepared_query)
+        cur1.execute(prepared_query)
+        with cur2.connection.transaction():
+            # Claim server 1 with client 2
+            cur2.execute("SELECT 2")
+            # Client 1 now runs the prepared query, and it's automatically
+            # prepared on server 2
             cur1.execute(prepared_query)
-            cur1.execute(prepared_query)
-            with cur2.connection.transaction():
-                # Claim server 1 with client 2
-                cur2.execute("SELECT 2")
-                # Client 1 now runs the prepared query, and it's automatically
-                # prepared on server 2
-                cur1.execute(prepared_query)
-                # Client 2 now prepares the same query that was already
-                # prepared on server 1. And PgBouncer reuses that already
-                # prepared query for this different client.
-                cur2.execute(prepared_query, prepare=True)
+            # Client 2 now prepares the same query that was already
+            # prepared on server 1. And PgBouncer reuses that already
+            # prepared query for this different client.
+            cur2.execute(prepared_query, prepare=True)
 
     stats = bouncer.admin("SHOW STATS", row_factory=dict_row)
     p0_stats = next(s for s in stats if s["database"] == "p0")

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -128,12 +128,14 @@ def test_server_ssl_verify(pg, bouncer_tls, cert_dir):
         pg.restart()
     else:
         pg.reload()
-    with bouncer_tls.log_contains(r"certificate verify failed"):
-        with pytest.raises(
+    with (
+        bouncer_tls.log_contains(r"certificate verify failed"),
+        pytest.raises(
             psycopg.OperationalError,
             match="connection timeout expired",
-        ):
-            bouncer_tls.test(connect_timeout=4)
+        ),
+    ):
+        bouncer_tls.test(connect_timeout=4)
     bouncer_tls.admin(f"set server_tls_ca_file = '{root}'")
     bouncer_tls.test()
 

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -680,7 +680,7 @@ async def test_server_check_delay(pg, bouncer):
     bouncer.admin("set server_login_retry=3")
     bouncer.admin("set query_timeout=10")
     with pg.drop_traffic():
-        time.sleep(3)
+        await asyncio.sleep(3)
         query_task = bouncer.atest(connect_timeout=10)
 
         # We wait for 1 second to show that the query is blocked while traffic

--- a/test/test_timeouts.py
+++ b/test/test_timeouts.py
@@ -122,10 +122,12 @@ def test_user_idle_transaction_timeout_negative(bouncer):
     """
 
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with bouncer.transaction(dbname="postgres", user="puser1") as cur:
-            time.sleep(3)
-            cur.execute("select 1")
+    with (
+        bouncer.run_with_config(config),
+        bouncer.transaction(dbname="postgres", user="puser1") as cur,
+    ):
+        time.sleep(3)
+        cur.execute("select 1")
 
 
 def test_user_idle_transaction_timeout_override_global(bouncer):
@@ -148,15 +150,17 @@ def test_user_idle_transaction_timeout_override_global(bouncer):
     """
 
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with bouncer.transaction(dbname="postgres", user="puser1") as cur:
-            with bouncer.log_contains(r"idle transaction timeout"):
-                time.sleep(3)
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
-                ):
-                    cur.execute("select 1")
+    with (
+        bouncer.run_with_config(config),
+        bouncer.transaction(dbname="postgres", user="puser1") as cur,
+        bouncer.log_contains(r"idle transaction timeout"),
+    ):
+        time.sleep(3)
+        with pytest.raises(
+            psycopg.OperationalError,
+            match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
+        ):
+            cur.execute("select 1")
 
 
 def test_user_idle_transaction_timeout(bouncer):
@@ -178,15 +182,17 @@ def test_user_idle_transaction_timeout(bouncer):
     """
 
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with bouncer.transaction(dbname="postgres", user="puser1") as cur:
-            with bouncer.log_contains(r"idle transaction timeout"):
-                time.sleep(3)
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
-                ):
-                    cur.execute("select 1")
+    with (
+        bouncer.run_with_config(config),
+        bouncer.transaction(dbname="postgres", user="puser1") as cur,
+        bouncer.log_contains(r"idle transaction timeout"),
+    ):
+        time.sleep(3)
+        with pytest.raises(
+            psycopg.OperationalError,
+            match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
+        ):
+            cur.execute("select 1")
 
 
 def test_user_query_timeout_override_global(bouncer):
@@ -209,13 +215,15 @@ def test_user_query_timeout_override_global(bouncer):
     """
 
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with bouncer.log_contains(r"query timeout"):
-            with pytest.raises(
-                psycopg.OperationalError,
-                match=r"query timeout|server closed the connection unexpectedly",
-            ):
-                bouncer.sleep(5, user="puser1", dbname="postgres")
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(r"query timeout"),
+        pytest.raises(
+            psycopg.OperationalError,
+            match=r"query timeout|server closed the connection unexpectedly",
+        ),
+    ):
+        bouncer.sleep(5, user="puser1", dbname="postgres")
 
 
 def test_user_query_timeout_negative(bouncer):
@@ -260,24 +268,28 @@ def test_user_query_timeout(bouncer):
     """
 
     # while configured to be in statement pooling mode
-    with bouncer.run_with_config(config):
-        with bouncer.log_contains(r"query timeout"):
-            with pytest.raises(
-                psycopg.OperationalError,
-                match=r"query timeout|server closed the connection unexpectedly",
-            ):
-                bouncer.sleep(5, user="puser1", dbname="postgres")
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(r"query timeout"),
+        pytest.raises(
+            psycopg.OperationalError,
+            match=r"query timeout|server closed the connection unexpectedly",
+        ),
+    ):
+        bouncer.sleep(5, user="puser1", dbname="postgres")
 
 
 def test_query_timeout(bouncer):
     bouncer.admin(f"set query_timeout=1")
 
-    with bouncer.log_contains(r"query timeout"):
-        with pytest.raises(
+    with (
+        bouncer.log_contains(r"query timeout"),
+        pytest.raises(
             psycopg.OperationalError,
             match=r"query timeout|server closed the connection unexpectedly",
-        ):
-            bouncer.sleep(5)
+        ),
+    ):
+        bouncer.sleep(5)
 
 
 def test_user_level_idle_client_timeout_negative(bouncer):
@@ -410,17 +422,21 @@ def test_transaction_timeout_user_overide_global(bouncer):
         puser1 = pool_mode=transaction transaction_timeout=2
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.transaction(dbname="postgres", user="puser1") as cur:
-            time.sleep(1)
+    with (
+        bouncer.run_with_config(config),
+        bouncer.transaction(dbname="postgres", user="puser1") as cur,
+    ):
+        time.sleep(1)
+        cur.execute("")
+        with (
+            bouncer.log_contains(r"transaction timeout"),
+            pytest.raises(
+                psycopg.OperationalError,
+                match=r"transaction timeout|Software caused connection abort",
+            ),
+        ):
+            time.sleep(2)
             cur.execute("")
-            with bouncer.log_contains(r"transaction timeout"):
-                time.sleep(2)
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match=r"transaction timeout|Software caused connection abort",
-                ):
-                    cur.execute("")
 
 
 def test_transaction_timeout_user(bouncer):
@@ -453,17 +469,21 @@ def test_transaction_timeout_user(bouncer):
         puser1 = pool_mode=transaction transaction_timeout=2
     """
 
-    with bouncer.run_with_config(config):
-        with bouncer.transaction(dbname="postgres", user="puser1") as cur:
-            time.sleep(1)
+    with (
+        bouncer.run_with_config(config),
+        bouncer.transaction(dbname="postgres", user="puser1") as cur,
+    ):
+        time.sleep(1)
+        cur.execute("")
+        with (
+            bouncer.log_contains(r"transaction timeout"),
+            pytest.raises(
+                psycopg.OperationalError,
+                match=r"transaction timeout|Software caused connection abort",
+            ),
+        ):
+            time.sleep(2)
             cur.execute("")
-            with bouncer.log_contains(r"transaction timeout"):
-                time.sleep(2)
-                with pytest.raises(
-                    psycopg.OperationalError,
-                    match=r"transaction timeout|Software caused connection abort",
-                ):
-                    cur.execute("")
 
 
 def test_transaction_timeout(bouncer):
@@ -498,14 +518,16 @@ def test_idle_transaction_timeout(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     bouncer.admin(f"set idle_transaction_timeout=2")
 
-    with bouncer.transaction() as cur:
-        with bouncer.log_contains(r"idle transaction timeout"):
-            time.sleep(3)
-            with pytest.raises(
-                psycopg.OperationalError,
-                match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
-            ):
-                cur.execute("select 1")
+    with (
+        bouncer.transaction() as cur,
+        bouncer.log_contains(r"idle transaction timeout"),
+    ):
+        time.sleep(3)
+        with pytest.raises(
+            psycopg.OperationalError,
+            match=r"idle transaction timeout|Software caused connection abort|server closed the connection unexpectedly",
+        ):
+            cur.execute("select 1")
 
     # test for GH issue #125
     with bouncer.transaction() as cur:
@@ -611,19 +633,23 @@ def test_server_connect_timeout_establish(pg, bouncer):
     pg.reload()
     bouncer.admin("set query_timeout=3")
     bouncer.admin("set server_connect_timeout=2")
-    with bouncer.log_contains(r"closing because: connect timeout"):
-        with pytest.raises(psycopg.errors.OperationalError, match="query_timeout"):
-            bouncer.test(connect_timeout=10)
+    with (
+        bouncer.log_contains(r"closing because: connect timeout"),
+        pytest.raises(psycopg.errors.OperationalError, match="query_timeout"),
+    ):
+        bouncer.test(connect_timeout=10)
 
 
 @pytest.mark.skipif("not USE_SUDO")
 def test_server_connect_timeout_drop_traffic(pg, bouncer):
     bouncer.admin("set query_timeout=3")
     bouncer.admin("set server_connect_timeout=2")
-    with bouncer.log_contains(r"closing because: connect failed"):
-        with pg.drop_traffic():
-            with pytest.raises(psycopg.errors.OperationalError, match="query_timeout"):
-                bouncer.test(connect_timeout=10)
+    with (
+        bouncer.log_contains(r"closing because: connect failed"),
+        pg.drop_traffic(),
+        pytest.raises(psycopg.errors.OperationalError, match="query_timeout"),
+    ):
+        bouncer.test(connect_timeout=10)
 
 
 @pytest.mark.skipif("not USE_SUDO")
@@ -637,13 +663,15 @@ def test_tcp_user_timeout(pg, bouncer):
     bouncer.test()
     # without tcp_user_timeout, you get a different error message
     # about "query timeout" instead
-    with bouncer.log_contains(r"closing because: server conn crashed?"):
-        with pg.reject_traffic():
-            with pytest.raises(
-                psycopg.OperationalError,
-                match=r"query timeout|Software caused connection abort|server closed the connection unexpectedly",
-            ):
-                bouncer.test(connect_timeout=10)
+    with (
+        bouncer.log_contains(r"closing because: server conn crashed?"),
+        pg.reject_traffic(),
+        pytest.raises(
+            psycopg.OperationalError,
+            match=r"query timeout|Software caused connection abort|server closed the connection unexpectedly",
+        ),
+    ):
+        bouncer.test(connect_timeout=10)
 
 
 @pytest.mark.skipif("not USE_SUDO")
@@ -666,18 +694,19 @@ async def test_server_check_delay(pg, bouncer):
 @pytest.mark.skipif("not USE_SUDO")
 def test_cancel_wait_timeout(pg, bouncer):
     bouncer.admin("set cancel_wait_timeout=1")
-    with bouncer.cur() as cur:
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            query = pool.submit(cur.execute, "select pg_sleep(3)")
+    with bouncer.cur() as cur, ThreadPoolExecutor(max_workers=2) as pool:
+        query = pool.submit(cur.execute, "select pg_sleep(3)")
 
-            time.sleep(1)
+        time.sleep(1)
 
-            with pg.drop_traffic():
-                with bouncer.log_contains(r"closing because: cancel_wait_timeout"):
-                    cancel = pool.submit(cur.connection.cancel)
-                    cancel.result()
+        with (
+            pg.drop_traffic(),
+            bouncer.log_contains(r"closing because: cancel_wait_timeout"),
+        ):
+            cancel = pool.submit(cur.connection.cancel)
+            cancel.result()
 
-            query.result()
+        query.result()
 
 
 def test_query_timeout_when_no_active_query(bouncer):

--- a/test/utils.py
+++ b/test/utils.py
@@ -246,6 +246,10 @@ PORT_UPPER_BOUND = 32768
 next_port = PORT_LOWER_BOUND
 
 
+class UnsupportedPlatformError(Exception):
+    """Raised by a test helper that has no implementation for this OS."""
+
+
 def cleanup_test_leftovers(*nodes):
     """
     Cleaning up test leftovers needs to be done in a specific order, because
@@ -562,7 +566,7 @@ class QueryRunner:
                     f"| pfctl -a pgbouncer_test/port_{self.port} -f -'"
                 )
             else:
-                raise Exception("This OS cannot run this test")
+                raise UnsupportedPlatformError("This OS cannot run this test")
             try:
                 yield
             finally:
@@ -597,7 +601,7 @@ class QueryRunner:
                     f"| pfctl -a pgbouncer_test/port_{self.port} -f -'"
                 )
             else:
-                raise Exception("This OS cannot run this test")
+                raise UnsupportedPlatformError("This OS cannot run this test")
             try:
                 yield
             finally:
@@ -617,7 +621,7 @@ class QueryRunner:
     def add_latency(self):
         """Adds one second of latency to all packets to this query runner"""
         if not LINUX:
-            raise Exception("This OS cannot run this test")
+            raise UnsupportedPlatformError("This OS cannot run this test")
         sudo(
             f"tc filter add dev lo parent 1:0 protocol ip prio {self.port} u32 match ip dport {self.port} 0xffff flowid 1:2"
         )

--- a/test/utils.py
+++ b/test/utils.py
@@ -315,7 +315,7 @@ class QueryRunner:
         self.port = port
         self.default_db = "postgres"
         self.default_user = "postgres"
-        self.default_password: typing.Optional[str] = None
+        self.default_password: str | None = None
 
         # Used to track objects that we want to clean up at the end of a test
         self.subscriptions = set()
@@ -431,7 +431,7 @@ class QueryRunner:
 
     async def asql_coroutine(
         self, query, params=None, **kwargs
-    ) -> typing.Optional[list[typing.Any]]:
+    ) -> list[typing.Any] | None:
         async with self.acur(**kwargs) as cur:
             await cur.execute(query, params=params)
             if cur.pgresult and cur.pgresult.status in [
@@ -626,7 +626,7 @@ class QueryRunner:
         finally:
             sudo(f"tc filter del dev lo parent 1: prio {self.port}")
 
-    def create_user(self, name, args: typing.Optional[psycopg.sql.Composable] = None):
+    def create_user(self, name, args: psycopg.sql.Composable | None = None):
         self.users.add(name)
         if args is None:
             args = sql.SQL("")
@@ -745,7 +745,7 @@ class Proxy(QueryRunner):
         self.pg = pg
         self.cursors = {}
         self.restarted = False
-        self.process: typing.Optional[subprocess.Popen] = None
+        self.process: subprocess.Popen | None = None
 
     def start(self):
         command = [
@@ -990,8 +990,8 @@ class Bouncer(QueryRunner):
             self.port_lock = PortLock()
             super().__init__("127.0.0.1", self.port_lock.port)
 
-        self.process: typing.Optional[subprocess.Popen] = None
-        self.aprocess: typing.Optional[asyncio.subprocess.Process] = None
+        self.process: subprocess.Popen | None = None
+        self.aprocess: asyncio.subprocess.Process | None = None
         config_dir.mkdir()
         self.config_dir = config_dir
         self.ini_path = self.config_dir / "test.ini"

--- a/test/utils.py
+++ b/test/utils.py
@@ -623,7 +623,6 @@ class QueryRunner:
             yield
         finally:
             sudo(f"tc filter del dev lo parent 1: prio {self.port}")
-            pass
 
     def create_user(self, name, args: typing.Optional[psycopg.sql.Composable] = None):
         self.users.add(name)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1077,7 +1077,7 @@ class Bouncer(QueryRunner):
         # use asyncio subprocesses, since that eventloop does not support them.
         # We fall back to regular subprocesses.
         if WINDOWS:
-            self.process = subprocess.Popen(
+            self.process = subprocess.Popen(  # noqa: ASYNC220
                 [*self.base_command(), "--quiet", self.ini_path], close_fds=True
             )
         else:
@@ -1168,9 +1168,11 @@ class Bouncer(QueryRunner):
             await self.wait_until_running()
             assert self.aprocess.pid != old_pid
         if self.process:
+            # A regular subprocess, so Windows: see the comment in start() for
+            # why asyncio subprocesses cannot be used there.
             old_process = self.process
             old_pid = old_process.pid
-            self.process = subprocess.Popen(
+            self.process = subprocess.Popen(  # noqa: ASYNC220
                 [*self.base_command(), "--reboot", "--quiet", self.ini_path],
                 close_fds=True,
             )

--- a/test/utils.py
+++ b/test/utils.py
@@ -373,12 +373,14 @@ class QueryRunner:
         The connection and the cursors automatically close once you leave the
         "with" block
         """
-        with self.conn(
-            autocommit=autocommit,
-            **kwargs,
-        ) as conn:
-            with conn.cursor() as cur:
-                yield cur
+        with (
+            self.conn(
+                autocommit=autocommit,
+                **kwargs,
+            ) as conn,
+            conn.cursor() as cur,
+        ):
+            yield cur
 
     @asynccontextmanager
     async def acur(self, **kwargs):
@@ -387,9 +389,8 @@ class QueryRunner:
         The connection and the cursors automatically close once you leave the
         "async with" block
         """
-        async with await self.aconn(**kwargs) as conn:
-            async with conn.cursor() as cur:
-                yield cur
+        async with await self.aconn(**kwargs) as conn, conn.cursor() as cur:
+            yield cur
 
     def sql(self, query, params=None, **kwargs):
         """Run an SQL query
@@ -464,9 +465,8 @@ class QueryRunner:
 
     @contextmanager
     def transaction(self, **kwargs):
-        with self.cur(**kwargs) as cur:
-            with cur.connection.transaction():
-                yield cur
+        with self.cur(**kwargs) as cur, cur.connection.transaction():
+            yield cur
 
     def sleep(self, duration=3, **kwargs):
         """Run pg_sleep"""
@@ -1020,30 +1020,28 @@ class Bouncer(QueryRunner):
         self.admin_runner.default_user = "pgbouncer"
         self.admin_runner.default_password = "fake"
 
-        with open(base_auth_path) as base_auth:
-            with self.auth_path.open("w") as auth:
-                auth.write(base_auth.read())
-                auth.write(f'"longpass" "{LONG_PASSWORD}"\n')
-                auth.flush()
+        with open(base_auth_path) as base_auth, self.auth_path.open("w") as auth:
+            auth.write(base_auth.read())
+            auth.write(f'"longpass" "{LONG_PASSWORD}"\n')
+            auth.flush()
 
-        with open(base_ini_path) as base_ini:
-            with self.ini_path.open("w") as ini:
-                ini.write(base_ini.read().replace("port=6666", f"port={pg.port}"))
-                ini.write("\n")
-                ini.write(f"logfile = {self.log_path}\n")
-                ini.write(f"auth_file = {self.auth_path}\n")
-                ini.write("pidfile = \n")
-                # Uncomment for much more noise but, more detailed debugging
-                # ini.write("verbose = 3\n")
+        with open(base_ini_path) as base_ini, self.ini_path.open("w") as ini:
+            ini.write(base_ini.read().replace("port=6666", f"port={pg.port}"))
+            ini.write("\n")
+            ini.write(f"logfile = {self.log_path}\n")
+            ini.write(f"auth_file = {self.auth_path}\n")
+            ini.write("pidfile = \n")
+            # Uncomment for much more noise but, more detailed debugging
+            # ini.write("verbose = 3\n")
 
-                if not USE_UNIX_SOCKETS:
-                    ini.write(f"unix_socket_dir = \n")
-                    ini.write(f"admin_users = pgbouncer\n")
-                else:
-                    ini.write(f"unix_socket_dir = {self.admin_host}\n")
-                ini.write(f"listen_port = {self.port}\n")
+            if not USE_UNIX_SOCKETS:
+                ini.write(f"unix_socket_dir = \n")
+                ini.write(f"admin_users = pgbouncer\n")
+            else:
+                ini.write(f"unix_socket_dir = {self.admin_host}\n")
+            ini.write(f"listen_port = {self.port}\n")
 
-                ini.flush()
+            ini.flush()
 
         with self.ini_path.open("r") as ini:
             self.original_ini_contents = ini.read()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from contextlib import closing, contextmanager
 from pathlib import Path

--- a/test/utils.py
+++ b/test/utils.py
@@ -428,7 +428,7 @@ class QueryRunner:
 
     async def asql_coroutine(
         self, query, params=None, **kwargs
-    ) -> typing.Optional[typing.List[typing.Any]]:
+    ) -> typing.Optional[list[typing.Any]]:
         async with self.acur(**kwargs) as cur:
             await cur.execute(query, params=params)
             if cur.pgresult and cur.pgresult.status in [

--- a/test/utils.py
+++ b/test/utils.py
@@ -292,7 +292,7 @@ class PortLock:
                     s.bind(("127.0.0.1", next_port))
                     self.port = next_port
                     break
-                except Exception:
+                except OSError:
                     continue
 
     def release(self):
@@ -1215,7 +1215,7 @@ class Bouncer(QueryRunner):
             with self.log_path.open() as f:
                 log_contents = f.read()
                 print(log_contents)
-        except Exception:
+        except (OSError, UnicodeDecodeError):
             pass
 
         # Most reliable way to detect Assert failures. Otherwise we might miss

--- a/test/utils.py
+++ b/test/utils.py
@@ -1090,7 +1090,7 @@ class Bouncer(QueryRunner):
                     self.print_logs()
                     raise
                 tries += 1
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
                 continue
             break
 


### PR DESCRIPTION
Fix issues reported by `make lint`.

```
$ make lint
.
.
.
Found 144 errors.
[*] 43 fixable with the `--fix` option (27 hidden fixes can be enabled with the `--unsafe-fixes` option).
make: *** [Makefile:210: lint] Error 1
```

and after

```
$ make lint
dev/format.sh lint
All checks passed!
```