### PR TITLE
Keep prepared statements registered after a pipelined reset

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -673,6 +673,20 @@ typedef struct OutstandingRequest {
 	PgServerPreparedStatement *server_ps;
 
 	uint64_t server_ps_query_id;
+
+	/*
+	 * Value of the client its prepared_statement_seq counter when this
+	 * request was queued. A reset only invalidates client statements that
+	 * were registered at or before this point; anything the client
+	 * registered later in the same pipeline still exists on the server.
+	 */
+	uint64_t client_ps_seq;
+
+	/*
+	 * Same idea for the server its statement cache: what the server had
+	 * prepared when this request was queued.
+	 */
+	uint64_t server_ps_seq;
 } OutstandingRequest;
 
 enum ReplicationType {
@@ -796,6 +810,8 @@ struct PgSocket {
 	PgClientPreparedStatement *client_prepared_statements;
 	/* server: prepared statements prepared on this server */
 	PgServerPreparedStatement *server_prepared_statements;
+	/* client and server: order in which statements were registered here */
+	uint64_t prepared_statement_seq;
 
 	/* cb state during SBUF_EV_PKT_CALLBACK processing */
 	struct CallbackState {

--- a/include/prepare.h
+++ b/include/prepare.h
@@ -21,6 +21,13 @@ typedef struct PgPreparedStatement {
 typedef struct PgClientPreparedStatement {
 	UT_hash_handle hh;
 	PgPreparedStatement *ps;
+	/*
+	 * Order in which the client registered this statement, taken from the
+	 * client its prepared_statement_seq counter. A DEALLOCATE ALL or
+	 * DISCARD ALL only invalidates statements that the client registered
+	 * before it sent the reset, so the reset compares against this.
+	 */
+	uint64_t seq;
 	char stmt_name[];	/* varying size */
 } PgClientPreparedStatement;
 
@@ -29,6 +36,12 @@ typedef struct PgServerPreparedStatement {
 	uint64_t query_id;
 	UT_hash_handle hh;
 	PgPreparedStatement *ps;
+	/*
+	 * Order in which this statement was prepared on the server, taken from
+	 * the server its prepared_statement_seq counter. A reset only removes
+	 * what the server had prepared before it ran the reset.
+	 */
+	uint64_t seq;
 } PgServerPreparedStatement;
 
 #define is_prepared_statements_enabled(client_or_server) \
@@ -44,4 +57,6 @@ void free_server_prepared_statement(PgServerPreparedStatement *server_ps);
 void unregister_prepared_statement(PgSocket *server, uint64_t query_id);
 bool add_prepared_statement(PgSocket *server, PgServerPreparedStatement *server_ps) _MUSTCHECK;
 void free_client_prepared_statements(PgSocket *client);
+void free_client_prepared_statements_upto(PgSocket *client, uint64_t seq);
 void free_server_prepared_statements(PgSocket *server);
+void free_server_prepared_statements_upto(PgSocket *server, uint64_t seq);

--- a/src/objects.c
+++ b/src/objects.c
@@ -1078,6 +1078,8 @@ bool add_outstanding_request(PgSocket *client, char type, ResponseAction action)
 		return false;
 	request->type = type;
 	request->action = action;
+	request->client_ps_seq = client->prepared_statement_seq;
+	request->server_ps_seq = server->prepared_statement_seq;
 	statlist_append(&server->outstanding_requests, &request->node);
 	slog_noise(client, "add_outstanding_request: added %c, still outstanding %d",
 		   type, statlist_count(&client->link->outstanding_requests));

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -210,6 +210,7 @@ void unregister_prepared_statement(PgSocket *server, uint64_t query_id)
  */
 bool add_prepared_statement(PgSocket *server, PgServerPreparedStatement *server_ps)
 {
+	server_ps->seq = ++server->prepared_statement_seq;
 	HASH_ADD_UINT64(server->server_prepared_statements, query_id, server_ps);
 	if (uthash_alloc_failed) {
 		uthash_alloc_failed = false;
@@ -341,6 +342,7 @@ bool handle_parse_command(PgSocket *client, PktHdr *pkt)
 	client_ps = create_client_prepared_statement(pp.name, ps);
 	if (client_ps == NULL)
 		goto oom;
+	client_ps->seq = ++client->prepared_statement_seq;
 	HASH_ADD_STR(client->client_prepared_statements, stmt_name, client_ps);
 	if (uthash_alloc_failed) {
 		uthash_alloc_failed = false;
@@ -693,6 +695,32 @@ bool handle_close_statement_command(PgSocket *client, PktHdr *pkt, PgClosePacket
 }
 
 /*
+ * Frees the prepared statements that the client registered at or before the
+ * given sequence number, leaving any it registered later in place.
+ *
+ * A DEALLOCATE ALL or DISCARD ALL is cleaned up when the server reports its
+ * CommandComplete, but pipelined input means the client can already have sent
+ * a Parse for a new statement by then. That statement really does exist on the
+ * server, so dropping its mapping would make PgBouncer reject a statement the
+ * client just prepared successfully.
+ */
+void free_client_prepared_statements_upto(PgSocket *client, uint64_t seq)
+{
+	PgClientPreparedStatement *client_ps, *tmp;
+
+	HASH_ITER(hh, client->client_prepared_statements, client_ps, tmp) {
+		if (client_ps->seq > seq)
+			continue;
+		HASH_DEL(client->client_prepared_statements, client_ps);
+		if (--client_ps->ps->use_count == 0) {
+			HASH_DEL(prepared_statements, client_ps->ps);
+			free(client_ps->ps);
+		}
+		free(client_ps);
+	}
+}
+
+/*
  * Frees all the prepared statements that are cached on the client.
  */
 void free_client_prepared_statements(PgSocket *client)
@@ -710,6 +738,23 @@ void free_client_prepared_statements(PgSocket *client)
 
 	free(client->client_prepared_statements);
 	client->client_prepared_statements = NULL;
+}
+
+/*
+ * Frees the statements prepared on the server at or before the given sequence
+ * number. A reset the server has just run only removes what it had prepared
+ * beforehand; anything Parsed later in the same pipeline still exists there.
+ */
+void free_server_prepared_statements_upto(PgSocket *server, uint64_t seq)
+{
+	struct PgServerPreparedStatement *current, *tmp_s;
+
+	HASH_ITER(hh, server->server_prepared_statements, current, tmp_s) {
+		if (current->seq > seq)
+			continue;
+		HASH_DEL(server->server_prepared_statements, current);
+		free_server_prepared_statement(current);
+	}
 }
 
 /*

--- a/src/server.c
+++ b/src/server.c
@@ -510,22 +510,31 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (mbuf_get_string(&pkt->data, &tag)) {
 				if (strcmp(tag, "DEALLOCATE ALL") == 0 ||
 				    strcmp(tag, "DISCARD ALL") == 0) {
-					struct List *reset_item = statlist_first(&server->outstanding_requests);
-					OutstandingRequest *reset_req = reset_item
-						? container_of(reset_item, OutstandingRequest, node) : NULL;
-					free_server_prepared_statements_upto(server,
-									    reset_req ? reset_req->server_ps_seq
-									    : server->prepared_statement_seq);
+					/*
+					 * Only what was prepared before the client sent the reset
+					 * is gone. Pipelined input means a Parse can already have
+					 * arrived since then, and the server ran it after the
+					 * reset, so those statements still exist and keep their
+					 * mappings. The request at the head of the queue is the
+					 * reset its own, and it carries the counters as they were
+					 * when the reset was queued.
+					 */
+					struct List *item = statlist_first(&server->outstanding_requests);
+					OutstandingRequest *reset_req = NULL;
+					uint64_t server_seq = server->prepared_statement_seq;
+
+					if (item) {
+						reset_req = container_of(item, OutstandingRequest, node);
+						server_seq = reset_req->server_ps_seq;
+					}
+					free_server_prepared_statements_upto(server, server_seq);
+
 					if (client) {
-						/*
-						 * Only the statements the client had registered when
-						 * it sent the reset are gone. Pipelined input means it
-						 * can already have prepared more since then, and those
-						 * do exist on the server, so their mappings stay.
-						 */
-						free_client_prepared_statements_upto(client,
-										     reset_req ? reset_req->client_ps_seq
-										     : client->prepared_statement_seq);
+						uint64_t client_seq = reset_req
+								      ? reset_req->client_ps_seq
+								      : client->prepared_statement_seq;
+
+						free_client_prepared_statements_upto(client, client_seq);
 					}
 				}
 			} else {

--- a/src/server.c
+++ b/src/server.c
@@ -510,9 +510,23 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (mbuf_get_string(&pkt->data, &tag)) {
 				if (strcmp(tag, "DEALLOCATE ALL") == 0 ||
 				    strcmp(tag, "DISCARD ALL") == 0) {
-					free_server_prepared_statements(server);
-					if (client)
-						free_client_prepared_statements(client);
+					struct List *reset_item = statlist_first(&server->outstanding_requests);
+					OutstandingRequest *reset_req = reset_item
+						? container_of(reset_item, OutstandingRequest, node) : NULL;
+					free_server_prepared_statements_upto(server,
+									    reset_req ? reset_req->server_ps_seq
+									    : server->prepared_statement_seq);
+					if (client) {
+						/*
+						 * Only the statements the client had registered when
+						 * it sent the reset are gone. Pipelined input means it
+						 * can already have prepared more since then, and those
+						 * do exist on the server, so their mappings stay.
+						 */
+						free_client_prepared_statements_upto(client,
+										     reset_req ? reset_req->client_ps_seq
+										     : client->prepared_statement_seq);
+					}
 				}
 			} else {
 				return false;

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -79,6 +79,28 @@ def test_deallocate_all(bouncer):
             cur1.execute(prepared_query)
 
 
+@pytest.mark.skipif("not LIBPQ_SUPPORTS_PIPELINING")
+@pytest.mark.parametrize("reset_query", ["DEALLOCATE ALL", "DISCARD ALL"])
+def test_reset_all_does_not_remove_later_prepared_statement(bouncer, reset_query):
+    bouncer.admin("set pool_mode=transaction")
+    prepared_query = "SELECT 1"
+    with bouncer.conn() as conn, conn.pipeline() as pipeline:
+        reset = conn.cursor()
+        cur = conn.cursor()
+
+        # The Parse for the prepared query reaches PgBouncer before the
+        # CommandComplete for the reset comes back from the server, so the
+        # cleanup must not drop the mapping registered after the reset.
+        reset.execute(reset_query)
+        cur.execute(prepared_query, prepare=True)
+        pipeline.sync()
+        assert cur.fetchall() == [(1,)]
+
+        cur.execute(prepared_query, prepare=True)
+        pipeline.sync()
+        assert cur.fetchall() == [(1,)]
+
+
 def test_discard_all(bouncer):
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT 1"


### PR DESCRIPTION
Fixes #1535.

## Problem

With `max_prepared_statements > 0` in transaction or statement pooling, PgBouncer registers a
client-visible prepared statement name eagerly, when it reads the `Parse` message
(`handle_parse_command()` in `src/prepare.c`). Cleanup for `DEALLOCATE ALL` and `DISCARD ALL`
happens late, when the backend's `CommandComplete` for the reset arrives (`src/server.c`), and it
cleared both statement caches wholesale.

Pipelined input can deliver the later `Parse` before that `CommandComplete` comes back. The
blanket cleanup then removed a mapping for a statement the server really had prepared, because the
server executes the reset first and the `Parse` afterwards. The client received a failure for a
statement it had just prepared successfully, and the connection was closed.

## Solution

Give both statement caches an ordering, and let the reset remove only what predates it.

- A per-socket `prepared_statement_seq` counter stamps each client and server statement as it is
  registered.
- `OutstandingRequest` records both counters when the request is queued.
- Handling the reset's `CommandComplete` frees only statements stamped at or before the values
  recorded on that request, via the new `free_client_prepared_statements_upto()` and
  `free_server_prepared_statements_upto()`.

Anything prepared later in the same pipeline keeps its mapping, which matches what actually exists
on the server.

Both caches needed this. Fixing only the client side moved the failure from a closed connection to
`prepared statement "PGBOUNCER_1" already exists`: the server cache had also been cleared, so
PgBouncer re-sent a `Parse` for a statement that was still present on the backend.

## Testing

`test_reset_all_does_not_remove_later_prepared_statement` is added to `test/test_prepared.py`,
parametrised over `DEALLOCATE ALL` and `DISCARD ALL`. It issues the reset and a named `Parse` in
one pipeline segment, then executes the statement. On master both parameters fail with
`psycopg.OperationalError: consuming input failed: server closed the connection unexpectedly`;
with this change both pass.

- `pytest test/test_prepared.py` — 27 passed, 1 skipped. This includes the existing
  `test_deallocate_all` and `test_discard_all`, which assert that a reset *does* invalidate
  statements prepared before it. Those still pass, so the reset keeps its intended effect.
- Wider run — 214 passed.
- `dev/format.sh check` and `dev/format.sh lint` — both clean.

I could not run `test/test_ssl.py` or `test/test_load_balance_hosts.py` locally: they fail on this
machine for want of TLS fixtures, and they fail identically on an unmodified checkout of `master`
(17 failed there versus 8 passed, the same set). Nothing in this change touches code those tests
reach, but I would rather say so than imply a clean full-suite run.

## AI assistance

Claude Code was used to reproduce the issue, write the change and the test, and run the
verification above. The complete diff was reviewed before submission.
