### PR TITLE
Fix non-canonical distribution archive paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ EXTRA_DIST = config.guess config.sub configure install-sh lib/usual/config.h.in
 dist: $(distdir).tar.gz
 
 $(PACKAGE_TARNAME)-$(PACKAGE_VERSION).tar.gz:
-	$(GIT) -C $(srcdir) -c core.autocrlf=false archive --format tar.gz -9 --prefix $(distdir)/ $(PG_GIT_REVISION) -o $(abs_top_builddir)/$@ $(foreach file,$(EXTRA_DIST),--prefix $(distdir)/$(dir $(file)) --add-file=$(file)) --prefix $(distdir)/
+	$(GIT) -C $(srcdir) -c core.autocrlf=false archive --format tar.gz -9 --prefix $(distdir)/ $(PG_GIT_REVISION) -o $(abs_top_builddir)/$@ $(foreach file,$(EXTRA_DIST),--prefix $(distdir)/$(patsubst ./,,$(dir $(file))) --add-file=$(file)) --prefix $(distdir)/
 
 #
 # test


### PR DESCRIPTION
## Summary

Fixes #1498 by removing the unintended `./` path component from archive prefixes used for root-level files added to the Autoconf distribution tarball.

The generated archive now uses canonical paths such as `pgbouncer-1.25.2/configure` instead of `pgbouncer-1.25.2/./configure`. Nested paths continue to retain their intended directory structure.

## Implementation

The Makefile recipe strips only a leading `./` from `$(dir $(file))` before passing the path to `git archive`. This keeps the fix scoped to root-level files and avoids changing archive layout for nested files.

## Testing

- Generated a distribution archive with the Makefile recipe.
- Verified no archive entry contains `/./`.
- Verified root-level and nested files extract at the expected paths.
- Confirmed the full CI suite passes, including Windows, macOS, Linux, Valgrind, and formatting/linting.

Fixes #1498

## Author and contact

Author: Karunakar Kotha

For questions about this change, please contact kkotha@microsft.com.