### PR TITLE
GSSAPI (Kerberos) authentication and encryption for client and backend connections

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -67,6 +67,12 @@ jobs:
             cflags: "-O0 -g"
             enable_valgrind: "yes"
             meson_args: "-Dcares=enabled -Dldap=disabled -Dpam=disabled"
+          # GSSAPI/Kerberos auth + encryption, exercised against a local MIT KDC
+          # set up by test/setup_kdc.sh (gated on setup_kdc below).
+          - name: gssapi
+            build_system: meson
+            meson_args: "-Dgssapi=enabled"
+            setup_kdc: "yes"
     env:
       PGVERSION: ${{ matrix.pgversion || '16' }}
       BUILD_SYSTEM: ${{ matrix.build_system }}
@@ -79,6 +85,7 @@ jobs:
       CFLAGS_OVERRIDE: ${{ matrix.cflags }}
       ENABLE_VALGRIND: ${{ matrix.enable_valgrind }}
       DIST: ${{ matrix.dist }}
+      SETUP_KDC: ${{ matrix.setup_kdc }}
     steps: &linux_steps
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -91,6 +98,7 @@ jobs:
           pkgs="autoconf automake ca-certificates cpio git iptables ldap-utils libc-ares-dev libevent-dev libldap-dev libpam0g-dev libssl-dev libsystemd-dev libtool make meson ninja-build pandoc pkg-config postgresql-$PGVERSION python3 python3-pip python3-venv slapd socat sudo"
           if [ "$ENABLE_VALGRIND" = "yes" ]; then pkgs="$pkgs valgrind"; fi
           if [ "$USE_SCAN_BUILD" = "yes" ]; then pkgs="$pkgs clang clang-tools"; fi
+          if [ "$SETUP_KDC" = "yes" ]; then pkgs="$pkgs krb5-kdc krb5-admin-server krb5-user libkrb5-dev"; fi
           # $pkgs is an intentionally word-split package list.
           # shellcheck disable=SC2086
           sudo apt-get -y --no-install-recommends install $pkgs
@@ -112,6 +120,9 @@ jobs:
           [ -n "$CFLAGS_OVERRIDE" ] && export CFLAGS="$CFLAGS_OVERRIDE"
           [ "${USE_SCAN_BUILD:-}" = "yes" ] && export SCANBUILD="scan-build"
           sh ci/run.sh build "$BUILD_SYSTEM"
+      - name: Set up Kerberos KDC
+        if: ${{ env.SETUP_KDC == 'yes' }}
+        run: sudo bash test/setup_kdc.sh
       - name: Test
         run: |
           set -e

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ pgbouncer_SOURCES = \
 	src/admin.c \
 	src/client.c \
 	src/dnslookup.c \
+	src/gssapi_auth.c \
 	src/hba.c \
 	src/janitor.c \
 	src/ldapauth.c \
@@ -42,6 +43,7 @@ pgbouncer_SOURCES = \
 	include/bouncer.h \
 	include/client.h \
 	include/dnslookup.h \
+	include/gssapi_auth.h \
 	include/hba.h \
 	include/iobuf.h \
 	include/janitor.h \

--- a/config.mak.in
+++ b/config.mak.in
@@ -69,6 +69,7 @@ DLLTOOL = @DLLTOOL@
 WINDRES = @WINDRES@
 
 enable_debug = @enable_debug@
+gssapi_support = @gssapi_support@
 ldap_support = @ldap_support@
 tls_support = @tls_support@
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,35 @@ AC_CHECK_FUNCS(lstat)
 dnl Find libevent
 PKG_CHECK_MODULES(LIBEVENT, libevent)
 
