### PR TITLE
Handle fake database allocation failure

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -540,6 +540,11 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 	client->db = find_or_register_database(client, dbname);
 	if (!client->db) {
 		client->db = calloc(1, sizeof(*client->db));
+		if (!client->db) {
+			slog_error(client, "set_pool(): failed to allocate fake database");
+			disconnect_client(client, true, "out of memory");
+			return false;
+		}
 		client->db->fake = true;
 		strlcpy(client->db->name, dbname, sizeof(client->db->name));
 	}


### PR DESCRIPTION
Handle fake database allocation failure in the same vein as #1541 and others[^1][^2][^3]

[^1]: [#1541: `client: set_pool(): add allocation handler`](https://github.com/pgbouncer/pgbouncer/pull/1541)
[^2]: [`set_pool()` LDAP allocation failure handling](https://github.com/pgbouncer/pgbouncer/blob/13a344f2625381296fc02e29b986a11be9c6b983/src/client.c#L591-L595)
[^3]: [`set_pool()` PAM allocation failure handling](https://github.com/pgbouncer/pgbouncer/blob/13a344f2625381296fc02e29b986a11be9c6b983/src/client.c#L610-L614)
