### PR TITLE
Clarify ignored options startup parameters

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -274,12 +274,18 @@ that they are handled by the admin and it can ignore them.
 If you need to specify multiple values, use a comma-separated list (e.g.
 `options,extra_float_digits`)
 
-The Postgres protocol allows specifying parameters settings, both directly as a
+The Postgres protocol allows specifying parameter settings, both directly as a
 parameter in the startup packet, or inside the [`options` startup
 packet][options-startup]. Parameters specified using both of these methods are
 supported by `ignore_startup_parameters`. It's even possible to include
-`options` itself in `track_extra_parameters`, which results in any unknown
-parameters contained inside `options` to be ignored.
+`options` itself in `ignore_startup_parameters`, which results in any unknown
+parameters contained inside `options` being ignored. This only suppresses the
+error; it does not forward those parameters to the server or track their values.
+For example, to use a Citus setting such as
+`citus.use_secondary_nodes`, add `options` to
+`ignore_startup_parameters` and set the Citus parameter after connecting. This
+requires session pooling unless the parameter is reported by PostgreSQL or the
+extension and added to `track_extra_parameters`.
 
 
 [options-startup]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS


### PR DESCRIPTION
## Summary

Clarifies #1500 in the configuration documentation.

The documentation now explains that adding `options` to `ignore_startup_parameters` suppresses errors for unsupported parameters inside the `options` startup value, but does not forward or track those parameters. It also documents the safe Citus workflow: set `citus.use_secondary_nodes` after connecting and use session pooling unless the parameter is reported and explicitly tracked.

## Implementation

- Corrected the `ignore_startup_parameters` explanation for parameters embedded in `options`.
- Clarified that ignored values are neither forwarded to PostgreSQL nor tracked.
- Documented the Citus session-pooling requirement without adding a vendor-specific parameter to PgBouncer's global allowlist.

## Testing

- Verified the documentation diff with `git diff --check`.
- Confirmed the full CI suite passes after line-ending normalization.

No vendor-specific Citus parameter was added to PgBouncer's global default allowlist.

Fixes #1500

## Author and contact

Author: Karunakar Kotha

For questions about this change, please contact kkotha@microsft.com.