+dnl Check for GSSAPI (Kerberos) authentication support
+gssapi_support=no
+AC_ARG_WITH(gssapi,
+  AS_HELP_STRING([--with-gssapi], [build with GSSAPI (Kerberos) support]),
+  [ GSSAPI=
+    if test "$withval" != no; then
+        # Look for GSSAPI header and library
+        AC_CHECK_HEADERS(gssapi/gssapi.h gssapi/gssapi_krb5.h, [have_gssapi_header=t])
+        AC_SEARCH_LIBS(gss_accept_sec_context, gssapi_krb5 gss, [have_libgssapi=t])
+        dnl gss_acquire_cred_from was added in MIT Kerberos 1.11 (2013).
+        AC_CHECK_FUNC(gss_acquire_cred_from, [have_gss_acquire_cred_from=t])
+        dnl gss_localname was added in MIT Kerberos 1.7 (2009).
+        AC_CHECK_FUNC(gss_localname, [have_gss_localname=t])
+        if test x"${have_gssapi_header}" != x -a x"${have_libgssapi}" != x; then
+          if test x"${have_gss_acquire_cred_from}" = x; then
+            AC_MSG_ERROR([GSSAPI library does not provide gss_acquire_cred_from; MIT Kerberos >= 1.11 is required])
+          fi
+          if test x"${have_gss_localname}" = x; then
+            AC_MSG_ERROR([GSSAPI library does not provide gss_localname; MIT Kerberos >= 1.7 is required])
+          fi
+          gssapi_support=yes
+          AC_SUBST(gssapi_support)
+          AC_DEFINE(HAVE_GSSAPI, 1, [GSSAPI support])
+        else
+          AC_MSG_ERROR([gssapi library or header is needed for GSSAPI compilation])
+        fi
+    fi
+  ], [])
+
 dnl Check for PAM authentication support
 pam_support=no
 AC_ARG_WITH(pam,
@@ -213,6 +242,7 @@ elif test "$ac_cv_usual_glibc_gaia" = "yes"; then
 else
   echo "  adns    = compat"
 fi
+echo "  gssapi  = $gssapi_support"
 echo "  ldap    = $ldap_support"
 echo "  pam     = $pam_support"
 echo "  systemd = $with_systemd"

--- a/doc/config.md
+++ b/doc/config.md
@@ -494,6 +494,12 @@ pam
     compatible with databases using the `auth_user` option. The service name reported to
     PAM is "pgbouncer". `pam` is not supported in the HBA configuration file.
 
+gssapi
+:   Client must authenticate using GSSAPI/Kerberos.  pgbouncer validates the
+    client's service ticket using `auth_gssapi_keytab` and maps the authenticated
+    principal to a local username via `gss_localname()`.  No password is used.
+    Requires pgbouncer to be built with `--with-gssapi`.
+
 ### auth_hba_file
 
 HBA configuration file to use when `auth_type` is `hba`. See
@@ -555,6 +561,92 @@ LDAP connection options to use if `auth_type` is `ldap`.  (Not used if
 authentication is configured via `auth_hba_file`.)  Example:
 
     auth_ldap_options = ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"
+
+### auth_gssapi_keytab
+
+Path to the keytab file containing the host-based service principal
+(`postgres/<pgbouncer-fqdn>@REALM`) used to accept client GSSAPI authentication.
+This is the only keytab required.  For backend connections, pgbouncer uses the
+process's existing TGT from the credential cache (KCM, FILE:, etc.) by default.
+
+Requires pgbouncer to be built with `--with-gssapi`.
+
+Default: not set
+
+### auth_gssapi_client_keytab
+
+Optional override: path to a keytab containing the pool service account principal,
+used to acquire initiator credentials for backend GSSAPI authentication.  Use this
+only when the pgbouncer process cannot maintain a live TGT through standard
+credential management (KCM, kinit, sssd, etc.).
+
+Do not set this to the same file as `auth_gssapi_keytab`: that file contains the
+host-based service SPN, which is the wrong identity for the initiator role.
+
+Requires pgbouncer to be built with `--with-gssapi`.
+
+Default: not set (uses the default credential cache)
+
+### auth_gssapi_service_name
+
+Kerberos service name used when constructing the backend service principal for
+initiator authentication.  Must match `krbsrvname` in the backend's
+`postgresql.conf`.  The SPN is constructed as `<service_name>@<host>` and passed
+to `gss_import_name()` with `GSS_C_NT_HOSTBASED_SERVICE`.
+
+Requires pgbouncer to be built with `--with-gssapi`.
+
+Default: `postgres`
+
+### client_gssencmode
+
+Controls whether GSSAPI transport encryption is requested on client connections
+(client → pgbouncer).  Accepted values:
+
+disable
+:   No GSSAPI encryption; plain-text connection.  The client may still
+    authenticate via GSSAPI (`auth_type = gssapi`) over an unencrypted channel.
+
+allow
+:   pgbouncer accepts either GSSAPI-encrypted or unencrypted client connections;
+    the client decides.
+
+require
+:   All client connections must be GSSAPI-encrypted; plain-text connections are
+    rejected.
+
+Note: `prefer` is not offered on the server (acceptor) side because a server
+responds to what the client requests rather than initiating encryption itself.
+
+Requires pgbouncer to be built with `--with-gssapi`.
+
+Default: `disable`
+
+### server_gssencmode
+
+Controls whether GSSAPI transport encryption is used on backend connections
+(pgbouncer → PostgreSQL server).  Accepted values:
+
+disable
+:   No GSSAPI encryption; plain-text backend connection.
+
+prefer
+:   Try GSSAPI encryption first, when pgbouncer has usable initiator credentials
+    (a client keytab or credential cache).  If credentials are unavailable, or
+    the server does not support GSSAPI encryption, fall back to the configured
+    backend SSL mode, or to a plain-text connection.
+
+require
+:   Require GSSAPI encryption for all backend connections; connections to servers
+    that do not support GSSAPI encryption are rejected.
+
+Note: `allow` is not offered on the client (initiator) side because a client
+controls how it initiates the connection; the server can only respond to or reject
+the client's request.
+
+Requires pgbouncer to be built with `--with-gssapi`.
+
+Default: `disable`
 
 ## Log settings
 

--- a/doc/gssapi-auth.md
+++ b/doc/gssapi-auth.md
@@ -1,0 +1,429 @@
+# GSSAPI (Kerberos) Authentication in PgBouncer
+
+## Overview
+
+PgBouncer supports GSSAPI/Kerberos authentication in both directions:
+
+- **Client → pgbouncer (acceptor)**: connecting clients present Kerberos service
+  tickets. pgbouncer validates the ticket using its keytab, maps the
+  authenticated principal to a local username via `gss_localname()` and the
+  site's `auth_to_local` rules in `krb5.conf`, and verifies the result matches
+  the username the client claimed in the startup packet.
+
+- **pgbouncer → postgres (initiator)**: when the backend requests GSSAPI
+  authentication, pgbouncer authenticates using its own pool service-account
+  identity. By default it uses whatever TGT already exists in the process
+  credential cache (KCM, FILE:, or any other standard ccache). No client
+  credentials are ever forwarded.
+
+No passwords are used anywhere.
+
+## Trust model and authorization boundary
+
+pgbouncer is the **authentication boundary**. It verifies each client's
+Kerberos identity and logs the authenticated principal. Postgres trusts the
+pool service account (e.g., `pgbouncer@EXAMPLE.COM`) and applies authorization
+at that role's level.
+
+```
+  [alice@workstation]          [pgbouncer]               [postgres]
+        |                          |                          |
+        |  StartupMessage          |                          |
+        |  user=alice, db=mydb ───>                           |
+        |                          |                          |
+        |  AuthenticationGSS(7) <──|                          |
+        |                          |                          |
+        |  GSSResponse (AP-REQ) ───>                          |
+        |   (svc ticket for        |  gss_accept_sec_context()|
+        |    postgres/<pgb-host>)  |                          |
+        |                          |  gss_localname():        |
+        |  AuthenticationOk <──────|  alice@EXAMPLE.COM       |
+        |                          |   -> alice               |
+        |                          |  (matches claimed "alice")|
+        |                          |                          |
+        |  query ──────────────────>  StartupMessage          |
+        |                          |  user=pgbouncer, db=mydb─>
+        |                          |                          |
+        |                          |  AuthenticationGSS(7) <──|
+        |                          |                          |
+        |                          |  GSSResponse (AP-REQ) ───>
+        |                          |   (svc ticket for        |
+        |                          |    postgres/<pg-host>)   |
+        |                          |  gss_init_sec_context()  |
+        |                          |                          |
+        |                          |  AuthenticationOk <──────|
+        |                          |                          |
+        |  result <────────────────────────────────── query ──>
+```
+
+Postgres sees all connections as the `pgbouncer` role. The `pgbouncer` role is
+granted the necessary database permissions. This is not a limitation — it is
+the correct design for a connection pooler:
+
+- **Connection pooling works by decoupling client identity from server
+  connection identity.** A pool of server connections is maintained and reused
+  across many clients. If each server connection carried an individual user's
+  Kerberos identity, connections could not be shared, eliminating the benefit
+  of pooling.
+- **The database permissions model follows from this.** Grant what the
+  `pgbouncer` role needs. Every client who passes Kerberos authentication to
+  pgbouncer inherits those permissions — which is exactly the access policy for
+  a shared database.
+- **Audit trail is at pgbouncer, not postgres.** pgbouncer logs the full
+  authenticated principal (e.g., `alice@EXAMPLE.COM`) on every login.
+  Postgres logs queries attributed to `pgbouncer`. This is expected and correct.
+
+### No credential delegation
+
+pgbouncer requests **only** `GSS_C_MUTUAL_FLAG` when calling
+`gss_init_sec_context()` for backend connections. `GSS_C_DELEG_FLAG` and
+`GSS_C_DELEG_POLICY_FLAG` are never set.
+
+Credential delegation — forwarding a client's TGT so pgbouncer could
+authenticate to postgres *as the client* — is deliberately not used:
+
+- It destroys connection reuse: each user's forwarded credential is distinct,
+  so connections cannot be shared across users.
+- It stores high-value credentials (user TGTs) in the pgbouncer process; a
+  compromise exposes every active user.
+- It requires the client's TGT to be forwardable and the pgbouncer SPN to be
+  flagged `ok-as-delegate` in the KDC.
+
+### Username mapping
+
+`gss_localname()` maps authenticated principals to local usernames by applying
+the `auth_to_local` rules from `krb5.conf`. This is the authoritative,
+site-policy-respecting mapping; no ad-hoc realm stripping is performed.
+
+Example mappings (configured via `auth_to_local` rules in `krb5.conf`):
+
+| Authenticated principal | Mapped local name |
+|---|---|
+| `alice@EXAMPLE.COM` | `alice` |
+| `alice/admin@EXAMPLE.COM` | `alice` |
+| `bob@EXAMPLE.COM` | `bob` |
+
+The mapped name must exactly match the username in the startup packet. The
+specific mapping rules depend on your site's `krb5.conf` configuration. Common
+`auth_to_local` rules strip the realm and optional instance components:
+
+```
+[realms]
+    EXAMPLE.COM = {
+        auth_to_local = RULE:[1:$1@$0](.*@EXAMPLE\.COM)s/@.*//
+        auth_to_local = DEFAULT
+    }
+```
+
+`gss_localname()` requires MIT Kerberos >= 1.7 (2009), which is verified at
+configure time.
+
+#### Relationship to postgres HBA options
+
+PostgreSQL maps GSSAPI principals with the `include_realm`, `krb_realm`, and
+`map=` (pg_ident) HBA options. pgbouncer instead delegates principal mapping to
+`gss_localname()` / `auth_to_local` in `krb5.conf`, keeping it under a single,
+centralized, site-controlled policy rather than split across pg_ident. The
+postgres options are handled as follows on a GSSAPI HBA line:
+
+- `include_realm=` is redundant with `auth_to_local` and is ignored with a
+  warning, so a GSSAPI `pg_hba.conf` line can be copied over unchanged.
+- `krb_realm=` and `map=` *restrict* which principals may authenticate. Silently
+  ignoring them would grant more access than the administrator wrote, so a line
+  carrying either is rejected (fail closed). Express the equivalent restriction
+  as an `auth_to_local` rule in `krb5.conf` and remove the option.
+
+## Build
+
+```sh
+./autogen.sh
+./configure --with-gssapi
+make
+```
+
+Requires MIT Kerberos headers and `libgssapi_krb5`. On Debian/Ubuntu:
+
+```sh
+apt install libkrb5-dev
+```
+
+Confirm GSSAPI compiled in by checking `configure` output:
+
+```
+Results:
+  gssapi  = yes
+```
+
+## Configuration
+
+### pgbouncer.ini
+
+**Minimal configuration** (ccache-based, default for most environments):
+
+```ini
+[pgbouncer]
+; Authentication method for incoming clients.
+; "hba" selects per-database from an auth_hba_file.
+auth_type = gssapi
+
+; Keytab for the host-based service SPN that clients acquire tickets for:
+;   postgres/<pgbouncer-canonical-fqdn>@REALM
+; This is the only required keytab.  pgbouncer uses the process's existing
+; TGT (from KCM, FILE:, or any ccache) to authenticate to postgres backends.
+auth_gssapi_keytab = /etc/pgbouncer/pgbouncer.keytab
+
+pool_mode = transaction
+server_reset_query = DISCARD ALL
+
+[databases]
+; IMPORTANT: user= must match the pool service account principal exactly
+; as mapped by postgres's pg_ident.conf.
+; Without user=pgbouncer, pgbouncer sends the client's username in the
+; backend startup message but the GSSAPI identity is the pool account;
+; postgres rejects the mismatch.
+mydb = host=postgres.example.com dbname=mydb user=pgbouncer
+```
+
+**Optional overrides**:
+
+```ini
+; Override: acquire backend credentials from a keytab instead of the ccache.
+; Use this only when the pgbouncer process cannot maintain a live TGT through
+; standard credential management (KCM, kinit, sssd, etc.).
+; When set, MIT Kerberos reads keys from this file and acquires a TGT directly.
+; The server keytab (auth_gssapi_keytab) must NOT be used here: it contains the
+; host-based service SPN, which is the wrong identity for the initiator role.
+;auth_gssapi_client_keytab = /etc/pgbouncer/pgbouncer-client.keytab
+
+; Kerberos service name used when constructing the backend service principal.
+; Must match krbsrvname in postgresql.conf (default: "postgres").
+; The SPN sent is "<service_name>@<host>", resolved to
+; <service_name>/<canonical-host>@REALM.
+;auth_gssapi_service_name = postgres
+```
+
+### HBA-based per-database authentication
+
+To apply different auth methods per database:
+
+```ini
+[pgbouncer]
+auth_type = hba
+auth_hba_file = /etc/pgbouncer/pg_hba.conf
+```
+
+```
+# /etc/pgbouncer/pg_hba.conf
+host  mydb  all  0.0.0.0/0  gssapi
+```
+
+**Divergence from PostgreSQL pg_hba.conf**: PostgreSQL supports GSSAPI-specific
+HBA options `include_realm`, `krb_realm`, and `map=`. pgbouncer does not
+implement these; principal-to-username mapping is handled entirely by
+`auth_to_local` rules in `krb5.conf` via `gss_localname()`. `include_realm=` is
+redundant with that and is ignored with a warning, so lines using only it copy
+over unchanged. `krb_realm=` and `map=` are *restrictive*, so ignoring them would
+grant more access than written; a GSSAPI line carrying either is rejected (fail
+closed). Move the restriction into an `auth_to_local` rule and remove the option.
+
+## Keytab provisioning
+
+### Required: acceptor keytab
+
+The host-based service principal that libpq clients acquire tickets for:
+
+```
+postgres/<pgbouncer-canonical-fqdn>@REALM
+```
+
+The FQDN must be the **canonical** name after DNS CNAME resolution. If
+`rdns = no` is set in `krb5.conf` (recommended), only forward CNAME resolution
+is used — not PTR (reverse) lookups. If clients connect via a DNS alias that
+CNAMEs to the pgbouncer host, the SPN must match the final canonical name, not
+the alias.
+
+Create the principal and extract a keytab (adjust for your KDC tooling):
+
+```sh
+kadmin -q "addprinc -randkey postgres/<pgbouncer-fqdn>@REALM"
+kadmin -q "ktadd -k /etc/pgbouncer/pgbouncer.keytab postgres/<pgbouncer-fqdn>@REALM"
+chown pgbouncer:pgbouncer /etc/pgbouncer/pgbouncer.keytab
+chmod 600 /etc/pgbouncer/pgbouncer.keytab
+```
+
+Verify:
+```sh
+klist -k -t /etc/pgbouncer/pgbouncer.keytab
+```
+
+This is the **only keytab required** in environments where the pgbouncer process
+already has a TGT (via KCM, kinit, sssd, or any other standard mechanism).
+pgbouncer uses that TGT to acquire service tickets for postgres backends, exactly
+as any other Kerberos client would.
+
+### Optional: pool service account keytab
+
+Only needed when the pgbouncer process cannot maintain a live TGT through
+standard credential management. The principal it should contain:
+
+```
+pgbouncer@REALM
+```
+
+Create and extract:
+
+```sh
+kadmin -q "addprinc -randkey pgbouncer@REALM"
+kadmin -q "ktadd -k /etc/pgbouncer/pgbouncer-client.keytab pgbouncer@REALM"
+chown pgbouncer:pgbouncer /etc/pgbouncer/pgbouncer-client.keytab
+chmod 600 /etc/pgbouncer/pgbouncer-client.keytab
+```
+
+Configure with `auth_gssapi_client_keytab = /etc/pgbouncer/pgbouncer-client.keytab`.
+
+**Important**: this file must be separate from the acceptor keytab.
+`auth_gssapi_keytab` contains the host-based service SPN
+(`postgres/<host>@REALM`), which is the wrong identity for the initiator role.
+The two keytabs hold credentials for completely different roles and must never
+be substituted for each other.
+
+## Postgres backend setup
+
+### pg_hba.conf
+
+Allow GSSAPI authentication for the pool service account:
+
+```
+host all all 0.0.0.0/0 gss map=gssmap
+```
+
+### pg_ident.conf
+
+Map the pool account's Kerberos principal to the postgres role:
+
+```
+gssmap  /^(.*)@EXAMPLE\.COM$  \1
+```
+
+This maps `pgbouncer@EXAMPLE.COM` to the postgres role `pgbouncer`. Adjust the
+regex to match your realm and principal naming conventions.
+
+### Pool service account role
+
+```sql
+CREATE ROLE pgbouncer LOGIN;
+GRANT CONNECT ON DATABASE mydb TO pgbouncer;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO pgbouncer;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO pgbouncer;
+```
+
+All clients who authenticate to pgbouncer via Kerberos inherit the permissions
+of the `pgbouncer` role. This is the correct model for shared databases.
+
+## Testing
+
+### Step 1: confirm direct client → postgres GSSAPI works
+
+Before introducing pgbouncer, verify that your Kerberos environment and postgres
+configuration are working end to end:
+
+```sh
+klist   # confirm a valid TGT is present
+psql "host=<postgres-fqdn> dbname=mydb user=alice sslmode=disable"
+klist   # should now show postgres/<postgres-fqdn>@REALM service ticket
+```
+
+### Step 2: confirm pgbouncer's TGT and postgres SPN reachability
+
+As the user account pgbouncer runs under:
+
+```sh
+klist   # should show a valid TGT for the pool service account
+kvno postgres/<postgres-fqdn>@REALM
+```
+
+`klist` confirms the process has a live TGT — pgbouncer will use this to
+acquire service tickets for postgres backends automatically.
+
+`kvno` failing with "Server not found in Kerberos database" means the postgres
+SPN does not exist in the KDC; address that before proceeding.
+
+If using `auth_gssapi_client_keytab` (no live TGT), test keytab-based
+acquisition instead:
+
+```sh
+kinit -k -t /etc/pgbouncer/pgbouncer-client.keytab pgbouncer@REALM
+kvno postgres/<postgres-fqdn>@REALM
+```
+
+### Step 3: start pgbouncer
+
+```sh
+./pgbouncer -v /etc/pgbouncer/pgbouncer.ini
+```
+
+### Step 4: connect as a user
+
+```sh
+# No password. libpq uses GSSAPI automatically when the server requests it.
+psql "host=<pgbouncer-fqdn> dbname=mydb user=alice sslmode=disable"
+```
+
+Expected pgbouncer log:
+```
+LOG C-alice@...: GSSAPI: authenticated principal: alice@EXAMPLE.COM
+LOG C-alice@...: GSSAPI: principal mapped to local user "alice"
+```
+
+Expected postgres log (for the backend connection):
+```
+LOG  connection received: host=<pgbouncer-ip> user=pgbouncer database=mydb
+```
+
+### Step 5: confirm no passwords were involved
+
+```sh
+klist   # client side: shows postgres/<pgbouncer-fqdn>@REALM ticket
+```
+
+```sql
+-- In the psql session:
+SELECT current_user;   -- "pgbouncer" — the pool service account
+SELECT session_user;   -- "pgbouncer"
+```
+
+## Troubleshooting
+
+| Error | Cause |
+|---|---|
+| `GSSAPI: failed to acquire server credentials from keytab /path` | Wrong keytab path, wrong principal name, or file not readable by pgbouncer user |
+| `gss_accept_sec_context: No key table entry for...` | Client's ticket was issued for a SPN not in the acceptor keytab. Confirm the pgbouncer FQDN matches the SPN after CNAME resolution. |
+| `GSSAPI: principal mapping failed` | `gss_localname()` could not map the authenticated principal. Check `auth_to_local` rules in `krb5.conf`. |
+| `GSSAPI: local name "alice" does not match claimed username "ALICE"` | Case mismatch between `auth_to_local` output and the postgres role name. Add an explicit rule or fix the role name. |
+| Backend auth fails: `FATAL: password authentication failed for user "alice"` | `user=pgbouncer` is missing from the `[databases]` entry. pgbouncer sent the client username in the startup message but authenticated via GSSAPI as the pool account; postgres rejected the mismatch. |
+| `GSSAPI: failed to acquire initiator credentials from default credential cache` | pgbouncer has no TGT. Ensure the process's ccache (KCM, FILE:, etc.) is populated, or configure `auth_gssapi_client_keytab`. |
+| `Server not found in Kerberos database` | The postgres service SPN `postgres/<host>@REALM` does not exist in the KDC. |
+
+## Security notes
+
+- Keytab files must be `chmod 600`, owned by the pgbouncer process user. Anyone
+  who can read the server keytab can impersonate the pgbouncer service; anyone
+  who can read the client keytab can authenticate to postgres as the pool
+  account.
+- pgbouncer logs the full authenticated Kerberos principal at INFO level on
+  every successful client login when `log_connections = on` (the default).
+  Ensure `log_connections` is not disabled in environments where this audit
+  trail is required.
+- `GSS_C_DELEG_FLAG` is never set. pgbouncer holds no user credentials; a
+  compromised pgbouncer process cannot be used to impersonate clients to other
+  services.
+
+## Limitations
+
+- **`server_gssencmode = prefer` falls back only on refusal, not on handshake
+  failure.** If the backend answers `N`, or pgbouncer has no usable initiator
+  credentials, pgbouncer falls back to SSL or plain text. But if the backend
+  accepts (`G`) and the GSSAPI handshake then fails (for example, a credential
+  expires mid-connect), the connection attempt fails rather than retrying
+  without encryption. This matches the existing behavior of
+  `server_tls_sslmode = prefer`.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -80,6 +80,9 @@ listen_port = 6432
 ;; disable, allow, require, verify-ca, verify-full
 ;client_tls_sslmode = disable
 
+;; GSSAPI transport encryption for client connections: disable, allow, require
+;client_gssencmode = disable
+
 ;; Path to file that contains trusted CA certs
 ;client_tls_ca_file = <system default>
 
@@ -110,6 +113,9 @@ listen_port = 6432
 
 ;; disable, allow, prefer, require, verify-ca, verify-full
 ;server_tls_sslmode = prefer
+
+;; GSSAPI transport encryption for backend connections: disable, prefer, require
+;server_gssencmode = disable
 
 ;; Path to that contains trusted CA certs
 ;server_tls_ca_file = <system default>
@@ -144,6 +150,16 @@ auth_file = /etc/pgbouncer/userlist.txt
 
 ;; LDAP connection options when "auth_type = ldap"
 ;auth_ldap_options =
+
+;; Acceptor keytab for GSSAPI client authentication ("auth_type = gssapi")
+;auth_gssapi_keytab =
+
+;; Optional initiator keytab for authenticating to backends; defaults to the
+;; process credential cache
+;auth_gssapi_client_keytab =
+
+;; Backend service principal name for GSSAPI (forms "<name>/<host>@REALM")
+;auth_gssapi_service_name = postgres
 
 ;; Query to use to fetch password from database.  Result
 ;; must have 2 columns - username and password hash.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -22,6 +22,10 @@
 
 #include "system.h"
 
+#ifdef HAVE_GSSAPI
+#include <gssapi/gssapi.h>
+#endif
+
 #include <usual/cfparser.h>
 #include <usual/time.h>
 #include <usual/list.h>
@@ -126,6 +130,13 @@ enum SSLMode {
 	SSLMODE_REQUIRE,
 	SSLMODE_VERIFY_CA,
 	SSLMODE_VERIFY_FULL
+};
+
+enum GssEncMode {
+	GSSENCMODE_DISABLED,
+	GSSENCMODE_ALLOW,
+	GSSENCMODE_PREFER,
+	GSSENCMODE_REQUIRE
 };
 
 enum PacketCallbackFlag {
@@ -248,6 +259,7 @@ enum auth_type {
 	AUTH_TYPE_SCRAM_SHA_256,
 	AUTH_TYPE_PEER,
 	AUTH_TYPE_REJECT,
+	AUTH_TYPE_GSSAPI,
 };
 
 /* type codes for weird pkts */
@@ -735,6 +747,7 @@ struct PgSocket {
 	bool wait_for_response : 1;	/* console client: waits for completion of PAUSE/SUSPEND cmd */
 
 	bool wait_sslchar : 1;		/* server: waiting for ssl response: S/N */
+	bool wait_gss_enc_char : 1;	/* server: waiting for gss enc response: G/N */
 	/* server: received an ErrorResponse, waiting for ReadyForQuery to clear
 	 * the outstanding requests until the next Sync */
 	bool query_failed : 1;
@@ -788,6 +801,77 @@ struct PgSocket {
 	} scram_state;
 #ifdef HAVE_LDAP
 	char ldap_options[MAX_LDAP_CONFIG];
+#endif
+
+#ifdef HAVE_GSSAPI
+	/*
+	 * Per-connection GSSAPI state.
+	 *
+	 * For client connections (acceptor role): context and creds are used
+	 * across multiple rounds of gss_accept_sec_context().
+	 * For server connections (initiator role): context, creds, and
+	 * target_name are used across multiple rounds of gss_init_sec_context().
+	 * target_name is only populated in the server/initiator path.
+	 */
+	struct GssState {
+		gss_ctx_id_t context;		/* GSS security context */
+		gss_cred_id_t creds;		/* acquired credential handle */
+		gss_name_t target_name;	/* initiator only: postgres@host */
+		/*
+		 * Set when we sent an AP-REP (AUTH_REQ_GSS_CONT) to complete
+		 * mutual authentication.  If the client's final gss_init_sec_context()
+		 * emits a token with GSS_S_COMPLETE (RFC 2744, mechanism-dependent),
+		 * libpq forwards one extra GSSResponse ('p'); handle_client_work()
+		 * uses this flag to absorb it silently rather than treating it as a
+		 * protocol error.
+		 */
+		bool sent_ap_rep;	/* acceptor only: AP-REP was sent */
+	} gss_state;
+
+	/*
+	 * Per-connection GSSAPI encryption state.
+	 *
+	 * When gss_enc.active is true, all I/O on this socket goes through
+	 * gss_wrap()/gss_unwrap() via the gss_sbufio_ops vtable in sbuf.
+	 * Buffer sizes match the postgres protocol constants:
+	 *   PQ_GSS_MAX_PACKET_SIZE  = 16384 (encrypted on-wire packet limit)
+	 *   PQ_GSS_AUTH_BUFFER_SIZE = 65536 (handshake token limit)
+	 */
+	struct GssEncState {
+		gss_ctx_id_t ctx;	/* established security context */
+		gss_cred_id_t creds;	/* credential handle for handshake */
+		gss_name_t target_name;	/* initiator: service principal name */
+		bool active;		/* encryption channel is live */
+
+		char *send_buf;		/* encrypted output buffering */
+		int send_len;		/* bytes of data in send_buf */
+		int send_next;		/* next byte index to send */
+		int send_consumed;	/* source bytes already encrypted */
+
+		char *recv_buf;		/* encrypted input buffering */
+		int recv_len;		/* bytes received into recv_buf */
+
+		char *result_buf;	/* decrypted result buffering */
+		int result_len;		/* bytes available in result_buf */
+		int result_next;	/* next byte to return to caller */
+
+		uint32_t max_pkt_size;	/* from gss_wrap_size_limit() */
+
+		/* handshake accumulation buffer */
+		char *hs_buf;		/* handshake token buffer */
+		int hs_len;		/* bytes accumulated in handshake */
+		int pkt_expected;	/* bytes expected for current packet (handshake or data, 0 = reading length) */
+
+		/*
+		 * Handshake output flow control.  An output token is framed into
+		 * send_buf and flushed non-blocking; a partial write re-arms
+		 * EV_WRITE (hs_want) and resumes on the next call.  When the token
+		 * that completes the context has been fully sent, hs_complete_pending
+		 * triggers the transition to the encrypted data phase.
+		 */
+		int hs_want;		/* GSSENC_HS_READ or GSSENC_HS_WRITE */
+		bool hs_complete_pending;	/* transition to data phase once output is flushed */
+	} gss_enc;
 #endif
 
 	VarCache vars;		/* state of interesting server parameters */
@@ -892,6 +976,11 @@ extern char *cf_auth_user;
 extern char *cf_auth_hba_file;
 extern char *cf_auth_dbname;
 extern char *cf_auth_ldap_options;
+extern char *cf_auth_gssapi_keytab;
+extern char *cf_auth_gssapi_client_keytab;
+extern char *cf_auth_gssapi_service_name;
+extern int cf_client_gssencmode;
+extern int cf_server_gssencmode;
 
 extern char *cf_pidfile;
 

--- a/include/gssapi_auth.h
+++ b/include/gssapi_auth.h
@@ -1,0 +1,70 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * GSSAPI (Kerberos) authentication and encryption support.
+ */
+
+/* Safety limit on GSSAPI auth token size */
+#define GSSAPI_MAX_TOKEN_SIZE (65536)
+
+/*
+ * GSSAPI encryption protocol constants.
+ * These match the postgres source (be-secure-gssapi.c, fe-secure-gssapi.c)
+ * and are effectively part of the protocol spec.
+ */
+#define PQ_GSS_MAX_PACKET_SIZE  16384	/* encrypted on-wire packet, includes uint32 header */
+#define PQ_GSS_AUTH_BUFFER_SIZE 65536	/* handshake token buffer, includes uint32 header */
+
+/*
+ * Which socket event the encryption handshake is waiting on next.  The handshake
+ * is event-driven: a round that cannot fully send its output token yet asks the
+ * sbuf layer to re-arm EV_WRITE; otherwise it waits for the peer's next token on
+ * EV_READ.  This mirrors the WANT_POLLIN/WANT_POLLOUT handling of the TLS layer.
+ */
+#define GSSENC_HS_READ  0
+#define GSSENC_HS_WRITE 1
+
+void gssapi_auth_init(void);
+
+/* Client-side: pgbouncer acts as GSSAPI acceptor for connecting clients */
+bool gssapi_accept_send_request(PgSocket *client)  _MUSTCHECK;
+bool gssapi_accept_continue(PgSocket *client, const uint8_t *token,
+			    unsigned token_len)     _MUSTCHECK;
+void gssapi_accept_cleanup(PgSocket *client);
+
+/* Server-side: pgbouncer acts as GSSAPI initiator to a postgres backend */
+bool gssapi_initiate_begin(PgSocket *server)       _MUSTCHECK;
+bool gssapi_initiate_continue(PgSocket *server, const uint8_t *token,
+			      unsigned token_len)  _MUSTCHECK;
+void gssapi_initiate_cleanup(PgSocket *server);
+
+/* GSSAPI encryption: wrap/unwrap for sbuf I/O layer */
+ssize_t gssenc_recv(PgSocket *sk, void *buf, size_t len);
+ssize_t gssenc_send(PgSocket *sk, const void *buf, size_t len);
+
+/* GSSAPI encryption: handshake */
+bool gssenc_accept_start(PgSocket *client)  _MUSTCHECK;
+bool gssenc_accept_handshake(PgSocket *client)  _MUSTCHECK;
+bool gssenc_have_initiator_cred(PgSocket *server)  _MUSTCHECK;
+bool gssenc_connect_start(PgSocket *server)  _MUSTCHECK;
+bool gssenc_connect_handshake(PgSocket *server)  _MUSTCHECK;
+void gssenc_cleanup(PgSocket *sk);
+
+/* GSSAPI encryption: identity extraction from encryption context */
+bool gssenc_extract_and_verify_identity(PgSocket *client)  _MUSTCHECK;

--- a/include/proto.h
+++ b/include/proto.h
@@ -63,6 +63,7 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt) _MUSTCHECK;
 
 bool send_startup_message(PgSocket *server) _MUSTCHECK;
 bool send_sslreq_packet(PgSocket *server) _MUSTCHECK;
+bool send_gssencreq_packet(PgSocket *server) _MUSTCHECK;
 
 int scan_text_result(struct MBuf *pkt, const char *tupdesc, ...) _MUSTCHECK;
 

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -29,7 +29,8 @@ typedef enum {
 	SBUF_EV_CONNECT_OK,	/* got connection */
 	SBUF_EV_FLUSH,		/* data is sent, buffer empty */
 	SBUF_EV_PKT_CALLBACK,	/* next part of pkt data */
-	SBUF_EV_TLS_READY	/* TLS was established */
+	SBUF_EV_TLS_READY,	/* TLS was established */
+	SBUF_EV_GSS_READY	/* GSS encryption was established */
 } SBufEvent;
 
 /*
@@ -74,6 +75,9 @@ struct SBuf {
 	uint8_t wait_type;	/* track wait state */
 	uint8_t pkt_action;	/* method for handling current pkt */
 	uint8_t tls_state;	/* progress of tls */
+#ifdef HAVE_GSSAPI
+	uint8_t gss_state;	/* progress of GSS encryption */
+#endif
 
 	int sock;		/* fd for this socket */
 
@@ -117,6 +121,9 @@ extern int server_connect_sslmode;
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
+
+bool sbuf_gss_accept(SBuf *sbuf)  _MUSTCHECK;
+bool sbuf_gss_connect(SBuf *sbuf)  _MUSTCHECK;
 
 bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);

--- a/meson.build
+++ b/meson.build
@@ -387,6 +387,23 @@ endif
 # LDAP (mirrors --with-ldap)
 # ----------------------------------------------------------------------
 
+gssapiopt = get_option('gssapi')
+gssapi = not_found_dep
+if gssapiopt != 'disabled'
+  gssapi = dependency('krb5-gssapi', required: gssapiopt == 'enabled')
+endif
+if gssapi.found()
+  # src/gssapi_auth.c calls these unconditionally; require the MIT Kerberos
+  # versions that provide them (gss_localname: 1.7, gss_acquire_cred_from: 1.11).
+  if not cc.has_function('gss_acquire_cred_from', dependencies: gssapi)
+    error('GSSAPI library does not provide gss_acquire_cred_from; MIT Kerberos >= 1.11 is required')
+  endif
+  if not cc.has_function('gss_localname', dependencies: gssapi)
+    error('GSSAPI library does not provide gss_localname; MIT Kerberos >= 1.7 is required')
+  endif
+  cdata.set('HAVE_GSSAPI', 1, description: 'GSSAPI (Kerberos) support.')
+endif
+
 ldapopt = get_option('ldap')
 ldap = not_found_dep
 if ldapopt != 'disabled'
@@ -546,6 +563,7 @@ pgbouncer_sources = files(
   'src/admin.c',
   'src/client.c',
   'src/dnslookup.c',
+  'src/gssapi_auth.c',
   'src/hba.c',
   'src/janitor.c',
   'src/ldapauth.c',
@@ -593,6 +611,7 @@ pgbouncer_deps = [
   libevent,
   openssl,
   systemd,
+  gssapi,
   pam,
   ldap,
   threads,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,6 +21,8 @@ option('cares', type: 'feature', value: 'auto',
 
 # combo rather than feature: these are probed with find_library, and passing a
 # feature to find_library's `required` needs meson 0.59 (newer than our floor).
+option('gssapi', type: 'combo', choices: ['auto', 'enabled', 'disabled'], value: 'auto',
+       description: 'Build with GSSAPI (Kerberos) authentication and encryption support')
 option('ldap', type: 'combo', choices: ['auto', 'enabled', 'disabled'], value: 'auto',
        description: 'Build with LDAP authentication support')
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -347,6 +347,17 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	if (sk->sbuf.tls || (sk->link && sk->link->sbuf.tls))
 		return true;
 
+#ifdef HAVE_GSSAPI
+	/*
+	 * Skip GSS-encrypted sockets: the encryption context cannot be handed
+	 * to the new process across a takeover, and resuming such an fd as
+	 * plaintext would emit unencrypted bytes on a stream the peer believes
+	 * is encrypted.
+	 */
+	if (sk->gss_enc.active || (sk->link && sk->link->gss_enc.active))
+		return true;
+#endif
+
 	mbuf_init_fixed_reader(&tmp, sk->cancel_key, 8);
 	if (!mbuf_get_uint64be(&tmp, &ckey))
 		return false;

--- a/src/client.c
+++ b/src/client.c
@@ -23,6 +23,7 @@
 #include "bouncer.h"
 #include "pam.h"
 #include "scram.h"
+#include "gssapi_auth.h"
 #include "common/builtins.h"
 
 #include <usual/pgutil.h>
@@ -430,6 +431,22 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 	/* remember method */
 	client->client_auth_type = auth;
 
+#ifdef HAVE_GSSAPI
+	/*
+	 * When GSS encryption is active and the configured method is GSSAPI,
+	 * the client's Kerberos identity is already established by the
+	 * encryption handshake.  Extract the principal from the encryption
+	 * context and skip the separate AUTH_REQ_GSS exchange.  This matches
+	 * postgres, which treats encryption and authentication as orthogonal:
+	 * any other configured method (scram, md5, plain, ...) still runs, now
+	 * over the encrypted channel.
+	 */
+	if (client->gss_enc.active && auth == AUTH_TYPE_GSSAPI) {
+		ok = gssenc_extract_and_verify_identity(client);
+		return ok;
+	}
+#endif
+
 	switch (auth) {
 	case AUTH_TYPE_ANY:
 		ok = finish_client_login(client);
@@ -452,6 +469,9 @@ static bool finish_set_pool(PgSocket *client, bool takeover)
 		break;
 	case AUTH_TYPE_PEER:
 		ok = login_as_unix_peer(client, rule);
+		break;
+	case AUTH_TYPE_GSSAPI:
+		ok = gssapi_accept_send_request(client);
 		break;
 	default:
 		disconnect_client(client, true, "login rejected");
@@ -526,6 +546,19 @@ static bool check_if_need_ldap_authentication(PgSocket *client, const char *dbna
 		struct HBARule *rule = hba_eval(parsed_hba, &client->remote_addr, !!client->sbuf.tls,
 						REPLICATION_NONE, dbname, username);
 		if (rule != NULL && rule->rule_method == AUTH_TYPE_LDAP)
+			return true;
+	}
+	return false;
+}
+#endif
+
+#ifdef HAVE_GSSAPI
+static bool check_if_need_gssapi_authentication(PgSocket *client, const char *dbname, const char *username)
+{
+	if (cf_auth_type == AUTH_TYPE_HBA) {
+		struct HBARule *rule = hba_eval(parsed_hba, &client->remote_addr, !!client->sbuf.tls,
+						REPLICATION_NONE, dbname, username);
+		if (rule != NULL && rule->rule_method == AUTH_TYPE_GSSAPI)
 			return true;
 	}
 	return false;
@@ -615,6 +648,26 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 		if (!check_user_connection_count(client)) {
 			return false;
 		}
+#ifdef HAVE_GSSAPI
+	} else if (check_if_need_gssapi_authentication(client, dbname, username) ||
+		   cf_auth_type == AUTH_TYPE_GSSAPI) {
+		if (client->db->auth_user_credentials) {
+			slog_error(client, "GSSAPI can't be used together with database authentication");
+			disconnect_client(client, true, "bouncer config error");
+			return false;
+		}
+		/* GSSAPI authenticates via Kerberos; no password is involved */
+		client->login_user_credentials = find_or_add_new_global_credentials(username, NULL);
+		if (!client->login_user_credentials) {
+			slog_error(client, "set_pool(): failed to allocate credentials for GSSAPI user");
+			disconnect_client(client, true, "bouncer resources exhaustion");
+			return false;
+		}
+		if (!check_db_connection_count(client))
+			return false;
+		if (!check_user_connection_count(client))
+			return false;
+#endif
 	} else {
 		client->login_user_credentials = find_global_credentials(username);
 
@@ -1257,6 +1310,10 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 				/* the packet was already parsed */
 				sbuf_prepare_skip(sbuf, pkt->len);
 			}
+#ifdef HAVE_GSSAPI
+			/* Any pending post-auth GSSResponse was just consumed above. */
+			client->gss_state.sent_ap_rep = false;
+#endif
 			return true;
 		} else {
 			return false;
@@ -1271,6 +1328,12 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			disconnect_client(client, false, "SSL req inside SSL");
 			return false;
 		}
+#ifdef HAVE_GSSAPI
+		if (client->gss_enc.active) {
+			disconnect_client(client, false, "SSL req inside GSS encryption");
+			return false;
+		}
+#endif
 		if (client_accept_sslmode != SSLMODE_DISABLED && !is_unix) {
 			slog_noise(client, "P: SSL ack");
 			if (!sbuf_answer(&client->sbuf, "S", 1)) {
@@ -1292,8 +1355,25 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 		}
 		break;
 	case PKT_GSSENCREQ:
-		/* reject GSS encryption attempt */
 		slog_noise(client, "C: req GSS enc");
+#ifdef HAVE_GSSAPI
+		if (client->gss_enc.active || client->sbuf.tls) {
+			disconnect_client(client, false, "GSS enc req inside existing encryption");
+			return false;
+		}
+		if (cf_client_gssencmode > GSSENCMODE_DISABLED && !is_unix) {
+			slog_noise(client, "P: GSS enc ack");
+			if (!sbuf_answer(&client->sbuf, "G", 1)) {
+				disconnect_client(client, false, "failed to ack GSS enc");
+				return false;
+			}
+			if (!sbuf_gss_accept(&client->sbuf)) {
+				disconnect_client(client, false, "GSS enc handshake init failed");
+				return false;
+			}
+			break;
+		}
+#endif
 		if (!sbuf_answer(&client->sbuf, "N", 1)) {
 			disconnect_client(client, false, "failed to nak GSS enc");
 			return false;
@@ -1310,6 +1390,14 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 
+#ifdef HAVE_GSSAPI
+		/* require GSSAPI encryption except on unix socket */
+		if (cf_client_gssencmode >= GSSENCMODE_REQUIRE && !client->gss_enc.active && !is_unix) {
+			disconnect_client(client, true, "GSSAPI encryption required");
+			return false;
+		}
+#endif
+
 		if (client->pool && !sending_auth_query(client)) {
 			disconnect_client(client, true, "client re-sent startup pkt");
 			return false;
@@ -1324,12 +1412,38 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 		}
 
 		break;
-	case PqMsg_PasswordMessage:	/* or SASLInitialResponse, or SASLResponse */
+	case PqMsg_PasswordMessage:	/* or SASLInitialResponse, SASLResponse, GSSResponse */
 		/* too early */
 		if (!client->login_user_credentials) {
 			disconnect_client(client, true, "client password pkt before startup packet");
 			return false;
 		}
+
+#ifdef HAVE_GSSAPI
+		if (client->client_auth_type == AUTH_TYPE_GSSAPI) {
+			/*
+			 * GSSResponse: the message body is a raw binary GSSAPI
+			 * token with no framing (unlike SASL).  Read all available
+			 * bytes as the token.
+			 */
+			unsigned gss_len = mbuf_avail_for_read(&pkt->data);
+			const uint8_t *gss_data;
+
+			if (!mbuf_get_bytes(&pkt->data, gss_len, &gss_data))
+				return false;
+			/*
+			 * On success (exchange complete on a warm pool, or another
+			 * token expected) fall through to consume the packet via the
+			 * common sbuf_prepare_skip below, exactly as the SCRAM path
+			 * does.  A false return means either failure (already
+			 * disconnected) or a pause waiting for the backend, where the
+			 * packet must stay buffered for the resumed login.
+			 */
+			if (!gssapi_accept_continue(client, gss_data, gss_len))
+				return false;
+			break;
+		}
+#endif
 
 		if (client->client_auth_type == AUTH_TYPE_SCRAM_SHA_256) {
 			const char *mech;
@@ -1537,6 +1651,28 @@ static bool handle_client_work(PgSocket *client, PktHdr *pkt)
 			return true;
 		}
 		break;
+
+#ifdef HAVE_GSSAPI
+	/*
+	 * After mutual authentication the client may send one final GSSResponse
+	 * ('p') if its last gss_init_sec_context() emitted a token together with
+	 * GSS_S_COMPLETE (RFC 2744 permits this; it is mechanism-dependent and
+	 * does not occur with standard single-realm MIT Kerberos).  Our context
+	 * is already established, so absorb that one packet silently.  Any
+	 * subsequent 'p' packet (sent_ap_rep already cleared) is an error.
+	 */
+	case PqMsg_PasswordMessage:
+		if (client->gss_state.sent_ap_rep) {
+			slog_debug(client, "GSSAPI: absorbing trailing post-completion GSSResponse token");
+			client->gss_state.sent_ap_rep = false;
+			if (client->packet_cb_state.flag != CB_HANDLE_COMPLETE_PACKET)
+				sbuf_prepare_skip(sbuf, pkt->len);
+			return true;
+		}
+		slog_error(client, "unknown pkt from client: %u/0x%x", pkt->type, pkt->type);
+		disconnect_client(client, true, "unknown pkt");
+		return false;
+#endif
 
 	/* client wants to go away */
 	default:
@@ -1834,6 +1970,7 @@ bool client_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		res = process_pkt_callback(client, data, client_handle_complete_packet);
 		break;
 	case SBUF_EV_TLS_READY:
+	case SBUF_EV_GSS_READY:
 		sbuf_continue(&client->sbuf);
 		res = true;
 		break;

--- a/src/gssapi_auth.c
+++ b/src/gssapi_auth.c
@@ -1,0 +1,1612 @@
+/*
+ * PgBouncer - Lightweight connection pooler for PostgreSQL.
+ *
+ * Copyright (c) 2007-2009  Marko Kreen, Skype Technologies OÜ
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * GSSAPI (Kerberos) authentication support.
+ *
+ * Architecture overview
+ * ---------------------
+ *
+ * Client-side (pgbouncer as GSSAPI acceptor):
+ *   A connecting PostgreSQL client presents a Kerberos ticket.  pgbouncer
+ *   acts as the GSSAPI acceptor: it acquires server credentials from its
+ *   keytab, drives gss_accept_sec_context() to completion, then maps the
+ *   authenticated principal to a local username via gss_localname().  The
+ *   mapped name must exactly match the username the client supplied in the
+ *   startup packet.
+ *
+ * Server-side (pgbouncer as GSSAPI initiator):
+ *   When a PostgreSQL backend requests GSSAPI authentication pgbouncer
+ *   calls gss_init_sec_context() targeting the backend's "postgres@<host>"
+ *   host-based service name.  The pool service account authenticates as
+ *   itself.  No client credentials are forwarded; GSS_C_DELEG_FLAG is
+ *   never requested.
+ *
+ * Username mapping
+ * ----------------
+ * We use gss_localname(), which delegates to the auth_to_local rules in
+ * krb5.conf.  This is the correct, site-policy-respecting approach.  We
+ * deliberately do not implement ad-hoc realm stripping.
+ *
+ * Credential store
+ * ----------------
+ * Acceptor: gss_acquire_cred_from() with an explicit credential store
+ * pointing to auth_gssapi_keytab.  MIT Kerberos reads keys directly from
+ * disk to validate client service tickets.
+ *
+ * Initiator: by default, gss_acquire_cred_from() is called with a NULL
+ * credential store, so MIT Kerberos uses the process's existing credential
+ * cache (KCM, FILE:, or whatever default_ccache_name specifies).  This is
+ * the standard behaviour for any Kerberos client with a live TGT.  If
+ * auth_gssapi_client_keytab is set, that keytab is used instead as an
+ * override for environments without automatic credential management.
+ */
+
+#include "bouncer.h"
+#include "gssapi_auth.h"
+
+#ifdef HAVE_GSSAPI
+
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+
+/*
+ * Initialise the GSSAPI subsystem.  Called once at startup.
+ */
+void gssapi_auth_init(void)
+{
+}
+
+/* --------------------------------------------------------------------------
+ * Internal helpers
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Log both the GSS-layer and mechanism-layer messages for a GSSAPI error.
+ * 'op' is a short string identifying the failing operation for log context.
+ */
+static void log_gss_error(PgSocket *sk, OM_uint32 major, OM_uint32 minor, const char *op)
+{
+	OM_uint32 msg_major, msg_minor;
+	gss_buffer_desc status;
+	OM_uint32 msg_ctx;
+
+	msg_ctx = 0;
+	do {
+		msg_major = gss_display_status(&msg_minor, major, GSS_C_GSS_CODE,
+					       GSS_C_NO_OID, &msg_ctx, &status);
+		if (!GSS_ERROR(msg_major) && status.length > 0) {
+			slog_error(sk, "GSSAPI %s: %.*s",
+				   op, (int)status.length, (char *)status.value);
+			gss_release_buffer(&msg_minor, &status);
+		}
+	} while (!GSS_ERROR(msg_major) && msg_ctx != 0);
+
+	msg_ctx = 0;
+	do {
+		msg_major = gss_display_status(&msg_minor, minor, GSS_C_MECH_CODE,
+					       GSS_C_NO_OID, &msg_ctx, &status);
+		if (!GSS_ERROR(msg_major) && status.length > 0) {
+			slog_error(sk, "GSSAPI %s (mechanism): %.*s",
+				   op, (int)status.length, (char *)status.value);
+			gss_release_buffer(&msg_minor, &status);
+		}
+	} while (!GSS_ERROR(msg_major) && msg_ctx != 0);
+}
+
+/*
+ * Build and send an AuthenticationRequest message to the client containing
+ * a GSSAPI token.  req_type is AUTH_REQ_GSS (7) or AUTH_REQ_GSS_CONT (8).
+ * token/token_len may be NULL/0 for the initial AUTH_REQ_GSS message.
+ */
+static bool send_auth_token_to_client(PgSocket *client, int req_type,
+				      const void *token, size_t token_len)
+{
+	PktBuf *pkt;
+	bool res;
+
+	pkt = pktbuf_dynamic((int)(token_len + 16));
+	if (!pkt) {
+		slog_error(client, "GSSAPI: out of memory for authentication packet");
+		return false;
+	}
+	pktbuf_start_packet(pkt, PqMsg_AuthenticationRequest);
+	pktbuf_put_uint32(pkt, (uint32_t)req_type);
+	if (token && token_len > 0)
+		pktbuf_put_bytes(pkt, token, (int)token_len);
+	pktbuf_finish_packet(pkt);
+	res = pktbuf_send_immediate(pkt, client);
+	pktbuf_free(pkt);
+	return res;
+}
+
+/*
+ * Send a raw binary GSSAPI token to the backend as a GSSResponse ('p').
+ * The entire message body is the token; there is no SASL framing.
+ */
+static bool send_gss_response_to_server(PgSocket *server, const void *token, size_t token_len)
+{
+	PktBuf *pkt;
+	bool res;
+
+	pkt = pktbuf_dynamic((int)(token_len + 8));
+	if (!pkt) {
+		slog_error(server, "GSSAPI: out of memory for GSSResponse packet");
+		return false;
+	}
+	pktbuf_start_packet(pkt, PqMsg_PasswordMessage);
+	pktbuf_put_bytes(pkt, token, (int)token_len);
+	pktbuf_finish_packet(pkt);
+	res = pktbuf_send_immediate(pkt, server);
+	pktbuf_free(pkt);
+	return res;
+}
+
+/* --------------------------------------------------------------------------
+ * Client-side (acceptor): verifying a client's Kerberos ticket
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Release all client-side GSSAPI state.  Safe to call multiple times.
+ */
+void gssapi_accept_cleanup(PgSocket *client)
+{
+	OM_uint32 minor;
+
+	if (client->gss_state.context != GSS_C_NO_CONTEXT) {
+		gss_delete_sec_context(&minor, &client->gss_state.context,
+				       GSS_C_NO_BUFFER);
+		client->gss_state.context = GSS_C_NO_CONTEXT;
+	}
+	if (client->gss_state.creds != GSS_C_NO_CREDENTIAL) {
+		gss_release_cred(&minor, &client->gss_state.creds);
+		client->gss_state.creds = GSS_C_NO_CREDENTIAL;
+	}
+}
+
+/*
+ * Map an authenticated GSSAPI principal to a local username and verify it
+ * matches what the client claimed in the startup packet.
+ *
+ * Uses gss_localname(), which applies auth_to_local rules from krb5.conf.
+ * This is the authoritative mapping function; no ad-hoc realm stripping.
+ *
+ * Logs the authenticated principal regardless of match outcome for auditing.
+ */
+static bool gssapi_map_and_verify_username(PgSocket *client, gss_name_t client_name,
+					   gss_OID mech_type)
+{
+	OM_uint32 major, minor;
+	gss_buffer_desc display = GSS_C_EMPTY_BUFFER;
+	gss_buffer_desc localname = GSS_C_EMPTY_BUFFER;
+	const char *claimed = client->login_user_credentials->name;
+	bool matched = false;
+
+	major = gss_display_name(&minor, client_name, &display, NULL);
+	if (!GSS_ERROR(major)) {
+		if (cf_log_connections) {
+			slog_info(client, "GSSAPI: authenticated principal: %.*s",
+				  (int)display.length, (char *)display.value);
+		}
+		gss_release_buffer(&minor, &display);
+	}
+
+	major = gss_localname(&minor, client_name, mech_type, &localname);
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_localname");
+		slog_error(client, "GSSAPI: principal mapping failed for "
+			   "claimed user \"%s\"", claimed);
+		return false;
+	}
+
+	/*
+	 * Exact match required.  Case folding and other transformations are
+	 * the responsibility of auth_to_local rules in krb5.conf, not of this
+	 * code.
+	 */
+	matched = (localname.length == strlen(claimed) &&
+		   memcmp(localname.value, claimed, localname.length) == 0);
+
+	if (!matched) {
+		slog_error(client, "GSSAPI: local name \"%.*s\" does not match "
+			   "claimed username \"%s\"",
+			   (int)localname.length, (char *)localname.value,
+			   claimed);
+	} else {
+		slog_debug(client, "GSSAPI: principal mapped to local user \"%s\"",
+			   claimed);
+	}
+
+	gss_release_buffer(&minor, &localname);
+	return matched;
+}
+
+/*
+ * Initiate GSSAPI authentication with a connecting client.
+ *
+ * Acquires server credentials from the configured keytab (any principal in
+ * the keytab is accepted; the actual principal is determined by what the
+ * client requests), then sends AuthenticationGSS (AUTH_REQ_GSS = 7) to
+ * prompt the client to begin the exchange.
+ */
+bool gssapi_accept_send_request(PgSocket *client)
+{
+	OM_uint32 major, minor;
+	gss_key_value_element_desc keytab_el;
+	gss_key_value_set_desc keytab_store;
+	const gss_key_value_set_desc *store_ptr = NULL;
+	bool res;
+
+	if (cf_auth_gssapi_keytab && *cf_auth_gssapi_keytab) {
+		keytab_el.key = "keytab";
+		keytab_el.value = cf_auth_gssapi_keytab;
+		keytab_store.count = 1;
+		keytab_store.elements = &keytab_el;
+		store_ptr = &keytab_store;
+	}
+
+	/*
+	 * GSS_C_NO_NAME: accept any principal we can validate with the keytab.
+	 * The GSSAPI library chooses the matching key based on the service
+	 * ticket the client sends.
+	 */
+	major = gss_acquire_cred_from(&minor,
+				      GSS_C_NO_NAME,
+				      GSS_C_INDEFINITE,
+				      GSS_C_NO_OID_SET,
+				      GSS_C_ACCEPT,
+				      store_ptr,
+				      &client->gss_state.creds,
+				      NULL,
+				      NULL);
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_acquire_cred_from (accept)");
+		slog_error(client, "GSSAPI: failed to acquire server credentials%s%s",
+			   store_ptr ? " from keytab " : "",
+			   store_ptr ? cf_auth_gssapi_keytab : "");
+		disconnect_client(client, true, "GSSAPI credential acquisition failed");
+		return false;
+	}
+
+	client->gss_state.context = GSS_C_NO_CONTEXT;
+
+	/* Send AUTH_REQ_GSS (7) with no token; client sends the first token. */
+	res = send_auth_token_to_client(client, AUTH_REQ_GSS, NULL, 0);
+	if (!res) {
+		slog_error(client, "GSSAPI: failed to send authentication request");
+		gssapi_accept_cleanup(client);
+	}
+	return res;
+}
+
+/*
+ * Process a GSSAPI token received from a client (a 'p' / GSSResponse packet).
+ *
+ * Calls gss_accept_sec_context() and handles all outcomes:
+ *   - GSS_S_CONTINUE_NEEDED: sends AUTH_REQ_GSS_CONT with the output token
+ *     and returns true, leaving the connection active for the next round.
+ *   - Context established: maps the principal via gss_localname(), verifies
+ *     it against the claimed username, and calls finish_client_login().
+ *   - Error: disconnects the client and returns false.
+ */
+bool gssapi_accept_continue(PgSocket *client, const uint8_t *token, unsigned token_len)
+{
+	OM_uint32 major, minor;
+	gss_buffer_desc input_token;
+	gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+	gss_name_t client_name = GSS_C_NO_NAME;
+	gss_OID mech_type = GSS_C_NO_OID;
+	bool ok;
+	bool sent_ap_rep = false;
+
+	if (token_len > GSSAPI_MAX_TOKEN_SIZE) {
+		slog_error(client, "GSSAPI: token too large (%u bytes, limit %d)",
+			   token_len, GSSAPI_MAX_TOKEN_SIZE);
+		disconnect_client(client, true, "GSSAPI token too large");
+		return false;
+	}
+
+	input_token.value = (void *)token;
+	input_token.length = token_len;
+
+	/*
+	 * delegated_cred is passed as NULL: we never accept delegated
+	 * credentials.  The pool connects to postgres under its own identity.
+	 */
+	major = gss_accept_sec_context(&minor,
+				       &client->gss_state.context,
+				       client->gss_state.creds,
+				       &input_token,
+				       GSS_C_NO_CHANNEL_BINDINGS,
+				       &client_name,
+				       &mech_type,
+				       &output_token,
+				       NULL,	/* ret_flags - not inspected */
+				       NULL,	/* time_rec */
+				       NULL);	/* delegated_cred - never */
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_accept_sec_context");
+		if (output_token.length > 0)
+			gss_release_buffer(&minor, &output_token);
+		if (client_name != GSS_C_NO_NAME)
+			gss_release_name(&minor, &client_name);
+		gssapi_accept_cleanup(client);
+		disconnect_client(client, true, "GSSAPI authentication failed");
+		return false;
+	}
+
+	/*
+	 * Whether or not the exchange is complete, send any output token the
+	 * library produced (e.g. the AP-REP for mutual authentication).
+	 */
+	if (output_token.length > 0) {
+		bool send_ok = send_auth_token_to_client(client, AUTH_REQ_GSS_CONT,
+							 output_token.value,
+							 output_token.length);
+		gss_release_buffer(&minor, &output_token);
+		if (!send_ok) {
+			slog_error(client, "GSSAPI: failed to send token to client");
+			if (client_name != GSS_C_NO_NAME)
+				gss_release_name(&minor, &client_name);
+			gssapi_accept_cleanup(client);
+			disconnect_client(client, false, "GSSAPI: send failed");
+			return false;
+		}
+		sent_ap_rep = true;
+	}
+
+	if (major & GSS_S_CONTINUE_NEEDED) {
+		/*
+		 * Exchange is not yet complete.  The client will send another
+		 * token; the sbuf will deliver it to gssapi_accept_continue()
+		 * again on the next event.
+		 */
+		if (client_name != GSS_C_NO_NAME)
+			gss_release_name(&minor, &client_name);
+		return true;
+	}
+
+	/* Context fully established.  Map the principal and finish login. */
+	ok = gssapi_map_and_verify_username(client, client_name, mech_type);
+	if (client_name != GSS_C_NO_NAME)
+		gss_release_name(&minor, &client_name);
+
+	gssapi_accept_cleanup(client);
+
+	if (!ok) {
+		disconnect_client(client, true,
+				  "GSSAPI authentication failed: principal mapping error");
+		return false;
+	}
+
+	/*
+	 * When GSS_C_MUTUAL_FLAG is negotiated, gss_accept_sec_context()
+	 * produces an AP-REP output token (sent above as AUTH_REQ_GSS_CONT).
+	 * The client feeds that token to gss_init_sec_context(); RFC 2744
+	 * permits the mechanism to emit a final token together with
+	 * GSS_S_COMPLETE, and when it does libpq forwards it as one more
+	 * GSSResponse ('p') even though our context is already established.
+	 * Standard single-realm MIT Kerberos returns an empty final token
+	 * (no trailing packet), but this is mechanism-dependent, so record
+	 * that we sent an AP-REP and let handle_client_work() absorb the
+	 * extra packet if it arrives rather than rejecting it as unknown.
+	 */
+	client->gss_state.sent_ap_rep = sent_ap_rep;
+
+	return finish_client_login(client);
+}
+
+/* --------------------------------------------------------------------------
+ * Server-side (initiator): connecting to a PostgreSQL backend via Kerberos
+ * -------------------------------------------------------------------------- */
+
+/*
+ * Release all server-side GSSAPI state.  Safe to call multiple times.
+ */
+void gssapi_initiate_cleanup(PgSocket *server)
+{
+	OM_uint32 minor;
+
+	if (server->gss_state.context != GSS_C_NO_CONTEXT) {
+		gss_delete_sec_context(&minor, &server->gss_state.context,
+				       GSS_C_NO_BUFFER);
+		server->gss_state.context = GSS_C_NO_CONTEXT;
+	}
+	if (server->gss_state.creds != GSS_C_NO_CREDENTIAL) {
+		gss_release_cred(&minor, &server->gss_state.creds);
+		server->gss_state.creds = GSS_C_NO_CREDENTIAL;
+	}
+	if (server->gss_state.target_name != GSS_C_NO_NAME) {
+		gss_release_name(&minor, &server->gss_state.target_name);
+		server->gss_state.target_name = GSS_C_NO_NAME;
+	}
+}
+
+/*
+ * Construct the GSSAPI target name for the PostgreSQL service.
+ *
+ * Uses GSS_C_NT_HOSTBASED_SERVICE with name "postgres@<host>".  The GSSAPI
+ * library canonicalises the hostname and appends the default realm, yielding
+ * the SPN postgres/<canonical-host>@REALM that must exist in the KDC.
+ */
+static bool build_target_name(PgSocket *server, gss_name_t *target_name_out)
+{
+	OM_uint32 major, minor;
+	gss_buffer_desc name_buf;
+	const char *host;
+	char *svc_name;
+	size_t svc_len;
+
+	/*
+	 * Use the host actually connected to, not db->host, which may be a
+	 * comma-separated list when load balancing over multiple hosts.  This is
+	 * the same field the TLS path uses for its peer name (sbuf_tls_connect).
+	 */
+	host = server->host;
+	if (!host || !*host) {
+		slog_error(server, "GSSAPI: backend database has no hostname configured; "
+			   "GSSAPI requires a resolvable hostname to construct the "
+			   "service principal");
+		return false;
+	}
+
+	/*
+	 * The service name defaults to "postgres", matching PostgreSQL's
+	 * default krbsrvname.  If the backend uses a non-default krbsrvname
+	 * (set in postgresql.conf), configure auth_gssapi_service_name to
+	 * match.
+	 */
+	{
+		const char *svcname = (cf_auth_gssapi_service_name && *cf_auth_gssapi_service_name)
+				      ? cf_auth_gssapi_service_name : "postgres";
+		svc_len = strlen(svcname) + 1 + strlen(host) + 1;	/* "svcname@host\0" */
+		svc_name = malloc(svc_len);
+		if (!svc_name) {
+			slog_error(server, "GSSAPI: out of memory constructing service name");
+			return false;
+		}
+		snprintf(svc_name, svc_len, "%s@%s", svcname, host);
+	}
+
+	name_buf.value = svc_name;
+	name_buf.length = strlen(svc_name);
+
+	major = gss_import_name(&minor, &name_buf,
+				GSS_C_NT_HOSTBASED_SERVICE, target_name_out);
+	free(svc_name);
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_import_name");
+		return false;
+	}
+	return true;
+}
+
+/*
+ * Begin GSSAPI authentication to a PostgreSQL backend.
+ * Called when the backend sends AuthenticationGSSAPI (AUTH_REQ_GSS = 7).
+ *
+ * Acquires initiator credentials, then sends the first GSSAPI token to the
+ * backend.
+ *
+ * Credential acquisition follows standard Kerberos client behaviour:
+ *   - By default (auth_gssapi_client_keytab unset), store_ptr is NULL and
+ *     gss_acquire_cred_from() uses the default credential cache (KCM, FILE:,
+ *     etc.).  This is the correct mode when the pgbouncer process already has
+ *     a TGT, obtained through any standard mechanism (KCM, kinitd, sssd).
+ *   - If auth_gssapi_client_keytab is set, MIT Kerberos acquires credentials
+ *     directly from the keytab without requiring a pre-existing ccache.  This
+ *     is an override for environments without automatic credential management.
+ *
+ * Only GSS_C_MUTUAL_FLAG is requested.  GSS_C_DELEG_FLAG and
+ * GSS_C_DELEG_POLICY_FLAG are deliberately absent: the pool connects under
+ * its own service-account identity and does not forward any user credential.
+ */
+bool gssapi_initiate_begin(PgSocket *server)
+{
+	OM_uint32 major, minor;
+	gss_key_value_element_desc keytab_el;
+	gss_key_value_set_desc keytab_store;
+	const gss_key_value_set_desc *store_ptr = NULL;
+	gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+
+	if (!build_target_name(server, &server->gss_state.target_name)) {
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI service name error");
+		return false;
+	}
+
+	if (cf_auth_gssapi_client_keytab && *cf_auth_gssapi_client_keytab) {
+		/*
+		 * Explicit keytab override: acquire credentials directly from
+		 * the keytab without a pre-existing ccache.  Only used when
+		 * auth_gssapi_client_keytab is configured.
+		 *
+		 * Note: do NOT fall back to auth_gssapi_keytab here.  That file
+		 * holds the host-based service SPN used to accept client tickets
+		 * (postgres/<pgbouncer-host>@REALM), which is the wrong identity
+		 * for the initiator role.
+		 */
+		keytab_el.key = "client_keytab";
+		keytab_el.value = cf_auth_gssapi_client_keytab;
+		keytab_store.count = 1;
+		keytab_store.elements = &keytab_el;
+		store_ptr = &keytab_store;
+	}
+	/* else store_ptr remains NULL: gss_acquire_cred_from() uses the
+	 * default credential cache (KCM:%{euid}, FILE:, etc.). */
+
+	major = gss_acquire_cred_from(&minor,
+				      GSS_C_NO_NAME,
+				      GSS_C_INDEFINITE,
+				      GSS_C_NO_OID_SET,
+				      GSS_C_INITIATE,
+				      store_ptr,
+				      &server->gss_state.creds,
+				      NULL,
+				      NULL);
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_acquire_cred_from (initiate)");
+		slog_error(server, "GSSAPI: failed to acquire initiator credentials from %s",
+			   store_ptr ? cf_auth_gssapi_client_keytab : "default credential cache");
+		gssapi_initiate_cleanup(server);
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI credential acquisition failed");
+		return false;
+	}
+
+	server->gss_state.context = GSS_C_NO_CONTEXT;
+
+	major = gss_init_sec_context(&minor,
+				     server->gss_state.creds,
+				     &server->gss_state.context,
+				     server->gss_state.target_name,
+				     GSS_C_NO_OID,	/* default mechanism (Kerberos) */
+				     GSS_C_MUTUAL_FLAG,	/* mutual auth; NO delegation */
+				     GSS_C_INDEFINITE,
+				     GSS_C_NO_CHANNEL_BINDINGS,
+				     GSS_C_NO_BUFFER,	/* no input on first call */
+				     NULL,
+				     &output_token,
+				     NULL,
+				     NULL);
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_init_sec_context (initial)");
+		if (output_token.length > 0)
+			gss_release_buffer(&minor, &output_token);
+		gssapi_initiate_cleanup(server);
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI context initialization failed");
+		return false;
+	}
+
+	if (output_token.length == 0) {
+		slog_error(server, "GSSAPI: gss_init_sec_context produced no token "
+			   "on first call; this is unexpected for Kerberos");
+		gssapi_initiate_cleanup(server);
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI produced no initial token");
+		return false;
+	}
+
+	slog_debug(server, "GSSAPI: sending initial token to backend (%zu bytes)",
+		   output_token.length);
+
+	if (!send_gss_response_to_server(server, output_token.value,
+					 output_token.length)) {
+		slog_error(server, "GSSAPI: failed to send initial token to backend");
+		gss_release_buffer(&minor, &output_token);
+		gssapi_initiate_cleanup(server);
+		return false;
+	}
+	gss_release_buffer(&minor, &output_token);
+
+	/* Unlikely for Kerberos, but handle single-round completion. */
+	if (!(major & GSS_S_CONTINUE_NEEDED)) {
+		slog_debug(server, "GSSAPI: context established in one round");
+		gssapi_initiate_cleanup(server);
+	}
+
+	return true;
+}
+
+/*
+ * Continue GSSAPI authentication to a PostgreSQL backend.
+ * Called when the backend sends AuthenticationGSSContinue (AUTH_REQ_GSS_CONT = 8).
+ */
+bool gssapi_initiate_continue(PgSocket *server, const uint8_t *token, unsigned token_len)
+{
+	OM_uint32 major, minor;
+	gss_buffer_desc input_token;
+	gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+
+	if (server->gss_state.context == GSS_C_NO_CONTEXT) {
+		slog_error(server, "GSSAPI: received AUTH_REQ_GSS_CONT but context "
+			   "is not in progress; protocol error");
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: unexpected GSSAPI continuation");
+		return false;
+	}
+
+	if (token_len > GSSAPI_MAX_TOKEN_SIZE) {
+		slog_error(server, "GSSAPI: backend token too large (%u bytes, limit %d)",
+			   token_len, GSSAPI_MAX_TOKEN_SIZE);
+		gssapi_initiate_cleanup(server);
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI token too large");
+		return false;
+	}
+
+	input_token.value = (void *)token;
+	input_token.length = token_len;
+
+	major = gss_init_sec_context(&minor,
+				     server->gss_state.creds,
+				     &server->gss_state.context,
+				     server->gss_state.target_name,
+				     GSS_C_NO_OID,
+				     GSS_C_MUTUAL_FLAG,	/* consistent; no delegation */
+				     GSS_C_INDEFINITE,
+				     GSS_C_NO_CHANNEL_BINDINGS,
+				     &input_token,
+				     NULL,
+				     &output_token,
+				     NULL,
+				     NULL);
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_init_sec_context (continuation)");
+		if (output_token.length > 0)
+			gss_release_buffer(&minor, &output_token);
+		gssapi_initiate_cleanup(server);
+		kill_pool_logins(server->pool, NULL,
+				 "server login failed: GSSAPI context establishment failed");
+		return false;
+	}
+
+	if (output_token.length > 0) {
+		slog_debug(server, "GSSAPI: sending continuation token to backend "
+			   "(%zu bytes)", output_token.length);
+		if (!send_gss_response_to_server(server, output_token.value,
+						 output_token.length)) {
+			slog_error(server, "GSSAPI: failed to send continuation token");
+			gss_release_buffer(&minor, &output_token);
+			gssapi_initiate_cleanup(server);
+			return false;
+		}
+		gss_release_buffer(&minor, &output_token);
+	}
+
+	if (!(major & GSS_S_CONTINUE_NEEDED)) {
+		slog_debug(server, "GSSAPI: context established with backend");
+		gssapi_initiate_cleanup(server);
+	}
+
+	return true;
+}
+
+/* --------------------------------------------------------------------------
+ * GSSAPI encryption: wrap/unwrap for the sbuf I/O layer
+ * --------------------------------------------------------------------------
+ *
+ * These functions mirror be_gssapi_read() / be_gssapi_write() from the
+ * postgres source (be-secure-gssapi.c).  The framing is:
+ *   [uint32 wrapped_length (network byte order)] [gss_wrap() output]
+ *
+ * gss_unwrap() requires the complete wrapped token; partial input is
+ * accumulated in gss_enc.recv_buf across calls.
+ */
+
+/*
+ * Decrypt data from the GSS-encrypted stream.
+ * Returns bytes of plaintext delivered, or -1 with errno set.
+ */
+ssize_t gssenc_recv(PgSocket *sk, void *buf, size_t len)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	OM_uint32 major, minor;
+	gss_buffer_desc input, output = GSS_C_EMPTY_BUFFER;
+	int conf_state;
+	int bytes_returned = 0;
+	ssize_t ret;
+	int raw_sock = sk->sbuf.sock;
+
+	while ((size_t)bytes_returned < len) {
+		int avail;
+
+		/* return any buffered decrypted data */
+		if (enc->result_next < enc->result_len) {
+			avail = enc->result_len - enc->result_next;
+			if (avail > (int)(len - bytes_returned))
+				avail = (int)(len - bytes_returned);
+			memcpy((char *)buf + bytes_returned,
+			       enc->result_buf + enc->result_next, avail);
+			enc->result_next += avail;
+			bytes_returned += avail;
+			break;
+		}
+
+		enc->result_len = enc->result_next = 0;
+		if (bytes_returned > 0)
+			break;
+
+		/* read 4-byte length header */
+		if (enc->recv_len < (int)sizeof(uint32_t)) {
+			ret = recv(raw_sock,
+				   enc->recv_buf + enc->recv_len,
+				   sizeof(uint32_t) - enc->recv_len, 0);
+			if (ret <= 0) {
+				if (ret == 0) {
+					errno = ECONNRESET;
+					return -1;
+				}
+				if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+					errno = EAGAIN;
+					return bytes_returned > 0 ? bytes_returned : -1;
+				}
+				return -1;
+			}
+			enc->recv_len += ret;
+			if (enc->recv_len < (int)sizeof(uint32_t)) {
+				errno = EAGAIN;
+				return -1;
+			}
+		}
+
+		/* decode and validate length */
+		{
+			uint32_t pktlen;
+			memcpy(&pktlen, enc->recv_buf, sizeof(uint32_t));
+			pktlen = ntohl(pktlen);
+			if (pktlen > PQ_GSS_MAX_PACKET_SIZE - sizeof(uint32_t)) {
+				slog_error(sk, "GSSAPI: encrypted packet too large (%u bytes)",
+					   pktlen);
+				errno = ECONNRESET;
+				return -1;
+			}
+			enc->pkt_expected = (int)pktlen;
+		}
+
+		/* read encrypted payload */
+		{
+			int need = enc->pkt_expected - (enc->recv_len - (int)sizeof(uint32_t));
+			if (need > 0) {
+				ret = recv(raw_sock,
+					   enc->recv_buf + enc->recv_len,
+					   need, 0);
+				if (ret <= 0) {
+					if (ret == 0) {
+						errno = ECONNRESET;
+						return -1;
+					}
+					if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+						errno = EAGAIN;
+						return bytes_returned > 0 ? bytes_returned : -1;
+					}
+					return -1;
+				}
+				enc->recv_len += ret;
+				if (enc->recv_len - (int)sizeof(uint32_t) < enc->pkt_expected) {
+					errno = EAGAIN;
+					return -1;
+				}
+			}
+		}
+
+		/* decrypt the complete packet */
+		input.value = enc->recv_buf + sizeof(uint32_t);
+		input.length = enc->pkt_expected;
+
+		major = gss_unwrap(&minor, enc->ctx, &input, &output,
+				   &conf_state, NULL);
+		if (GSS_ERROR(major)) {
+			log_gss_error(sk, major, minor, "gss_unwrap");
+			if (output.length > 0)
+				gss_release_buffer(&minor, &output);
+			errno = ECONNRESET;
+			return -1;
+		}
+		if (conf_state == 0) {
+			slog_error(sk, "GSSAPI: incoming message did not use confidentiality");
+			gss_release_buffer(&minor, &output);
+			errno = ECONNRESET;
+			return -1;
+		}
+
+		memcpy(enc->result_buf, output.value, output.length);
+		enc->result_len = output.length;
+		enc->result_next = 0;
+		enc->recv_len = 0;
+		gss_release_buffer(&minor, &output);
+	}
+
+	return bytes_returned;
+}
+
+/*
+ * Encrypt and send data over the GSS-encrypted stream.
+ * Returns bytes of plaintext consumed, or -1 with errno set.
+ */
+ssize_t gssenc_send(PgSocket *sk, const void *buf, size_t len)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	OM_uint32 major, minor;
+	gss_buffer_desc input, output = GSS_C_EMPTY_BUFFER;
+	int conf_state;
+	int bytes_encrypted = enc->send_consumed;
+	int bytes_to_encrypt = (int)len - bytes_encrypted;
+	ssize_t ret;
+	int raw_sock = sk->sbuf.sock;
+
+	if ((int)len < enc->send_consumed) {
+		slog_error(sk, "GSSAPI: send retry with fewer bytes than consumed");
+		errno = EINVAL;
+		return -1;
+	}
+
+	while (bytes_to_encrypt > 0 || enc->send_len > 0) {
+		/* flush any pending encrypted data */
+		while (enc->send_next < enc->send_len) {
+			ret = send(raw_sock,
+				   enc->send_buf + enc->send_next,
+				   enc->send_len - enc->send_next, 0);
+			if (ret <= 0) {
+				if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+					enc->send_consumed = bytes_encrypted;
+					errno = EAGAIN;
+					return -1;
+				}
+				return -1;
+			}
+			enc->send_next += ret;
+		}
+		enc->send_len = enc->send_next = 0;
+
+		if (bytes_to_encrypt <= 0)
+			break;
+
+		/* chunk plaintext and encrypt */
+		input.length = bytes_to_encrypt;
+		if (input.length > enc->max_pkt_size)
+			input.length = enc->max_pkt_size;
+		input.value = (char *)buf + bytes_encrypted;
+
+		major = gss_wrap(&minor, enc->ctx, 1, GSS_C_QOP_DEFAULT,
+				 &input, &conf_state, &output);
+		if (GSS_ERROR(major)) {
+			log_gss_error(sk, major, minor, "gss_wrap");
+			if (output.length > 0)
+				gss_release_buffer(&minor, &output);
+			errno = ECONNRESET;
+			return -1;
+		}
+		if (conf_state == 0) {
+			slog_error(sk, "GSSAPI: outgoing message would not use confidentiality");
+			gss_release_buffer(&minor, &output);
+			errno = ECONNRESET;
+			return -1;
+		}
+		if (output.length > PQ_GSS_MAX_PACKET_SIZE - sizeof(uint32_t)) {
+			slog_error(sk, "GSSAPI: wrapped output too large (%zu bytes)",
+				   output.length);
+			gss_release_buffer(&minor, &output);
+			errno = ECONNRESET;
+			return -1;
+		}
+
+		/* frame: [uint32 length][encrypted payload] */
+		{
+			uint32_t netlen = htonl((uint32_t)output.length);
+			memcpy(enc->send_buf, &netlen, sizeof(uint32_t));
+			enc->send_len = sizeof(uint32_t);
+			memcpy(enc->send_buf + enc->send_len, output.value, output.length);
+			enc->send_len += output.length;
+			enc->send_next = 0;
+		}
+
+		bytes_encrypted += input.length;
+		bytes_to_encrypt -= input.length;
+		gss_release_buffer(&minor, &output);
+	}
+
+	enc->send_consumed = 0;
+	return bytes_encrypted;
+}
+
+/*
+ * Allocate GSS encryption buffers for the handshake phase.
+ * send/recv/result are allocated at the given size; hs_buf is
+ * always allocated at PQ_GSS_AUTH_BUFFER_SIZE.
+ */
+static bool gssenc_alloc_buffers(struct GssEncState *enc, int size)
+{
+	free(enc->send_buf);
+	free(enc->recv_buf);
+	free(enc->result_buf);
+	enc->send_buf = malloc(size);
+	enc->recv_buf = malloc(size);
+	enc->result_buf = malloc(size);
+	if (!enc->send_buf || !enc->recv_buf || !enc->result_buf) {
+		free(enc->send_buf);
+		free(enc->recv_buf);
+		free(enc->result_buf);
+		enc->send_buf = enc->recv_buf = enc->result_buf = NULL;
+		return false;
+	}
+	enc->send_len = enc->send_next = enc->send_consumed = 0;
+	enc->recv_len = 0;
+	enc->result_len = enc->result_next = 0;
+	enc->pkt_expected = 0;
+	enc->hs_want = GSSENC_HS_READ;
+	enc->hs_complete_pending = false;
+
+	free(enc->hs_buf);
+	enc->hs_buf = malloc(PQ_GSS_AUTH_BUFFER_SIZE);
+	if (!enc->hs_buf) {
+		free(enc->send_buf);
+		free(enc->recv_buf);
+		free(enc->result_buf);
+		enc->send_buf = enc->recv_buf = enc->result_buf = NULL;
+		return false;
+	}
+	enc->hs_len = 0;
+	return true;
+}
+
+/*
+ * Resize send/recv/result buffers for the data phase
+ * (PQ_GSS_MAX_PACKET_SIZE).  Called at handshake completion after
+ * hs_buf has been freed.
+ */
+static bool gssenc_realloc_data_buffers(struct GssEncState *enc)
+{
+	free(enc->send_buf);
+	free(enc->recv_buf);
+	free(enc->result_buf);
+	enc->send_buf = malloc(PQ_GSS_MAX_PACKET_SIZE);
+	enc->recv_buf = malloc(PQ_GSS_MAX_PACKET_SIZE);
+	enc->result_buf = malloc(PQ_GSS_MAX_PACKET_SIZE);
+	if (!enc->send_buf || !enc->recv_buf || !enc->result_buf) {
+		free(enc->send_buf);
+		free(enc->recv_buf);
+		free(enc->result_buf);
+		enc->send_buf = enc->recv_buf = enc->result_buf = NULL;
+		return false;
+	}
+	enc->send_len = enc->send_next = enc->send_consumed = 0;
+	enc->recv_len = 0;
+	enc->result_len = enc->result_next = 0;
+	enc->pkt_expected = 0;
+	return true;
+}
+
+/*
+ * Release all GSS encryption state.
+ */
+void gssenc_cleanup(PgSocket *sk)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	OM_uint32 minor;
+
+	if (enc->ctx != GSS_C_NO_CONTEXT) {
+		gss_delete_sec_context(&minor, &enc->ctx, GSS_C_NO_BUFFER);
+		enc->ctx = GSS_C_NO_CONTEXT;
+	}
+	if (enc->creds != GSS_C_NO_CREDENTIAL) {
+		gss_release_cred(&minor, &enc->creds);
+		enc->creds = GSS_C_NO_CREDENTIAL;
+	}
+	if (enc->target_name != GSS_C_NO_NAME) {
+		gss_release_name(&minor, &enc->target_name);
+		enc->target_name = GSS_C_NO_NAME;
+	}
+	free(enc->send_buf);
+	free(enc->recv_buf);
+	free(enc->result_buf);
+	free(enc->hs_buf);
+	enc->send_buf = enc->recv_buf = enc->result_buf = enc->hs_buf = NULL;
+	enc->active = false;
+}
+
+/*
+ * Start accepting a GSS-encrypted connection from a client.
+ * Allocates buffers and acquires acceptor credentials.
+ */
+bool gssenc_accept_start(PgSocket *client)
+{
+	OM_uint32 major, minor;
+	gss_key_value_element_desc keytab_el;
+	gss_key_value_set_desc keytab_store;
+	const gss_key_value_set_desc *store_ptr = NULL;
+	struct GssEncState *enc = &client->gss_enc;
+
+	if (!gssenc_alloc_buffers(enc, PQ_GSS_AUTH_BUFFER_SIZE))
+		return false;
+	enc->ctx = GSS_C_NO_CONTEXT;
+	enc->active = false;
+
+	/* acquire acceptor credentials from keytab */
+	if (cf_auth_gssapi_keytab && *cf_auth_gssapi_keytab) {
+		keytab_el.key = "keytab";
+		keytab_el.value = cf_auth_gssapi_keytab;
+		keytab_store.count = 1;
+		keytab_store.elements = &keytab_el;
+		store_ptr = &keytab_store;
+	}
+
+	major = gss_acquire_cred_from(&minor, GSS_C_NO_NAME,
+				      GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
+				      GSS_C_ACCEPT, store_ptr,
+				      &enc->creds, NULL, NULL);
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_acquire_cred_from (enc accept)");
+		gssenc_cleanup(client);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+ * Frame [uint32 length][token] into send_buf for a non-blocking flush.
+ * During the handshake send_buf is PQ_GSS_AUTH_BUFFER_SIZE bytes, matching the
+ * maximum token size accepted on read, so any legitimate token fits.
+ */
+static bool gssenc_hs_queue(PgSocket *sk, gss_buffer_desc *tok)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	uint32_t netlen;
+
+	if (tok->length > PQ_GSS_AUTH_BUFFER_SIZE - sizeof(uint32_t)) {
+		slog_error(sk, "GSSAPI enc: output token too large (%zu bytes)", tok->length);
+		return false;
+	}
+	netlen = htonl((uint32_t)tok->length);
+	memcpy(enc->send_buf, &netlen, sizeof(uint32_t));
+	memcpy(enc->send_buf + sizeof(uint32_t), tok->value, tok->length);
+	enc->send_len = (int)(sizeof(uint32_t) + tok->length);
+	enc->send_next = 0;
+	return true;
+}
+
+/*
+ * Flush a queued handshake token, non-blocking.
+ * Returns 1 when fully sent, 0 when the socket would block (caller must re-arm
+ * EV_WRITE and resume later), -1 on a fatal error.
+ */
+static int gssenc_hs_flush(PgSocket *sk)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	int raw_sock = sk->sbuf.sock;
+	ssize_t ret;
+
+	while (enc->send_next < enc->send_len) {
+		ret = send(raw_sock, enc->send_buf + enc->send_next,
+			   enc->send_len - enc->send_next, 0);
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				return 0;
+			return -1;
+		}
+		enc->send_next += ret;
+	}
+	enc->send_len = enc->send_next = 0;
+	return 1;
+}
+
+/*
+ * The context is established and its final token has been fully sent: free the
+ * handshake buffer, size the data buffers, and switch the socket to the
+ * encrypted data phase.  Shared by the acceptor and initiator.
+ */
+static bool gssenc_hs_transition(PgSocket *sk, const char *role)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	OM_uint32 major, minor;
+
+	free(enc->hs_buf);
+	enc->hs_buf = NULL;
+
+	if (!gssenc_realloc_data_buffers(enc))
+		return false;
+
+	major = gss_wrap_size_limit(&minor, enc->ctx, 1, GSS_C_QOP_DEFAULT,
+				    PQ_GSS_MAX_PACKET_SIZE - sizeof(uint32_t),
+				    &enc->max_pkt_size);
+	if (GSS_ERROR(major)) {
+		log_gss_error(sk, major, minor, "gss_wrap_size_limit");
+		return false;
+	}
+
+	enc->active = true;
+	if (cf_log_connections)
+		slog_info(sk, "GSSAPI: encrypted channel established (%s)", role);
+	return true;
+}
+
+/*
+ * Accumulate one framed [uint32 length][token] handshake message into hs_buf
+ * across event-driven reads.  Returns 1 when a whole token is available (input
+ * then points into hs_buf), 0 when more data is needed (wait for EV_READ), or
+ * -1 on error.
+ */
+static int gssenc_hs_read_token(PgSocket *sk, gss_buffer_desc *input)
+{
+	struct GssEncState *enc = &sk->gss_enc;
+	int raw_sock = sk->sbuf.sock;
+	ssize_t ret;
+
+	while (enc->hs_len < (int)sizeof(uint32_t)) {
+		ret = recv(raw_sock, enc->hs_buf + enc->hs_len,
+			   sizeof(uint32_t) - enc->hs_len, 0);
+		if (ret <= 0) {
+			if (ret == 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
+				slog_error(sk, "GSSAPI enc: handshake read failed");
+				return -1;
+			}
+			return 0;
+		}
+		enc->hs_len += ret;
+	}
+
+	if (enc->pkt_expected == 0) {
+		uint32_t pktlen;
+		memcpy(&pktlen, enc->hs_buf, sizeof(uint32_t));
+		pktlen = ntohl(pktlen);
+		if (pktlen > PQ_GSS_AUTH_BUFFER_SIZE - sizeof(uint32_t)) {
+			slog_error(sk, "GSSAPI enc: handshake token too large (%u)", pktlen);
+			return -1;
+		}
+		enc->pkt_expected = (int)pktlen;
+	}
+
+	{
+		int need = enc->pkt_expected - (enc->hs_len - (int)sizeof(uint32_t));
+		while (need > 0) {
+			ret = recv(raw_sock, enc->hs_buf + enc->hs_len, need, 0);
+			if (ret <= 0) {
+				if (ret == 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
+					slog_error(sk, "GSSAPI enc: handshake read failed");
+					return -1;
+				}
+				return 0;
+			}
+			enc->hs_len += ret;
+			need -= ret;
+		}
+	}
+
+	input->value = enc->hs_buf + sizeof(uint32_t);
+	input->length = enc->pkt_expected;
+	return 1;
+}
+
+/*
+ * Process one round of the GSS encryption handshake for the acceptor.
+ * Returns true if more data is expected or handshake is complete.
+ * Returns false on error.
+ *
+ * Event-driven: each call either consumes the peer's next token (EV_READ) or
+ * resumes flushing our own output token (EV_WRITE).  gss_enc.hs_want tells the
+ * sbuf layer which event to wait on next.
+ */
+bool gssenc_accept_handshake(PgSocket *client)
+{
+	struct GssEncState *enc = &client->gss_enc;
+	OM_uint32 major, minor;
+	gss_buffer_desc input, output = GSS_C_EMPTY_BUFFER;
+	int fr;
+
+	/* Resume flushing a token that was only partially sent on a prior call. */
+	if (enc->send_len > 0) {
+		fr = gssenc_hs_flush(client);
+		if (fr < 0) {
+			slog_error(client, "GSSAPI enc: handshake write failed");
+			return false;
+		}
+		if (fr == 0) {
+			enc->hs_want = GSSENC_HS_WRITE;
+			return true;
+		}
+		if (enc->hs_complete_pending)
+			return gssenc_hs_transition(client, "acceptor");
+		enc->hs_want = GSSENC_HS_READ;
+		return true;
+	}
+
+	/* Read the client's next token. */
+	enc->hs_want = GSSENC_HS_READ;
+	fr = gssenc_hs_read_token(client, &input);
+	if (fr < 0)
+		return false;
+	if (fr == 0)
+		return true;	/* need more data */
+
+	major = gss_accept_sec_context(&minor, &enc->ctx, enc->creds,
+				       &input, GSS_C_NO_CHANNEL_BINDINGS,
+				       NULL, NULL, &output, NULL, NULL, NULL);
+
+	enc->hs_len = 0;
+	enc->pkt_expected = 0;
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_accept_sec_context (enc)");
+		if (output.length > 0)
+			gss_release_buffer(&minor, &output);
+		return false;
+	}
+
+	enc->hs_complete_pending = !(major & GSS_S_CONTINUE_NEEDED);
+
+	if (output.length > 0) {
+		bool queued = gssenc_hs_queue(client, &output);
+		gss_release_buffer(&minor, &output);
+		if (!queued)
+			return false;
+		fr = gssenc_hs_flush(client);
+		if (fr < 0) {
+			slog_error(client, "GSSAPI enc: handshake write failed");
+			return false;
+		}
+		if (fr == 0) {
+			enc->hs_want = GSSENC_HS_WRITE;
+			return true;
+		}
+	}
+
+	if (enc->hs_complete_pending)
+		return gssenc_hs_transition(client, "acceptor");
+
+	enc->hs_want = GSSENC_HS_READ;
+	return true;
+}
+
+/*
+ * Start a GSS-encrypted connection to a backend server.
+ */
+bool gssenc_have_initiator_cred(PgSocket *server)
+{
+	OM_uint32 major, minor;
+	gss_key_value_element_desc keytab_el;
+	gss_key_value_set_desc keytab_store;
+	const gss_key_value_set_desc *store_ptr = NULL;
+	gss_cred_id_t creds = GSS_C_NO_CREDENTIAL;
+
+	if (cf_auth_gssapi_client_keytab && *cf_auth_gssapi_client_keytab) {
+		keytab_el.key = "client_keytab";
+		keytab_el.value = cf_auth_gssapi_client_keytab;
+		keytab_store.count = 1;
+		keytab_store.elements = &keytab_el;
+		store_ptr = &keytab_store;
+	}
+
+	major = gss_acquire_cred_from(&minor, GSS_C_NO_NAME, GSS_C_INDEFINITE,
+				      GSS_C_NO_OID_SET, GSS_C_INITIATE,
+				      store_ptr, &creds, NULL, NULL);
+	if (GSS_ERROR(major))
+		return false;
+
+	gss_release_cred(&minor, &creds);
+	return true;
+}
+
+bool gssenc_connect_start(PgSocket *server)
+{
+	struct GssEncState *enc = &server->gss_enc;
+	OM_uint32 major, minor;
+	gss_key_value_element_desc keytab_el;
+	gss_key_value_set_desc keytab_store;
+	const gss_key_value_set_desc *store_ptr = NULL;
+	gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
+	bool queued;
+	int fr;
+
+	if (!gssenc_alloc_buffers(enc, PQ_GSS_AUTH_BUFFER_SIZE))
+		return false;
+	enc->ctx = GSS_C_NO_CONTEXT;
+	enc->active = false;
+
+	/* acquire initiator credentials */
+	if (cf_auth_gssapi_client_keytab && *cf_auth_gssapi_client_keytab) {
+		keytab_el.key = "client_keytab";
+		keytab_el.value = cf_auth_gssapi_client_keytab;
+		keytab_store.count = 1;
+		keytab_store.elements = &keytab_el;
+		store_ptr = &keytab_store;
+	}
+
+	major = gss_acquire_cred_from(&minor, GSS_C_NO_NAME,
+				      GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
+				      GSS_C_INITIATE, store_ptr,
+				      &enc->creds, NULL, NULL);
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_acquire_cred_from (enc initiate)");
+		gssenc_cleanup(server);
+		return false;
+	}
+
+	if (!build_target_name(server, &enc->target_name)) {
+		gssenc_cleanup(server);
+		return false;
+	}
+
+	/* first gss_init_sec_context call */
+	{
+		OM_uint32 gss_flags = GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG |
+				      GSS_C_SEQUENCE_FLAG | GSS_C_CONF_FLAG |
+				      GSS_C_INTEG_FLAG;
+
+		major = gss_init_sec_context(&minor, enc->creds, &enc->ctx,
+					     enc->target_name, GSS_C_NO_OID,
+					     gss_flags, GSS_C_INDEFINITE,
+					     GSS_C_NO_CHANNEL_BINDINGS,
+					     GSS_C_NO_BUFFER, NULL,
+					     &output, NULL, NULL);
+	}
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_init_sec_context (enc initial)");
+		if (output.length > 0)
+			gss_release_buffer(&minor, &output);
+		gssenc_cleanup(server);
+		return false;
+	}
+
+	if (output.length == 0) {
+		slog_error(server, "GSSAPI enc: gss_init_sec_context produced no token "
+			   "on first call; this is unexpected for Kerberos");
+		gssenc_cleanup(server);
+		return false;
+	}
+
+	/*
+	 * Queue the first token and flush it non-blocking.  A partial write leaves
+	 * the remainder buffered and asks the sbuf layer to re-arm EV_WRITE; the
+	 * first token never completes the context, so hs_complete_pending stays false.
+	 */
+	queued = gssenc_hs_queue(server, &output);
+	gss_release_buffer(&minor, &output);
+	if (!queued) {
+		gssenc_cleanup(server);
+		return false;
+	}
+	enc->hs_complete_pending = false;
+	fr = gssenc_hs_flush(server);
+	if (fr < 0) {
+		gssenc_cleanup(server);
+		return false;
+	}
+	enc->hs_want = (fr == 0) ? GSSENC_HS_WRITE : GSSENC_HS_READ;
+	return true;
+}
+
+/*
+ * Continue the GSS encryption handshake for the initiator.
+ */
+bool gssenc_connect_handshake(PgSocket *server)
+{
+	struct GssEncState *enc = &server->gss_enc;
+	OM_uint32 major, minor;
+	gss_buffer_desc input, output = GSS_C_EMPTY_BUFFER;
+	OM_uint32 gss_flags = GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG |
+			      GSS_C_SEQUENCE_FLAG | GSS_C_CONF_FLAG |
+			      GSS_C_INTEG_FLAG;
+	int fr;
+
+	/* Resume flushing a token that was only partially sent on a prior call. */
+	if (enc->send_len > 0) {
+		fr = gssenc_hs_flush(server);
+		if (fr < 0)
+			return false;
+		if (fr == 0) {
+			enc->hs_want = GSSENC_HS_WRITE;
+			return true;
+		}
+		if (enc->hs_complete_pending)
+			return gssenc_hs_transition(server, "initiator");
+		enc->hs_want = GSSENC_HS_READ;
+		return true;
+	}
+
+	/* Read the backend's next token. */
+	enc->hs_want = GSSENC_HS_READ;
+	fr = gssenc_hs_read_token(server, &input);
+	if (fr < 0)
+		return false;
+	if (fr == 0)
+		return true;	/* need more data */
+
+	major = gss_init_sec_context(&minor, enc->creds, &enc->ctx,
+				     enc->target_name, GSS_C_NO_OID,
+				     gss_flags, GSS_C_INDEFINITE,
+				     GSS_C_NO_CHANNEL_BINDINGS,
+				     &input, NULL, &output, NULL, NULL);
+
+	enc->hs_len = 0;
+	enc->pkt_expected = 0;
+
+	if (GSS_ERROR(major)) {
+		log_gss_error(server, major, minor, "gss_init_sec_context (enc continue)");
+		if (output.length > 0)
+			gss_release_buffer(&minor, &output);
+		return false;
+	}
+
+	enc->hs_complete_pending = !(major & GSS_S_CONTINUE_NEEDED);
+
+	if (output.length > 0) {
+		bool queued = gssenc_hs_queue(server, &output);
+		gss_release_buffer(&minor, &output);
+		if (!queued)
+			return false;
+		fr = gssenc_hs_flush(server);
+		if (fr < 0)
+			return false;
+		if (fr == 0) {
+			enc->hs_want = GSSENC_HS_WRITE;
+			return true;
+		}
+	}
+
+	if (enc->hs_complete_pending)
+		return gssenc_hs_transition(server, "initiator");
+
+	enc->hs_want = GSSENC_HS_READ;
+	return true;
+}
+
+/*
+ * Extract the client principal from a GSS encryption context and verify
+ * it against the claimed username.  Used when GSS encryption is active
+ * to skip the separate AUTH_REQ_GSS exchange.
+ */
+bool gssenc_extract_and_verify_identity(PgSocket *client)
+{
+	struct GssEncState *enc = &client->gss_enc;
+	OM_uint32 major, minor;
+	gss_name_t client_name = GSS_C_NO_NAME;
+	gss_OID mech_type = GSS_C_NO_OID;
+
+	major = gss_inquire_context(&minor, enc->ctx, &client_name,
+				    NULL, NULL, &mech_type, NULL, NULL, NULL);
+	if (GSS_ERROR(major)) {
+		log_gss_error(client, major, minor, "gss_inquire_context");
+		return false;
+	}
+
+	{
+		bool ok = gssapi_map_and_verify_username(client, client_name,
+							 mech_type);
+		gss_release_name(&minor, &client_name);
+		if (!ok) {
+			disconnect_client(client, true,
+					  "GSSAPI enc: principal mapping error");
+			return false;
+		}
+	}
+
+	return finish_client_login(client);
+}
+
+#else /* !HAVE_GSSAPI */
+
+void gssapi_auth_init(void)
+{
+}
+
+bool gssapi_accept_send_request(PgSocket *client)
+{
+	disconnect_client(client, true,
+			  "GSSAPI authentication is not supported in this build");
+	return false;
+}
+
+bool gssapi_accept_continue(PgSocket *client, const uint8_t *token, unsigned token_len)
+{
+	(void)token;
+	(void)token_len;
+	disconnect_client(client, true,
+			  "GSSAPI authentication is not supported in this build");
+	return false;
+}
+
+void gssapi_accept_cleanup(PgSocket *client)
+{
+}
+
+bool gssapi_initiate_begin(PgSocket *server)
+{
+	slog_error(server, "GSSAPI is not supported in this build");
+	kill_pool_logins(server->pool, NULL,
+			 "server login failed: GSSAPI not supported in this build");
+	return false;
+}
+
+bool gssapi_initiate_continue(PgSocket *server, const uint8_t *token, unsigned token_len)
+{
+	(void)token;
+	(void)token_len;
+	kill_pool_logins(server->pool, NULL,
+			 "server login failed: GSSAPI not supported in this build");
+	return false;
+}
+
+void gssapi_initiate_cleanup(PgSocket *server)
+{
+}
+
+ssize_t gssenc_recv(PgSocket *sk, void *buf, size_t len)
+{
+	(void)sk; (void)buf; (void)len;
+	errno = ECONNRESET;
+	return -1;
+}
+
+ssize_t gssenc_send(PgSocket *sk, const void *buf, size_t len)
+{
+	(void)sk; (void)buf; (void)len;
+	errno = ECONNRESET;
+	return -1;
+}
+
+bool gssenc_accept_start(PgSocket *client)
+{
+	disconnect_client(client, true, "GSSAPI encryption not supported in this build");
+	return false;
+}
+
+bool gssenc_accept_handshake(PgSocket *client)
+{
+	(void)client;
+	return false;
+}
+
+bool gssenc_have_initiator_cred(PgSocket *server)
+{
+	(void)server;
+	return false;
+}
+
+bool gssenc_connect_start(PgSocket *server)
+{
+	(void)server;
+	return false;
+}
+
+bool gssenc_connect_handshake(PgSocket *server)
+{
+	(void)server;
+	return false;
+}
+
+void gssenc_cleanup(PgSocket *sk)
+{
+	(void)sk;
+}
+
+bool gssenc_extract_and_verify_identity(PgSocket *client)
+{
+	disconnect_client(client, true, "GSSAPI encryption not supported in this build");
+	return false;
+}
+
+#endif /* HAVE_GSSAPI */

