### PR TITLE
Reject repeated startup messages

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1320,7 +1320,7 @@ static bool handle_client_startup(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 
-		if (client->pool && !sending_auth_query(client)) {
+		if (client->startup_message_received) {
 			disconnect_client(client, true, "client re-sent startup pkt");
 			return false;
 		}

--- a/test/test_no_user.py
+++ b/test/test_no_user.py
@@ -1,3 +1,6 @@
+import socket
+import struct
+
 import psycopg
 import pytest
 
@@ -5,6 +8,12 @@ import pytest
 # nonexistent user under various authentication types.  Database p1
 # has a forced user, p2 does not; these exercise slightly different
 # code paths.
+
+
+def _recv_message(stream):
+    message_type = stream.read(1)
+    message_length = struct.unpack("!I", stream.read(4))[0]
+    return message_type, stream.read(message_length - 4)
 
 
 def test_no_user_trust(bouncer):
@@ -50,6 +59,31 @@ def test_no_user_md5(bouncer):
         pytest.raises(psycopg.OperationalError, match="password authentication failed"),
     ):
         bouncer.test(dbname="p2", user="nosuchuser", password="whatever")
+
+
+@pytest.mark.md5
+def test_no_user_repeated_startup(bouncer):
+    bouncer.admin("set auth_type='md5'")
+    parameters = b"user\0nosuchuser\0database\0p2\0\0"
+    payload = struct.pack("!I", 0x30000) + parameters
+    startup = struct.pack("!I", len(payload) + 4) + payload
+
+    with (
+        socket.create_connection((bouncer.host, bouncer.port), timeout=2) as sock,
+        sock.makefile("rb") as stream,
+    ):
+        sock.sendall(startup)
+        message_type, message = _recv_message(stream)
+        assert message_type == b"R"
+        assert struct.unpack("!I", message[:4])[0] == 5
+
+        with bouncer.log_contains(r"client re-sent startup pkt"):
+            sock.sendall(startup)
+            message_type, message = _recv_message(stream)
+            assert message_type == b"E"
+            assert b"client re-sent startup pkt" in message
+
+    assert bouncer.admin_value("show version")
 
 
 def test_no_user_md5_forced_user(bouncer):


### PR DESCRIPTION
Mock authentication leaves `client->pool` unset. Repeated StartupMessages can therefore overwrite `client->login_user_credentials`, leaking one `PgCredentials` allocation each.

Commit 5767152c1e9cb76639696a935219737ba4d2beb6 shows this.

```console
$ ENABLE_VALGRIND=yes pytest -q test/test_no_user.py::test_no_user_repeated_startup
...
E   AssertionError: assert b'R' == b'E'
...
==1308883== VALGRIND-ERROR-BEGIN
==1308883== 65,816 bytes in 1 blocks are definitely lost in loss record 8 of 8
==1308883==    at 0x488C0AC: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==1308883==    by 0x11E97F: set_pool (client.c:670)
==1308883==    by 0x11FF27: decide_startup_pool (client.c:1123)
==1308883==    ...
==1308883==
==1308883== VALGRIND-ERROR-END
...
1 failed, 1 error in 2.82s
```

[The fix rejects repeated StartupMessages](https://github.com/cosgroveb/pgbouncer/commit/75e65e47f565f45b89373ae19dd9186861968c3a) using `startup_message_received`, which is set after the first StartupMessage has been processed. 