### PR TITLE
Free startup protocol extension buffer

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1037,7 +1037,7 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			username = val;
 		} else if (strcmp(key, "options") == 0) {
 			if (!set_startup_options(client, val))
-				return false;
+				goto fail;
 		} else if (strcmp(key, "application_name") == 0) {
 			set_appname(client, val);
 			appname_found = true;
@@ -1047,7 +1047,7 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 			slog_debug(client, "ignoring protocol extension parameter: %s=%s", key, val);
 			unsupported_protocol_extensions_count++;
 			if (!mbuf_write(&unsupported_protocol_extensions, key, strlen(key) + 1))
-				return false;
+				goto fail;
 		} else if (varcache_set(&client->vars, key, val)) {
 			slog_debug(client, "got var: %s=%s", key, val);
 		} else if (strlist_contains(cf_ignore_startup_params, key)) {
@@ -1055,19 +1055,19 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 		} else {
 			slog_warning(client, "unsupported startup parameter: %s=%s", key, val);
 			disconnect_client(client, true, "unsupported startup parameter: %s", key);
-			return false;
+			goto fail;
 		}
 	}
 
 	/* ran out of bytes before seeing a terminator, or got a double \0 before the end */
 	if (!ok || mbuf_avail_for_read(&pkt->data) != 0) {
 		disconnect_client(client, true, "invalid startup packet layout: expected terminator as last byte");
-		return false;
+		goto fail;
 	}
 
 	if (!username || !username[0]) {
 		disconnect_client(client, true, "no username supplied");
-		return false;
+		goto fail;
 	}
 
 	/* if missing dbname, default to username */
@@ -1084,7 +1084,7 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 	if (get_active_client_count() > cf_max_client_conn) {
 		if (strcmp(dbname, "pgbouncer") != 0) {
 			disconnect_client(client, true, "no more connections allowed (max_client_conn)");
-			return false;
+			goto fail;
 		}
 	}
 
@@ -1104,12 +1104,16 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 		pktbuf_free(buf);
 		if (!res) {
 			disconnect_client(client, false, "unable to send protocol negotiation packet");
-			return false;
+			goto fail;
 		}
 	}
 
 	/* find pool */
+	mbuf_free(&unsupported_protocol_extensions);
 	return set_pool(client, dbname, username, NULL, false);
+fail:
+	mbuf_free(&unsupported_protocol_extensions);
+	return false;
 }
 
 static bool scram_client_first(PgSocket *client, uint32_t datalen, const uint8_t *data)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,5 +1,7 @@
 import asyncio
 import re
+import socket
+import struct
 import threading
 import time
 
@@ -531,6 +533,62 @@ async def test_host_list(bouncer):
 async def test_host_list_dummy(bouncer):
     with bouncer.log_contains(r"new connection to server \(from 127.0.0.1", times=2):
         await bouncer.asleep(1, dbname="hostlist2", times=2)
+
+
+def _send_startup_message(bouncer, parameters):
+    payload = struct.pack("!I", 0x30000) + parameters
+
+    with socket.create_connection((bouncer.host, bouncer.port)) as sock:
+        sock.sendall(struct.pack("!I", len(payload) + 4) + payload)
+        with sock.makefile("rb") as stream:
+            message_type = stream.read(1)
+            message_length = struct.unpack("!I", stream.read(4))[0]
+            return message_type, stream.read(message_length - 4)
+
+
+def test_protocol_extension_negotiation(bouncer):
+    protocol_version = 0x30000
+    extension = b"_pq_.test_protocol_negotiation"
+    parameters = (
+        b"\0".join(
+            (
+                b"user",
+                b"puser1",
+                b"database",
+                b"p0",
+                extension,
+                b"",
+                b"",
+            )
+        )
+        + b"\0"
+    )
+    message_type, message = _send_startup_message(bouncer, parameters)
+
+    assert message_type == b"v"
+    negotiated_version, extension_count = struct.unpack("!II", message[:8])
+    assert negotiated_version == protocol_version
+    assert extension_count == 1
+    assert message[8:] == extension + b"\0"
+
+    parameters = (
+        b"\0".join(
+            (
+                b"user",
+                b"puser1",
+                extension,
+                b"",
+                b"unsupported",
+                b"value",
+                b"",
+            )
+        )
+        + b"\0"
+    )
+    message_type, message = _send_startup_message(bouncer, parameters)
+
+    assert message_type == b"E"
+    assert b"unsupported startup parameter: unsupported\0" in message
 
 
 def test_options_startup_param(bouncer):


### PR DESCRIPTION
`decide_startup_pool()` never freed its protocol-extension buffer. Because this happens before authentication, a client can leak one allocation for each StartupMessage containing an `_pq_.`
parameter.

59ce4e7a6fbb1407affe36aded40572a4f8fd4a6 demonstrates that.

```console
$ ENABLE_VALGRIND=yes pytest -q test/test_misc.py::test_protocol_extension_negotiation
...
==3847055== VALGRIND-ERROR-BEGIN
==3847055== 256 bytes in 2 blocks are definitely lost in loss record 241 of 302
==3847055==    at 0x488C2D8: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==3847055==    by 0x17167B: mbuf_make_room (mbuf.c:29)
==3847055==    by 0x11D2D3: mbuf_write (mbuf.h:267)
==3847055==    by 0x120583: decide_startup_pool (client.c:1049)
==3847055==    by 0x121427: handle_client_startup (client.c:1318)
==3847055==    by 0x12275B: client_proto (client.c:1820)
==3847055==    by 0x14C917: sbuf_call_proto (sbuf.c:507)
==3847055==    by 0x14D2BF: sbuf_process_pending (sbuf.c:811)
==3847055==    by 0x14DA9B: sbuf_main_loop (sbuf.c:1040)
==3847055==    by 0x14D887: sbuf_recv_cb (sbuf.c:950)
==3847055==    by 0x49412B7: ??? (in /usr/lib/aarch64-linux-gnu/libevent-2.1.so.7.0.1)
==3847055==    by 0x4942EBF: event_base_loop (in /usr/lib/aarch64-linux-gnu/libevent-2.1.so.7.0.1)
==3847055==
==3847055== VALGRIND-ERROR-END
```

[Free the buffer](https://github.com/pgbouncer/pgbouncer/pull/1540/changes/368703513ebbdc3284c6a9f3e65ad30ce7acb3ef) on every exit. Test both negotiation and failure after allocation. Valgrind detects the leak.

After:

```console
ENABLE_VALGRIND=yes pytest -q test/test_misc.py::test_protocol_extension_negotiation

.                                                                                                           [100%]
1 passed in 2.85s
```

Fixes #1519