--- a/src/hba.c
+++ b/src/hba.c
@@ -774,6 +774,10 @@ static bool parse_line(struct HBA *hba, struct Ident *ident, struct TokParser *t
 		rule->rule_method = AUTH_TYPE_SCRAM_SHA_256;
 	} else if (check_kw(tp, "ldap")) {
 		rule->rule_method = AUTH_TYPE_LDAP;
+#ifdef HAVE_GSSAPI
+	} else if (eat_kw(tp, "gssapi")) {
+		rule->rule_method = AUTH_TYPE_GSSAPI;
+#endif
 	} else {
 		log_warning("hba line %d: unsupported method: buf=%s", linenr, tp->buf);
 		goto failed;
@@ -787,6 +791,38 @@ static bool parse_line(struct HBA *hba, struct Ident *ident, struct TokParser *t
 		eat_all(tp);
 	}
 
+#ifdef HAVE_GSSAPI
+	if (rule->rule_method == AUTH_TYPE_GSSAPI) {
+		/*
+		 * pgbouncer maps principals with gss_localname()/auth_to_local
+		 * (krb5.conf), not pg_ident.  include_realm= is redundant with that
+		 * and is tolerated (ignored with a warning) so a GSSAPI line copies
+		 * over from a postgres pg_hba.conf.  krb_realm= and map= are
+		 * *restrictive* options, though: silently ignoring them would grant
+		 * more access than the administrator wrote, so reject the line (fail
+		 * closed), consistent with how pgbouncer treats other unsupported HBA
+		 * parameters.  Express the equivalent restriction via auth_to_local.
+		 */
+		while (tp->cur_tok == TOK_IDENT) {
+			if (strncmp(tp->cur_tok_str, "include_realm=", 14) == 0) {
+				log_warning("hba line %d: GSSAPI option \"%s\" is ignored; "
+					    "principal-to-username mapping is handled by "
+					    "auth_to_local rules in krb5.conf",
+					    linenr, tp->cur_tok_str);
+				next_token(tp);
+			} else if (strncmp(tp->cur_tok_str, "krb_realm=", 10) == 0 ||
+				   strncmp(tp->cur_tok_str, "map=", 4) == 0) {
+				log_warning("hba line %d: restrictive GSSAPI option \"%s\" is "
+					    "not supported; express the restriction via "
+					    "auth_to_local rules in krb5.conf and remove it",
+					    linenr, tp->cur_tok_str);
+				goto failed;
+			} else {
+				break;
+			}
+		}
+	} else
+#endif
 	if (!parse_map_definition(rule, ident, tp, linenr)) {
 		goto failed;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
  */
 
 #include "bouncer.h"
+#include "gssapi_auth.h"
 
 #include <usual/signal.h>
 #include <usual/err.h>
@@ -126,6 +127,11 @@ char *cf_auth_ldap_options;
 char *cf_auth_user;
 char *cf_auth_query;
 char *cf_auth_dbname;
+char *cf_auth_gssapi_keytab;
+char *cf_auth_gssapi_client_keytab;
+char *cf_auth_gssapi_service_name;
+int cf_client_gssencmode;
+int cf_server_gssencmode;
 char *cf_track_extra_parameters;
 
 int cf_max_client_conn;
@@ -231,6 +237,9 @@ static const struct CfLookup auth_type_map[] = {
 #ifdef HAVE_PAM
 	{ "pam", AUTH_TYPE_PAM },
 #endif
+#ifdef HAVE_GSSAPI
+	{ "gssapi", AUTH_TYPE_GSSAPI },
+#endif
 	{ "scram-sha-256", AUTH_TYPE_SCRAM_SHA_256 },
 	{ NULL }
 };
@@ -258,6 +267,30 @@ const struct CfLookup load_balance_hosts_map[] = {
 	{ NULL }
 };
 
+#ifdef HAVE_GSSAPI
+/*
+ * As an acceptor, pgbouncer responds to the client's request rather than
+ * initiating encryption, so "prefer" is meaningless on this side.
+ */
+static const struct CfLookup client_gssencmode_map[] = {
+	{ "disable", GSSENCMODE_DISABLED },
+	{ "allow", GSSENCMODE_ALLOW },
+	{ "require", GSSENCMODE_REQUIRE },
+	{ NULL }
+};
+
+/*
+ * As an initiator, pgbouncer controls how it connects, so "allow" (an
+ * acceptor concept) is meaningless on this side; the set mirrors libpq.
+ */
+static const struct CfLookup server_gssencmode_map[] = {
+	{ "disable", GSSENCMODE_DISABLED },
+	{ "prefer", GSSENCMODE_PREFER },
+	{ "require", GSSENCMODE_REQUIRE },
+	{ NULL }
+};
+#endif
+
 /*
  * Add new parameters in alphabetical order. This order is used by SHOW CONFIG.
  */
@@ -266,6 +299,11 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("application_name_add_host", CF_INT, cf_application_name_add_host, 0, "0"),
 	CF_ABS("auth_dbname", CF_AUTHDB, cf_auth_dbname, 0, NULL),
 	CF_ABS("auth_file", CF_STR, cf_auth_file, 0, NULL),
+#ifdef HAVE_GSSAPI
+	CF_ABS("auth_gssapi_client_keytab", CF_STR, cf_auth_gssapi_client_keytab, 0, NULL),
+	CF_ABS("auth_gssapi_keytab", CF_STR, cf_auth_gssapi_keytab, 0, NULL),
+	CF_ABS("auth_gssapi_service_name", CF_STR, cf_auth_gssapi_service_name, 0, "postgres"),
+#endif
 	CF_ABS("auth_hba_file", CF_STR, cf_auth_hba_file, 0, ""),
 	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
 	CF_ABS("auth_ldap_options", CF_STR, cf_auth_ldap_options, 0, NULL),
@@ -274,6 +312,9 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 	CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),
 	CF_ABS("cancel_wait_timeout", CF_TIME_USEC, cf_cancel_wait_timeout, 0, "10"),
+#ifdef HAVE_GSSAPI
+	CF_ABS("client_gssencmode", CF_LOOKUP(client_gssencmode_map), cf_client_gssencmode, 0, "disable"),
+#endif
 	CF_ABS("client_idle_timeout", CF_TIME_USEC, cf_client_idle_timeout, 0, "0"),
 	CF_ABS("client_login_timeout", CF_TIME_USEC, cf_client_login_timeout, 0, "60"),
 	CF_ABS("client_tls13_ciphers", CF_STR, cf_client_tls13_ciphers, 0, NULL),
@@ -328,6 +369,9 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "<empty>"),
 	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
 	CF_ABS("server_fast_close", CF_INT, cf_server_fast_close, 0, "0"),
