### PR TITLE
Handle extra_float_digits in the admin database

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -172,6 +172,7 @@ static const struct FakeParam fake_param_list[] = {
 	{ "standard_conforming_strings", "on" },
 	{ "datestyle", "ISO" },
 	{ "timezone", "GMT" },
+	{ "extra_float_digits", "2" },
 	{ NULL },
 };
 

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -107,6 +107,10 @@ def test_show(bouncer):
         bouncer.admin(f"SHOW {item}")
 
 
+def test_jdbc_extra_float_digits(bouncer):
+    bouncer.admin("SET extra_float_digits = 2")
+
+
 def test_socket_id(bouncer) -> None:
     """Test that PgSocket id is assigned as expected for sockets."""
     config = f"""


### PR DESCRIPTION
## Summary

Fixes #1509 by treating `extra_float_digits` as a fake read-only parameter in the PgBouncer admin database. Newer PostgreSQL JDBC drivers issue `SET extra_float_digits = 2` during connection setup; PgBouncer now accepts and ignores that compatibility query instead of returning `SET failed`.

## Implementation

- Added `extra_float_digits` to the admin database fake parameter list.
- Added a regression test covering the JDBC startup `SET` query.
- Kept the change limited to the admin compatibility path; normal database parameter handling is unchanged.

This is a focused replacement for the stale approach in #1525.

## Testing

- Added `test_jdbc_extra_float_digits`.
- Confirmed the focused diff has no whitespace errors.
- CI passed on Linux, macOS, Windows, Valgrind, and formatting/linting after line-ending normalization.

Fixes #1509

## Author and contact

Author: Karunakar Kotha

For questions about this change, please contact kkotha@microsft.com.