### PR TITLE
Document SHOW TOTALS byte field names

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -278,7 +278,11 @@ Subset of **SHOW STATS** showing the average values (**avg_**).
 
 #### SHOW TOTALS
 
-Like **SHOW STATS** but aggregated across all databases.
+Like **SHOW STATS** but aggregated across all databases. The byte fields
+use different names from the per-database output: `avg_client_bytes` and
+`avg_server_bytes` correspond to `avg_recv` and `avg_sent` in **SHOW STATS**.
+Likewise, `total_client_bytes` and `total_server_bytes` correspond to
+`total_received` and `total_sent`.
 
 #### SHOW SERVERS
 


### PR DESCRIPTION
## Summary

Fixes #1247 by documenting the historical field-name differences between `SHOW STATS` and `SHOW TOTALS`.

## Changes

- Documented that `SHOW TOTALS` uses `avg_client_bytes` and `avg_server_bytes` for the values exposed as `avg_recv` and `avg_sent` by `SHOW STATS`.
- Documented that `total_client_bytes` and `total_server_bytes` correspond to `total_received` and `total_sent`.
- Kept the change documentation-only; runtime behavior and output compatibility are unchanged.

## Testing

- Verified the field names against `src/stats.c`.
- Ran `git diff --check` successfully.
- Confirmed the PR contains one documentation file and no unrelated changes.

## Author and contact

Author: Karunakar Kotha

For questions about this change, please contact kkotha@microsft.com.