+#ifdef HAVE_GSSAPI
+	CF_ABS("server_gssencmode", CF_LOOKUP(server_gssencmode_map), cf_server_gssencmode, 0, "disable"),
+#endif
 	CF_ABS("server_idle_timeout", CF_TIME_USEC, cf_server_idle_timeout, 0, "600"),
 	CF_ABS("server_lifetime", CF_TIME_USEC, cf_server_lifetime, 0, "3600"),
 	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
@@ -454,9 +498,13 @@ static void set_peers_dead(bool flag)
 /* Tells if the specified auth type requires data from the auth file. */
 static bool requires_auth_file(int auth_type)
 {
-	/* For PAM authentication auth file is not used */
+	/* PAM and GSSAPI authenticate via external mechanisms; no auth file needed */
 	if (auth_type == AUTH_TYPE_PAM)
 		return false;
+#ifdef HAVE_GSSAPI
+	if (auth_type == AUTH_TYPE_GSSAPI)
+		return false;
+#endif
 	return auth_type >= AUTH_TYPE_TRUST;
 }
 
@@ -997,6 +1045,11 @@ static void cleanup(void)
 	xfree(&cf_auth_ldap_options);
 	xfree(&cf_auth_query);
 	xfree(&cf_auth_user);
+#ifdef HAVE_GSSAPI
+	xfree(&cf_auth_gssapi_keytab);
+	xfree(&cf_auth_gssapi_client_keytab);
+	xfree(&cf_auth_gssapi_service_name);
+#endif
 	xfree(&cf_server_reset_query);
 	xfree(&cf_server_check_query);
 	xfree(&cf_ignore_startup_params);
@@ -1166,6 +1219,7 @@ int main(int argc, char *argv[])
 
 	auth_ldap_init();
 	pam_init();
+	gssapi_auth_init();
 
 	if (did_takeover) {
 		takeover_finish();

--- a/src/objects.c
+++ b/src/objects.c
@@ -22,6 +22,7 @@
 
 #include "bouncer.h"
 #include "scram.h"
+#include "gssapi_auth.h"
 
 #include <usual/err.h>
 #include <usual/safeio.h>
@@ -191,6 +192,8 @@ void init_caches(void)
 static void client_free(PgSocket *client)
 {
 	free_client_prepared_statements(client);
+	gssapi_accept_cleanup(client);
+	gssenc_cleanup(client);
 	varcache_clean(&client->vars);
 	slab_free(var_list_cache, client->vars.var_list);
 	slab_free(client_cache, client);
@@ -211,6 +214,8 @@ static void server_free(PgSocket *server)
 	}
 
 	free_server_prepared_statements(server);
+	gssapi_initiate_cleanup(server);
+	gssenc_cleanup(server);
 	free(server->host);
 	varcache_clean(&server->vars);
 	slab_free(var_list_cache, server->vars.var_list);

--- a/src/proto.c
+++ b/src/proto.c
@@ -22,6 +22,7 @@
 
 #include "bouncer.h"
 #include "scram.h"
+#include "gssapi_auth.h"
 #include "common/sha2.h"
 
 /*
@@ -726,6 +727,32 @@ bool answer_authreq(PgSocket *server, PktHdr *pkt)
 		free_scram_state(&server->scram_state);
 		break;
 	}
+	case AUTH_REQ_GSS:
+		/*
+		 * Backend requests GSSAPI authentication.  pgbouncer initiates
+		 * the exchange using its own service-account credentials from
+		 * the configured keytab.  No client credentials are forwarded.
+		 */
+		slog_debug(server, "S: req GSSAPI");
+		res = gssapi_initiate_begin(server);
+		break;
+	case AUTH_REQ_GSS_CONT:
+	{
+		unsigned len;
+		const uint8_t *data;
+
+		slog_debug(server, "S: GSSAPI continuation");
+		len = mbuf_avail_for_read(&pkt->data);
+		if (len == 0) {
+			slog_error(server, "GSSAPI: backend sent AUTH_REQ_GSS_CONT "
+				   "with empty body; this is a protocol violation");
+			return false;
+		}
+		if (!mbuf_get_bytes(&pkt->data, len, &data))
+			return false;
+		res = gssapi_initiate_continue(server, data, len);
+		break;
+	}
 	default:
 		slog_error(server, "unknown/unsupported auth method: %u", cmd);
 		res = false;
@@ -806,6 +833,15 @@ bool send_sslreq_packet(PgSocket *server)
 	int res;
 	SEND_wrap(16, pktbuf_write_SSLRequest, res, server);
 	return res;
+}
+
+bool send_gssencreq_packet(PgSocket *server)
+{
+	static const uint8_t pkt[] = {
+		0, 0, 0, 8,			/* uint32 length = 8 */
+		0x04, 0xd2, 0x16, 0x30		/* uint32 80877104 = PKT_GSSENCREQ */
+	};
+	return sbuf_answer(&server->sbuf, pkt, sizeof(pkt));
 }
 
 /*

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -112,6 +112,30 @@ static void sbuf_tls_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf);
 static void sbuf_possible_direct_tls_startup_cb(evutil_socket_t fd, short flags, void *_sbuf);
 #endif
 
+/* I/O over GSSAPI encryption */
+#ifdef HAVE_GSSAPI
+#include "gssapi_auth.h"
+
+enum SBufGssState {
+	SBUF_GSS_NONE = 0,
+	SBUF_GSS_DO_HANDSHAKE,
+	SBUF_GSS_OK
+};
+
+static ssize_t gss_sbufio_peek(struct SBuf *sbuf, void *buf, size_t len);
+static ssize_t gss_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len);
+static ssize_t gss_sbufio_send(struct SBuf *sbuf, const void *data, size_t len);
+static int gss_sbufio_close(struct SBuf *sbuf);
+static const SBufIO gss_sbufio_ops = {
+	gss_sbufio_peek,
+	gss_sbufio_recv,
+	gss_sbufio_send,
+	gss_sbufio_close
+};
+static bool handle_gss_handshake(SBuf *sbuf, bool is_server) _MUSTCHECK;
+static void sbuf_gss_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf);
+#endif
+
 /*
  *********************************
  * Public functions
@@ -1057,6 +1081,14 @@ skip_recv:
 		if (!handle_tls_handshake(sbuf))
 			sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
 	}
+
+#ifdef HAVE_GSSAPI
+	if (sbuf->gss_state == SBUF_GSS_DO_HANDSHAKE) {
+		PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+		if (!handle_gss_handshake(sbuf, is_server_socket(sk)))
+			sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
+	}
+#endif
 }
 
 /* check if there is any error pending on socket */
@@ -1551,6 +1583,142 @@ static int tls_sbufio_close(struct SBuf *sbuf)
 	}
 	return 0;
 }
+
+#endif /* USE_TLS */
+
+/*
+ * GSSAPI encryption I/O ops and handshake.  GSS transport encryption does not
+ * depend on TLS, so this block is guarded by HAVE_GSSAPI alone.
+ */
+
+#ifdef HAVE_GSSAPI
+
+static ssize_t gss_sbufio_peek(struct SBuf *sbuf, void *buf, size_t len)
+{
+	Assert(0);
+	return -1;
+}
+
+static ssize_t gss_sbufio_recv(struct SBuf *sbuf, void *dst, size_t len)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	if (sbuf->gss_state != SBUF_GSS_OK) {
+		errno = EIO;
+		return -1;
+	}
+	return gssenc_recv(sk, dst, len);
+}
+
+static ssize_t gss_sbufio_send(struct SBuf *sbuf, const void *data, size_t len)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	if (sbuf->gss_state != SBUF_GSS_OK) {
+		errno = EIO;
+		return -1;
+	}
+	return gssenc_send(sk, data, len);
+}
+
+static int gss_sbufio_close(struct SBuf *sbuf)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	gssenc_cleanup(sk);
+	if (sbuf->sock > 0) {
+		safe_close(sbuf->sock);
+		sbuf->sock = 0;
+	}
+	return 0;
+}
+
+static bool handle_gss_handshake(SBuf *sbuf, bool is_server)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+	bool ok;
+
+	if (is_server)
+		ok = gssenc_connect_handshake(sk);
+	else
+		ok = gssenc_accept_handshake(sk);
+
+	if (!ok)
+		return false;
+
+	if (sk->gss_enc.active) {
+		sbuf->gss_state = SBUF_GSS_OK;
+		sbuf_call_proto(sbuf, SBUF_EV_GSS_READY);
+	} else {
+		short ev = (sk->gss_enc.hs_want == GSSENC_HS_WRITE) ? EV_WRITE : EV_READ;
+		return sbuf_use_callback_once(sbuf, ev, sbuf_gss_handshake_cb);
+	}
+	return true;
+}
+
+static void sbuf_gss_handshake_cb(evutil_socket_t fd, short flags, void *_sbuf)
+{
+	SBuf *sbuf = _sbuf;
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	sbuf->wait_type = W_NONE;
+	if (!handle_gss_handshake(sbuf, is_server_socket(sk)))
+		sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
+}
+
+bool sbuf_gss_accept(SBuf *sbuf)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	if (!sbuf_pause(sbuf))
+		return false;
+
+	if (!gssenc_accept_start(sk))
+		return false;
+
+	sbuf->ops = &gss_sbufio_ops;
+	sbuf->gss_state = SBUF_GSS_DO_HANDSHAKE;
+	return true;
+}
+
+bool sbuf_gss_connect(SBuf *sbuf)
+{
+	PgSocket *sk = container_of(sbuf, PgSocket, sbuf);
+
+	if (!sbuf_pause(sbuf))
+		return false;
+
+	if (!gssenc_connect_start(sk))
+		return false;
+
+	sbuf->ops = &gss_sbufio_ops;
+	sbuf->gss_state = SBUF_GSS_DO_HANDSHAKE;
+
+	/*
+	 * Let the main loop drive the handshake, exactly as sbuf_tls_connect and
+	 * the accept path do.  Self-arming an event here as well would double-drive
+	 * the handshake and can re-assign a still-pending libevent event.
+	 */
+	return true;
+}
+
+#else
+
+bool sbuf_gss_accept(SBuf *sbuf)
+{
+	(void)sbuf;
+	return false;
+}
+
+bool sbuf_gss_connect(SBuf *sbuf)
+{
+	(void)sbuf;
+	return false;
+}
+
+#endif /* HAVE_GSSAPI */
+
+#ifdef USE_TLS
 
 void sbuf_cleanup(void)
 {

--- a/src/server.c
+++ b/src/server.c
@@ -21,6 +21,7 @@
  */
 
 #include "bouncer.h"
+#include "gssapi_auth.h"
 #include "usual/time.h"
 
 #include <usual/slab.h>
@@ -708,6 +709,27 @@ static bool handle_connect(PgSocket *server)
 		disconnect_server(server, false, "peer server was not necessary anymore, because client cancel connection was already closed");
 	} else {
 		/* proceed with login */
+#ifdef HAVE_GSSAPI
+		bool try_gss = cf_server_gssencmode > GSSENCMODE_DISABLED && !is_unix;
+		/*
+		 * Under "prefer", only offer GSS encryption when initiator
+		 * credentials are actually available; otherwise fall back to SSL or
+		 * plain startup.  This mirrors libpq, which skips GSS when
+		 * pg_GSS_have_cred_cache() finds no usable credentials.  Under
+		 * "require" we always attempt it and let the handshake fail loudly.
+		 */
+		if (try_gss && cf_server_gssencmode < GSSENCMODE_REQUIRE &&
+		    !gssenc_have_initiator_cred(server)) {
+			slog_debug(server, "no GSS initiator credentials; skipping GSS encryption");
+			try_gss = false;
+		}
+		if (try_gss) {
+			slog_noise(server, "P: GSS enc request");
+			res = send_gssencreq_packet(server);
+			if (res)
+				server->wait_gss_enc_char = true;
+		} else
+#endif
 		if (server_connect_sslmode > SSLMODE_DISABLED && !is_unix) {
 			slog_noise(server, "P: SSL request");
 			res = send_sslreq_packet(server);
@@ -773,6 +795,53 @@ static bool server_handle_complete_packet(PgSocket *server, PktHdr *pkt)
 		return handle_server_startup(server, pkt);
 	return handle_server_work(server, pkt);
 }
+#ifdef HAVE_GSSAPI
+static bool handle_gssencchar(PgSocket *server, struct MBuf *data)
+{
+	uint8_t gchar;
+	bool ok;
+
+	server->wait_gss_enc_char = false;
+
+	ok = mbuf_get_byte(data, &gchar);
+	if (!ok || (gchar != 'G' && gchar != 'N')) {
+		disconnect_server(server, false, "bad gssencreq answer");
+		return false;
+	}
+	if (mbuf_avail_for_read(data) != 0) {
+		disconnect_server(server, false,
+				  "received unencrypted data after GSS enc response");
+		return false;
+	}
+
+	if (gchar == 'G') {
+		slog_noise(server, "launching GSS encryption");
+		ok = sbuf_gss_connect(&server->sbuf);
+	} else if (cf_server_gssencmode >= GSSENCMODE_REQUIRE) {
+		disconnect_server(server, false, "server refused GSS encryption");
+		return false;
+	} else {
+		/* clean up GSS state from the failed negotiation */
+		gssenc_cleanup(server);
+		/* fall through to SSL or plain startup */
+		if (server_connect_sslmode > SSLMODE_DISABLED) {
+			slog_noise(server, "P: SSL request (after GSS refused)");
+			ok = send_sslreq_packet(server);
+			if (ok)
+				server->wait_sslchar = true;
+		} else {
+			ok = send_startup_message(server);
+		}
+	}
+
+	if (ok) {
+		sbuf_prepare_skip(&server->sbuf, 1);
+	} else {
+		disconnect_server(server, false, "gssencreq processing failed");
+	}
+	return ok;
+}
+#endif
 
 /* callback from SBuf */
 bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
@@ -801,6 +870,12 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 		disconnect_client(server->link, false, "unexpected eof");
 		break;
 	case SBUF_EV_READ:
+#ifdef HAVE_GSSAPI
+		if (server->wait_gss_enc_char) {
+			res = handle_gssencchar(server, data);
+			break;
+		}
+#endif
 		if (server->wait_sslchar) {
 			res = handle_sslchar(server, data);
 			break;
@@ -925,6 +1000,17 @@ bool server_proto(SBuf *sbuf, SBufEvent evtype, struct MBuf *data)
 			sbuf_continue(&server->sbuf);
 		else
 			disconnect_server(server, false, "TLS startup failed");
+		break;
+	case SBUF_EV_GSS_READY:
+		Assert(server->state == SV_LOGIN);
+		if (cf_log_connections)
+			slog_info(server, "GSSAPI encrypted connection established");
+		server->request_time = get_cached_time();
+		res = send_startup_message(server);
+		if (res)
+			sbuf_continue(&server->sbuf);
+		else
+			disconnect_server(server, false, "GSS enc startup failed");
 		break;
 	}
 	if (!res && pool->db->admin)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ import filelock
 import pytest
 
 from .utils import (
+    GSS_SUPPORT,
     LDAP_SUPPORT,
     LINUX,
     LONG_PASSWORD,
@@ -119,6 +120,10 @@ def pg(tmp_path_factory, cert_dir):
             f.write(f"ssl_cert_file='{cert}'\n")
             f.write(f"ssl_key_file='{key}'\n")
 
+    if GSS_SUPPORT:
+        with pg.conf_path.open("a") as f:
+            f.write("krb_server_keyfile = 'FILE:/tmp/pgbouncer-test.keytab'\n")
+
     pg.nossl_access("replication", "trust", user="postgres")
     pg.nossl_access("all", "trust")
     pg.nossl_access("p4", "password")
@@ -133,6 +138,9 @@ def pg(tmp_path_factory, cert_dir):
 
     if LDAP_SUPPORT:
         pg.sql("create user ldapuser1 login password 'secret1'")
+
+    if GSS_SUPPORT:
+        pg.sql("create user testuser login")
 
     pg.sql("create database unconfigured_auth_database")
     pg.sql("create user bouncer")

--- a/test/setup_kdc.sh
+++ b/test/setup_kdc.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#
+# Set up a local MIT KDC for pgbouncer GSSAPI integration tests.
+#
+# This script is designed to run inside a disposable container or CI
+# environment.  It overwrites /etc/krb5.conf and /etc/krb5kdc/ config.
+# Do NOT run on a production host.
+#
+# After this script completes:
+#   - KDC config and database are created and the krb5kdc daemon is left running,
+#     ready for the tests to kinit against
+#   - User principal: testuser@TEST.PGBOUNCER (password: testpass)
+#   - Service principal: postgres/localhost@TEST.PGBOUNCER
+#   - Keytab: /tmp/pgbouncer-test.keytab (world-readable for test use)
+#   - auth_to_local rules strip the realm via gss_localname()
+#
+
+set -euo pipefail
+
+REALM="TEST.PGBOUNCER"
+KDC_DIR="/etc/krb5kdc"
+KEYTAB="/tmp/pgbouncer-test.keytab"
+MASTER_PASSWORD="masterpass"
+USER_PRINCIPAL="testuser@${REALM}"
+USER_PASSWORD="testpass"
+SVC_PRINCIPAL_LOCALHOST="postgres/localhost@${REALM}"
+SVC_PRINCIPAL_IP="postgres/127.0.0.1@${REALM}"
+
+# --- krb5.conf ---
+cat > /etc/krb5.conf <<EOF
+[libdefaults]
+    default_realm = ${REALM}
+    dns_lookup_kdc = false
+    dns_lookup_realm = false
+    rdns = false
+    forwardable = true
+
+[realms]
+    ${REALM} = {
+        kdc = localhost
+        admin_server = localhost
+        auth_to_local = RULE:[1:\$1@\$0](.*@${REALM})s/@.*//
+        auth_to_local = DEFAULT
+    }
+
+[domain_realm]
+    localhost = ${REALM}
+    .localhost = ${REALM}
+EOF
+
+# --- kdc.conf ---
+mkdir -p "${KDC_DIR}"
+cat > "${KDC_DIR}/kdc.conf" <<EOF
+[kdcdefaults]
+    kdc_ports = 88
+    kdc_tcp_ports = 88
+
+[realms]
+    ${REALM} = {
+        database_name = ${KDC_DIR}/principal
+        admin_keytab = FILE:${KDC_DIR}/kadm5.keytab
+        acl_file = ${KDC_DIR}/kadm5.acl
+        key_stash_file = ${KDC_DIR}/stash
+        supported_enctypes = aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal
+        max_life = 24h
+        max_renewable_life = 7d
+    }
+EOF
+
+# --- kadm5.acl ---
+cat > "${KDC_DIR}/kadm5.acl" <<EOF
+*/admin@${REALM} *
+EOF
+
+# --- Create KDC database ---
+# In containers, /dev/random may block waiting for entropy.
+# Start haveged if available to feed the kernel entropy pool.
+if command -v haveged >/dev/null 2>&1; then
+    haveged -F &
+    HAVEGED_PID=$!
+    sleep 1
+fi
+kdb5_util create -s -r "${REALM}" -P "${MASTER_PASSWORD}" 2>/dev/null || true
+if [ -n "${HAVEGED_PID:-}" ]; then
+    kill "${HAVEGED_PID}" 2>/dev/null || true
+fi
+
+# --- Start the KDC (left running for the tests to authenticate against) ---
+krb5kdc
+sleep 1
+
+# --- Create principals ---
+kadmin.local -q "delete_principal -force ${USER_PRINCIPAL}" 2>/dev/null || true
+kadmin.local -q "delete_principal -force ${SVC_PRINCIPAL_LOCALHOST}" 2>/dev/null || true
+kadmin.local -q "delete_principal -force ${SVC_PRINCIPAL_IP}" 2>/dev/null || true
+
+kadmin.local -q "addprinc -pw ${USER_PASSWORD} ${USER_PRINCIPAL}"
+kadmin.local -q "addprinc -randkey ${SVC_PRINCIPAL_LOCALHOST}"
+kadmin.local -q "addprinc -randkey ${SVC_PRINCIPAL_IP}"
+
+# --- Extract keytab (both localhost and 127.0.0.1 SPNs for test flexibility) ---
+rm -f "${KEYTAB}"
+kadmin.local -q "ktadd -k ${KEYTAB} ${SVC_PRINCIPAL_LOCALHOST}"
+kadmin.local -q "ktadd -k ${KEYTAB} ${SVC_PRINCIPAL_IP}"
+chmod 644 "${KEYTAB}"
+
+echo ""
+echo "KDC setup complete:"
+echo "  Realm:     ${REALM}"
+echo "  User:      ${USER_PRINCIPAL} (password: ${USER_PASSWORD})"
+echo "  Service:   ${SVC_PRINCIPAL_LOCALHOST}, ${SVC_PRINCIPAL_IP}"
+echo "  Keytab:    ${KEYTAB}"
+echo ""
+klist -k -t "${KEYTAB}"

--- a/test/test_auth_gss.py
+++ b/test/test_auth_gss.py
@@ -1,0 +1,654 @@
+"""
+GSSAPI (Kerberos) authentication tests for PgBouncer.
+
+Requires a running KDC (set up by test/setup_kdc.sh) and pgbouncer built
+with --with-gssapi.  Tests are skipped automatically if either is not
+available.
+"""
+
+import os
+import socket
+import ssl
+import struct
+import subprocess
+
+import psycopg
+import pytest
+
+from .utils import GSS_SUPPORT, TLS_SUPPORT, WINDOWS
+
+REALM = "TEST.PGBOUNCER"
+USER_PRINCIPAL = f"testuser@{REALM}"
+USER_PASSWORD = "testpass"
+KEYTAB = "/tmp/pgbouncer-test.keytab"
+
+
+def kdc_is_running():
+    """Check if the test KDC is running and the keytab exists."""
+    if not os.path.exists(KEYTAB):
+        return False
+    try:
+        result = subprocess.run(
+            ["klist", "-k", "-t", KEYTAB],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+KDC_AVAILABLE = kdc_is_running()
+
+pytestmark = [
+    pytest.mark.skipif(WINDOWS, reason="GSSAPI tests not supported on Windows"),
+    pytest.mark.skipif(not GSS_SUPPORT, reason="pgbouncer built without GSSAPI"),
+    pytest.mark.skipif(
+        not KDC_AVAILABLE,
+        reason="test KDC not running (run test/setup_kdc.sh first)",
+    ),
+]
+
+
+def kinit():
+    """Acquire a TGT for the test user."""
+    subprocess.run(
+        ["kinit", USER_PRINCIPAL],
+        input=USER_PASSWORD.encode() + b"\n",
+        check=True,
+        capture_output=True,
+        timeout=10,
+    )
+
+
+def kdestroy():
+    """Destroy the credential cache."""
+    subprocess.run(["kdestroy"], capture_output=True, timeout=5, check=False)
+
+
+def setup_module(module):
+    """Acquire test user credentials before running tests."""
+    kinit()
+
+
+def teardown_module(module):
+    """Clean up credentials."""
+    kdestroy()
+
+
+def gss_bouncer_config(bouncer, pg, *, auth_type="gssapi", extra=""):
+    """Generate a pgbouncer config for GSSAPI testing."""
+    return f"""\
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {bouncer.port}
+auth_type = {auth_type}
+auth_gssapi_keytab = {KEYTAB}
+logfile = {bouncer.log_path}
+pidfile =
+unix_socket_dir = {bouncer.config_dir}
+admin_users = testuser
+{extra}
+
+[databases]
+p0 = host=127.0.0.1 port={pg.port} dbname=p0 user=testuser
+"""
+
+
+def gss_hba_config(bouncer, pg, *, hba_content, extra=""):
+    """Generate a pgbouncer config with HBA-based GSSAPI."""
+    hba_file = bouncer.config_dir / "gss_hba.conf"
+    with open(hba_file, "w") as f:
+        f.write(hba_content + "\n")
+    return f"""\
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {bouncer.port}
+auth_type = hba
+auth_hba_file = {hba_file}
+auth_gssapi_keytab = {KEYTAB}
+logfile = {bouncer.log_path}
+pidfile =
+unix_socket_dir = {bouncer.config_dir}
+admin_users = testuser
+{extra}
+
+[databases]
+p0 = host=127.0.0.1 port={pg.port} dbname=p0 user=testuser
+"""
+
+
+def test_gssapi_auth_type(pg, bouncer):
+    """auth_type = gssapi works end-to-end."""
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+
+        kdestroy()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="disable",
+            )
+
+    kinit()
+
+
+def test_gssapi_auth_warm_pool_second_login(pg, bouncer):
+    """Two sequential GSSAPI logins to the same pool; the second hits a warm
+    pool (welcome cached), exercising the finish_client_login==true path."""
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+
+
+def test_gssapi_hba(pg, bouncer):
+    """auth_type = hba with gssapi method works."""
+    config = gss_hba_config(
+        bouncer,
+        pg,
+        hba_content="host all all 0.0.0.0/0 gssapi",
+    )
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+
+
+def test_gssapi_wrong_username(pg, bouncer):
+    """Client claiming a wrong username is rejected by gss_localname mismatch."""
+    pg.sql("DROP ROLE IF EXISTS wronguser", gssencmode="disable")
+    pg.sql("CREATE ROLE wronguser LOGIN", gssencmode="disable")
+
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError, match="GSSAPI|principal mapping"):
+            bouncer.test(
+                user="wronguser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="disable",
+            )
+
+
+def test_gssapi_no_ticket(pg, bouncer):
+    """Connection fails when the client has no TGT."""
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kdestroy()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="disable",
+            )
+
+    kinit()
+
+
+def test_gssapi_gssencmode_prefer(pg, bouncer):
+    """Connection with gssencmode=prefer (libpq's default) works.
+
+    The client offers GSSAPI encryption first; with client_gssencmode=disable
+    pgbouncer declines it, and libpq falls back to a plain-text connection and
+    completes GSSAPI authentication over that channel.
+    """
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="prefer"
+        )
+
+
+def test_gssapi_gssencmode_disable(pg, bouncer):
+    """Connection with gssencmode=disable works."""
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+
+
+def test_gssapi_backend_auth(pg, bouncer):
+    """Full path: client GSSAPI to pgbouncer, pgbouncer GSSAPI to postgres.
+
+    Postgres is configured with krb_server_keyfile in conftest.py (session
+    scope).  This test adds a GSS HBA line so postgres requires GSSAPI from
+    pgbouncer's backend connection.
+    """
+    with pg.hba_path.open() as f:
+        old_hba = f.read()
+    with pg.hba_path.open("w") as f:
+        f.write("host all testuser 127.0.0.1/32 gss include_realm=0\n")
+        f.write(old_hba)
+    pg.reload()
+
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser",
+            dbname="p0",
+            sslmode="disable",
+            gssencmode="disable",
+        )
+
+
+def test_gssapi_hba_include_realm_warning(pg, bouncer):
+    """HBA line with include_realm=0 is accepted with a warning, not rejected."""
+    config = gss_hba_config(
+        bouncer,
+        pg,
+        hba_content="host all all 0.0.0.0/0 gssapi include_realm=0",
+    )
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+        with open(bouncer.log_path) as f:
+            assert 'GSSAPI option "include_realm=0" is ignored' in f.read()
+
+
+def test_gssapi_hba_map_rejected(pg, bouncer):
+    """HBA line with a restrictive map= is rejected (fail closed).
+
+    map= restricts which principals may authenticate. pgbouncer maps principals
+    via auth_to_local, so honoring map= as a no-op would grant more access than
+    the administrator wrote. The line is rejected rather than silently ignored,
+    so with it as the only rule the connection has no matching HBA entry.
+    """
+    ident_file = bouncer.config_dir / "gss_ident.conf"
+    with open(ident_file, "w") as f:
+        f.write("gssmap testuser nonexistent_user\n")
+
+    config = gss_hba_config(
+        bouncer,
+        pg,
+        hba_content="host all all 0.0.0.0/0 gssapi map=gssmap",
+        extra=f"auth_ident_file = {ident_file}",
+    )
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+            )
+        with open(bouncer.log_path) as f:
+            assert 'restrictive GSSAPI option "map=gssmap" is not supported' in f.read()
+
+
+def test_gssapi_wrong_service_name(pg, bouncer):
+    """auth_gssapi_service_name = wrongname causes backend auth failure.
+
+    Postgres is configured with GSS auth so the wrong service name actually
+    prevents pgbouncer from authenticating to the backend.
+    """
+    with pg.hba_path.open() as f:
+        old_hba = f.read()
+    with pg.hba_path.open("w") as f:
+        f.write("host all testuser 127.0.0.1/32 gss include_realm=0\n")
+        f.write(old_hba)
+    pg.reload()
+
+    config = gss_bouncer_config(
+        bouncer,
+        pg,
+        extra="auth_gssapi_service_name = wrongname",
+    )
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="disable",
+            )
+
+
+def test_gssapi_missing_keytab(pg, bouncer):
+    """Pgbouncer with a nonexistent keytab rejects GSSAPI connections."""
+    config = gss_bouncer_config(bouncer, pg).replace(KEYTAB, "/nonexistent/path.keytab")
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="disable",
+            )
+
+
+# --------------------------------------------------------------------------
+# GSSAPI encryption tests
+# --------------------------------------------------------------------------
+
+
+def gss_enc_bouncer_config(bouncer, pg, *, extra=""):
+    """Generate a pgbouncer config with GSS encryption enabled."""
+    return f"""\
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {bouncer.port}
+auth_type = gssapi
+auth_gssapi_keytab = {KEYTAB}
+client_gssencmode = allow
+server_gssencmode = disable
+logfile = {bouncer.log_path}
+pidfile =
+unix_socket_dir = {bouncer.config_dir}
+admin_users = testuser
+{extra}
+
+[databases]
+p0 = host=127.0.0.1 port={pg.port} dbname=p0 user=testuser
+"""
+
+
+def test_gssapi_gssencmode_require_client(pg, bouncer):
+    """Client with gssencmode=require connects when pgbouncer allows GSS enc."""
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="require"
+        )
+
+
+def test_gssapi_gssencmode_require_rejected(pg, bouncer):
+    """Client with gssencmode=require is rejected when pgbouncer disables GSS enc."""
+    config = gss_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="require",
+            )
+
+
+def test_gssapi_enc_mitm_plaintext_rejected(pg, bouncer):
+    """Plaintext pipelined with a GSSENCRequest is rejected before the handshake.
+
+    Mirrors postgres: if data is already buffered when the GSSENCRequest is
+    processed, it arrived unencrypted and may have been injected by a
+    man-in-the-middle, so the connection is refused rather than upgraded. A
+    correct pgbouncer never answers 'G' in this case.
+    """
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        gssencreq = struct.pack("!ii", 8, 80877104)
+        s = socket.create_connection(("127.0.0.1", bouncer.port), timeout=5)
+        try:
+            # Send the request and injected plaintext in a single segment so
+            # pgbouncer buffers both before it processes the GSSENCRequest.
+            s.sendall(gssencreq + b"injected-plaintext-not-a-gss-token")
+            resp = s.recv(1024)
+        finally:
+            s.close()
+        assert not resp.startswith(b"G"), f"handshake must not start; got {resp!r}"
+
+
+@pytest.mark.skipif(not TLS_SUPPORT, reason="pgbouncer built without TLS")
+def test_gssapi_enc_req_after_tls_rejected(pg, bouncer, cert_dir):
+    """A GSSENCRequest after encryption is already established is refused.
+
+    pgbouncer must not re-negotiate encryption once a secure channel exists;
+    postgres threads ssl_done/gss_done for exactly this, refusing a second
+    SSL/GSS request. Establish TLS, then send a GSSENCRequest over it: pgbouncer
+    must reject rather than answer 'G' and start a second handshake (which would
+    also leak the existing GSS context/credentials on the acceptor side).
+    """
+    cert = cert_dir / "TestCA1" / "sites" / "01-localhost.crt"
+    key = cert_dir / "TestCA1" / "sites" / "01-localhost.key"
+    config = f"""\
+[pgbouncer]
+listen_addr = 127.0.0.1
+listen_port = {bouncer.port}
+auth_type = gssapi
+auth_gssapi_keytab = {KEYTAB}
+client_gssencmode = allow
+client_tls_sslmode = allow
+client_tls_cert_file = {cert}
+client_tls_key_file = {key}
+logfile = {bouncer.log_path}
+pidfile =
+unix_socket_dir = {bouncer.config_dir}
+admin_users = testuser
+
+[databases]
+p0 = host=127.0.0.1 port={pg.port} dbname=p0 user=testuser
+"""
+    with bouncer.run_with_config(config):
+        raw = socket.create_connection(("127.0.0.1", bouncer.port), timeout=5)
+        raw.sendall(struct.pack("!ii", 8, 80877103))  # SSLRequest
+        assert raw.recv(1) == b"S"
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        tls = ctx.wrap_socket(raw, server_hostname="localhost")
+        try:
+            tls.sendall(struct.pack("!ii", 8, 80877104))  # GSSENCRequest over TLS
+            tls.settimeout(5)
+            # Rejection closes the connection without sending 'G'; EOF, a TLS
+            # error, or a timeout all mean the re-negotiation was refused.
+            try:
+                resp = tls.recv(1024)
+            except (ssl.SSLError, OSError):
+                resp = b""
+        finally:
+            tls.close()
+        assert not resp.startswith(b"G"), (
+            f"re-negotiation must be refused; got {resp!r}"
+        )
+
+
+def test_gssapi_enc_and_auth(pg, bouncer):
+    """Full round-trip: client uses GSSAPI encryption and GSSAPI auth to
+    pgbouncer; pgbouncer uses trust to the backend."""
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="require"
+        )
+
+
+def test_gssapi_server_gssencmode_require(pg, bouncer):
+    """Full round-trip with server_gssencmode=require.
+
+    Both client and backend use GSS encryption. The backend postgres in the
+    test container supports GSS encryption, so this succeeds.
+    """
+    config = gss_enc_bouncer_config(bouncer, pg, extra="server_gssencmode = require")
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser",
+            dbname="p0",
+            sslmode="disable",
+            gssencmode="require",
+        )
+
+
+def test_gssapi_server_gssencmode_prefer_fallback(pg, bouncer):
+    """pgbouncer falls back gracefully when backend sends N and prefer is set."""
+    config = gss_enc_bouncer_config(bouncer, pg, extra="server_gssencmode = prefer")
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="require"
+        )
+
+
+def test_gssapi_server_gssencmode_prefer_no_creds_fallback(pg, bouncer):
+    """server_gssencmode=prefer falls back when pgbouncer has no initiator creds.
+
+    The test backend supports GSS encryption, so it would answer 'G'. With
+    prefer and no usable credential cache, pgbouncer must not offer GSS to the
+    backend (which it could not complete); it connects over plain-text instead.
+    Mirrors libpq, which skips GSS when pg_GSS_have_cred_cache() finds nothing.
+    Client uses trust so it needs no ticket; only the backend path is exercised.
+    """
+    auth_file = bouncer.config_dir / "gss_trust_userlist.txt"
+    with open(auth_file, "w") as f:
+        f.write('"testuser" "trust-unused"\n')
+    config = gss_bouncer_config(
+        bouncer,
+        pg,
+        auth_type="trust",
+        extra=f"auth_file = {auth_file}\nserver_gssencmode = prefer",
+    )
+    with bouncer.run_with_config(config):
+        kdestroy()
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+        )
+    kinit()
+
+
+def test_gssapi_enc_backend_gss_auth(pg, bouncer):
+    """Full path: client GSS-encrypted, backend GSS-encrypted + GSS-authenticated."""
+    with pg.hba_path.open() as f:
+        old_hba = f.read()
+    with pg.hba_path.open("w") as f:
+        f.write("host all testuser 127.0.0.1/32 gss include_realm=0\n")
+        f.write(old_hba)
+    pg.reload()
+
+    config = gss_enc_bouncer_config(bouncer, pg, extra="server_gssencmode = require")
+    with bouncer.run_with_config(config):
+        kinit()
+        bouncer.test(
+            user="testuser",
+            dbname="p0",
+            sslmode="disable",
+            gssencmode="require",
+        )
+
+
+def test_gssapi_enc_wrong_username(pg, bouncer):
+    """Encrypted channel established, but username mismatch still rejected."""
+    pg.sql("DROP ROLE IF EXISTS wronguser", gssencmode="disable")
+    pg.sql("CREATE ROLE wronguser LOGIN", gssencmode="disable")
+
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError, match="GSSAPI|principal mapping"):
+            bouncer.test(
+                user="wronguser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="require",
+            )
+
+
+def test_gssapi_enc_no_ticket(pg, bouncer):
+    """Encrypted channel cannot be established without a TGT."""
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kdestroy()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser",
+                dbname="p0",
+                sslmode="disable",
+                gssencmode="require",
+            )
+
+    kinit()
+
+
+def test_gssapi_client_gssencmode_require_rejects_plaintext(pg, bouncer):
+    """client_gssencmode=require refuses unencrypted client connections.
+
+    This mirrors the sslmode=require behavior: a plain-text StartupMessage is
+    rejected, while a GSS-encrypted client is accepted.
+    """
+    config = gss_enc_bouncer_config(bouncer, pg, extra="client_gssencmode = require")
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser", dbname="p0", sslmode="disable", gssencmode="disable"
+            )
+        bouncer.test(
+            user="testuser", dbname="p0", sslmode="disable", gssencmode="require"
+        )
+
+
+def test_gssapi_enc_does_not_bypass_password_auth(pg, bouncer):
+    """GSS encryption must not bypass the configured non-GSS auth method.
+
+    With auth_type=plain and client_gssencmode=allow, a GSS-encrypted client
+    still has to complete the configured password exchange; encryption and
+    authentication are orthogonal. The identity shortcut applies only when the
+    configured method is itself GSSAPI. Without a password the connection is
+    rejected; with the correct password the exchange runs over the encrypted
+    channel and succeeds.
+    """
+    auth_file = bouncer.config_dir / "gss_plain_userlist.txt"
+    with open(auth_file, "w") as f:
+        f.write('"testuser" "supersecret"\n')
+
+    config = gss_enc_bouncer_config(
+        bouncer, pg, extra=f"auth_type = plain\nauth_file = {auth_file}"
+    )
+    with bouncer.run_with_config(config):
+        kinit()
+        with pytest.raises(psycopg.OperationalError):
+            bouncer.test(
+                user="testuser", dbname="p0", sslmode="disable", gssencmode="require"
+            )
+        bouncer.test(
+            user="testuser",
+            dbname="p0",
+            sslmode="disable",
+            gssencmode="require",
+            password="supersecret",
+        )
+
+
+def test_gssapi_enc_large_payload(pg, bouncer):
+    """Payloads larger than PQ_GSS_MAX_PACKET_SIZE (16 KB) round-trip in both
+    directions, exercising the multi-packet gss_wrap()/gss_unwrap() framing.
+    """
+    config = gss_enc_bouncer_config(bouncer, pg)
+    with bouncer.run_with_config(config):
+        kinit()
+        conn = {
+            "user": "testuser",
+            "dbname": "p0",
+            "sslmode": "disable",
+            "gssencmode": "require",
+        }
+        n = 100000
+        # server -> client: large result, pgbouncer encrypts the outbound stream
+        assert bouncer.sql_value(f"select repeat('x', {n})", **conn) == "x" * n
+        # client -> server: large bind parameter, pgbouncer decrypts the inbound stream
+        assert (
+            bouncer.sql_value("select length(%s::text)", params=("y" * n,), **conn) == n
+        )

--- a/test/utils.py
+++ b/test/utils.py
@@ -228,6 +228,13 @@ def get_ldap_support():
 LDAP_SUPPORT = get_ldap_support()
 
 
+def get_gss_support():
+    return get_build_feature("gssapi_support", "HAVE_GSSAPI")
+
+
+GSS_SUPPORT = get_gss_support()
+
+
 def get_tls_support():
     return get_build_feature("tls_support", "USUAL_LIBSSL_FOR_TLS")
 
@@ -348,6 +355,12 @@ class QueryRunner:
         # client_encoding specified in the config and client_encoding by the
         # client will force a varcache change when a connection is given.
         options.setdefault("client_encoding", "UTF8")
+        # Pin gssencmode so psycopg doesn't rely on libpq's ambiguous default
+        # and emit a RuntimeWarning when a Kerberos ccache is present (as in the
+        # gssapi CI job); filterwarnings=error would turn that into a spurious
+        # failure. Tests that exercise GSS set gssencmode explicitly, which
+        # overrides this default.
+        options.setdefault("gssencmode", "disable")
         return options
 
     def make_conninfo(self, **kwargs) -> str:


### PR DESCRIPTION
Adds GSSAPI/Kerberos support to PgBouncer: authentication (acceptor and initiator) and transport encryption (`gssencmode=require` / `gssencmode=prefer`), enabling fully Kerberos-secured connection pooling without passwords.

### Authentication

**Client (acceptor)**: pgbouncer validates Kerberos service tickets using `gss_accept_sec_context()` and maps authenticated principals to local usernames via `gss_localname()`.

**Backend (initiator)**: pgbouncer authenticates to postgres using the process's existing TGT from the credential cache (KCM, FILE:, etc.), with an optional keytab override for environments without automatic credential management.

### Encryption

**Client (acceptor)**: pgbouncer accepts `GSSENCRequest` from libpq clients and performs the GSS encryption handshake as the acceptor, establishing a `gss_wrap()`/`gss_unwrap()` encrypted channel.

**Backend (initiator)**: pgbouncer sends `GSSENCRequest` to postgres backends and performs the GSS encryption handshake as the initiator. When the backend responds `'N'`, pgbouncer falls back to SSL or plain; under `server_gssencmode = prefer` it also skips GSS when no initiator credentials are available.

**Transport layer**: GSS encryption uses the same `SBufIO` vtable abstraction as TLS. After the handshake, `gss_sbufio_ops` replaces `raw_sbufio_ops`, routing all I/O through `gss_wrap()`/`gss_unwrap()` transparently. A dedicated `SBUF_EV_GSS_READY` event signals handshake completion.

**Identity extraction**: When GSS encryption is active and the configured method is GSSAPI, the client's Kerberos identity is already established by the encryption handshake. No separate `AUTH_REQ_GSS` exchange is needed; the principal is extracted via `gss_inquire_context()` and mapped via `gss_localname()`. Any other configured method still runs over the encrypted channel.

### Differences from PR #1209

This is a parallel implementation to #1209. Both address the same feature request (#318). The key architectural differences:

**Event-driven, not threaded.** `gss_accept_sec_context()` is a local cryptographic operation with no network I/O, in the same class as verifying a SCRAM proof. PostgreSQL itself runs it inline. Threading adds locking, request queues, and thread lifecycle complexity for an operation that does not block.

**Multi-round `GSS_S_CONTINUE_NEEDED` support.** The GSSAPI spec requires support for multi-round context establishment. Each round is a separate sbuf event; GSS context state persists on the PgSocket struct. PR #1209's author noted this as an unresolved concern: "I also am not sure how this loop type flow could be implemented in the pgbouncer async framework." The event-driven approach handles it naturally.

**`gss_localname()` for principal-to-username mapping.** Rather than implementing PostgreSQL's `include_realm` and `krb_realm` HBA options (application-level ad-hoc realm stripping), this delegates mapping to `auth_to_local` rules in `krb5.conf` via `gss_localname()`. This is the site-policy-respecting approach: the same rules apply to all Kerberos services on the system. PostgreSQL added `gss_localname()` support in v12 as the preferred alternative. MIT Kerberos >= 1.7 (2009) is universally available on systems that can build with GSSAPI. `include_realm` is redundant with `auth_to_local` and is ignored with a warning, so administrators can copy GSSAPI HBA rules from postgres without modification; the restrictive `krb_realm` and `map=` options are rejected (fail closed) rather than silently weakened, so a line never grants more access than written.

**Credential-cache-default initiator.** Backend connections use the process's existing TGT from the default credential cache (KCM, FILE:, etc.), like any Kerberos client. An explicit keytab override (`auth_gssapi_client_keytab`) is available for environments without automatic credential management, but it is not the default.

**Transport encryption.** This implementation adds full GSSAPI transport encryption support with `client_gssencmode` and `server_gssencmode` configuration, matching PostgreSQL's `gssencmode` semantics. The encryption context requests `GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG | GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG`, matching postgres's `fe-secure-gssapi.c`. This differs intentionally from the auth-only context which uses only `GSS_C_MUTUAL_FLAG`: the encryption context needs replay and sequence protection since it carries application data. When `client_gssencmode = disable` (the default), no encryption buffers are allocated and there is zero per-connection overhead.

### New configuration parameters

- `auth_gssapi_keytab`: path to the acceptor keytab (required)
- `auth_gssapi_client_keytab`: optional initiator keytab override
- `auth_gssapi_service_name`: backend SPN service name (default: `postgres`)
- `client_gssencmode`: GSS encryption mode for client connections (`disable`, `allow`, `require`; default: `disable`)
- `server_gssencmode`: GSS encryption mode for backend connections (`disable`, `prefer`, `require`; default: `disable`)

The asymmetry reflects negotiation role: a server responds to what the client requests (`disable`/`allow`/`require`), while a client controls how it initiates (`disable`/`prefer`/`require`).

### Testing

A test suite (`test/test_auth_gss.py`, 26 cases) covers authentication, transport encryption, backend-encryption fallback, downgrade/injection refusal, and error paths, run against a local MIT KDC (`test/setup_kdc.sh`). A GitHub Actions job builds with `--with-gssapi`, sets up the KDC, and runs it; the tests auto-skip when GSSAPI is not built or the KDC is not running.

### References

- Issue #318: Feature idea: Support for GSS/Kerberos
- PR #1209: GSS Auth Implementation (parallel effort)
- PR #441: Add Kerberos token based GSSAPI authentication (closed)
- PR #743: Add GSS/KRB5 Encryption support (closed)