### PR TITLE
Refresh cached timezone after database changes

### DIFF
--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -791,6 +791,7 @@ struct PgSocket {
 #endif
 
 	VarCache vars;		/* state of interesting server parameters */
+	VarCache startup_vars;	/* parameters received before server login succeeds */
 
 	/* client: prepared statements prepared by this client */
 	PgClientPreparedStatement *client_prepared_statements;

--- a/include/proto.h
+++ b/include/proto.h
@@ -55,7 +55,7 @@ bool send_pooler_error(PgSocket *client, bool send_ready, const char *sqlstate, 
 void log_server_error(const char *note, PktHdr *pkt);
 void parse_server_error(PktHdr *pkt, const char **level_p, const char **msg_p, const char **sqlstate_p);
 
-bool add_welcome_parameter(PgPool *pool, const char *key, const char *val) _MUSTCHECK;
+bool add_welcome_parameter(PgSocket *server, const char *key, const char *val) _MUSTCHECK;
 void finish_welcome_msg(PgSocket *server);
 bool welcome_client(PgSocket *client) _MUSTCHECK;
 

--- a/include/varcache.h
+++ b/include/varcache.h
@@ -18,6 +18,7 @@ struct VarCache {
 void init_var_lookup(const char *cf_track_extra_parameters);
 int get_num_var_cached(void);
 bool varcache_set(VarCache *cache, const char *key, const char *value) /* _MUSTCHECK */;
+void varcache_merge(VarCache *dst, const VarCache *src);
 bool varcache_apply(PgSocket *server, PgSocket *client, bool *changes_p) _MUSTCHECK;
 void varcache_apply_startup(PktBuf *pkt, PgSocket *client);
 void varcache_fill_unset(VarCache *src, PgSocket *dst);

--- a/src/objects.c
+++ b/src/objects.c
@@ -123,6 +123,7 @@ static void construct_server(void *obj)
 	list_init(&server->head);
 	sbuf_init(&server->sbuf, server_proto);
 	server->vars.var_list = slab_alloc(var_list_cache);
+	server->startup_vars.var_list = slab_alloc(var_list_cache);
 	server->state = SV_FREE;
 	server->server_prepared_statements = NULL;
 	server->host = NULL;
@@ -212,8 +213,14 @@ static void server_free(PgSocket *server)
 
 	free_server_prepared_statements(server);
 	free(server->host);
+	if (server->pool && !server->pool->welcome_msg_ready) {
+		pktbuf_free(server->pool->welcome_msg);
+		server->pool->welcome_msg = NULL;
+	}
 	varcache_clean(&server->vars);
 	slab_free(var_list_cache, server->vars.var_list);
+	varcache_clean(&server->startup_vars);
+	slab_free(var_list_cache, server->startup_vars.var_list);
 	slab_free(server_cache, server);
 }
 

--- a/src/proto.c
+++ b/src/proto.c
@@ -320,37 +320,37 @@ void log_server_error(const char *note, PktHdr *pkt)
  */
 
 /* add another server parameter packet to cache */
-bool add_welcome_parameter(PgPool *pool, const char *key, const char *val)
+bool add_welcome_parameter(PgSocket *server, const char *key, const char *val)
 {
+	PgPool *pool = server->pool;
 	PktBuf *msg = pool->welcome_msg;
 
-	/*
-	 * Keep the cached server defaults current when a database setting changes
-	 * while the pool remains alive. The welcome packet itself is immutable once
-	 * it has been sent, so only append parameters while it is being built.
-	 */
-	if (!varcache_set(&pool->orig_vars, key, val) && !pool->welcome_msg_ready) {
-		if (!msg) {
-			msg = pktbuf_dynamic(128);
-			if (!msg)
-				return false;
-			pool->welcome_msg = msg;
-		}
-
-		/* first packet must be AuthOk */
-		if (msg->write_pos == 0)
-			pktbuf_write_AuthenticationOk(msg);
-
-		pktbuf_write_ParameterStatus(msg, key, val);
+	if (!msg) {
+		msg = pktbuf_dynamic(128);
+		if (!msg)
+			return false;
+		pool->welcome_msg = msg;
 	}
 
-	return !msg || !msg->failed;
+	/* first packet must be AuthOk */
+	if (msg->write_pos == 0)
+		pktbuf_write_AuthenticationOk(msg);
+
+	/*
+	 * Do not publish values until this server reaches ReadyForQuery. A backend
+	 * can send ParameterStatus before rejecting the startup.
+	 */
+	if (!varcache_set(&server->startup_vars, key, val) && !pool->welcome_msg_ready)
+		pktbuf_write_ParameterStatus(msg, key, val);
+
+	return !msg->failed;
 }
 
 /* all parameters processed */
 void finish_welcome_msg(PgSocket *server)
 {
 	PgPool *pool = server->pool;
+	varcache_merge(&pool->orig_vars, &server->startup_vars);
 	if (pool->welcome_msg_ready)
 		return;
 	pool->welcome_msg_ready = true;

--- a/src/proto.c
+++ b/src/proto.c
@@ -324,25 +324,27 @@ bool add_welcome_parameter(PgPool *pool, const char *key, const char *val)
 {
 	PktBuf *msg = pool->welcome_msg;
 
-	if (pool->welcome_msg_ready)
-		return true;
+	/*
+	 * Keep the cached server defaults current when a database setting changes
+	 * while the pool remains alive. The welcome packet itself is immutable once
+	 * it has been sent, so only append parameters while it is being built.
+	 */
+	if (!varcache_set(&pool->orig_vars, key, val) && !pool->welcome_msg_ready) {
+		if (!msg) {
+			msg = pktbuf_dynamic(128);
+			if (!msg)
+				return false;
+			pool->welcome_msg = msg;
+		}
 
-	if (!msg) {
-		msg = pktbuf_dynamic(128);
-		if (!msg)
-			return false;
-		pool->welcome_msg = msg;
+		/* first packet must be AuthOk */
+		if (msg->write_pos == 0)
+			pktbuf_write_AuthenticationOk(msg);
+
+		pktbuf_write_ParameterStatus(msg, key, val);
 	}
 
-	/* first packet must be AuthOk */
-	if (msg->write_pos == 0)
-		pktbuf_write_AuthenticationOk(msg);
-
-	/* if not stored in ->orig_vars, write full packet */
-	if (!varcache_set(&pool->orig_vars, key, val))
-		pktbuf_write_ParameterStatus(msg, key, val);
-
-	return !msg->failed;
+	return !msg || !msg->failed;
 }
 
 /* all parameters processed */

--- a/src/server.c
+++ b/src/server.c
@@ -53,7 +53,7 @@ static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
 	}
 
 	if (startup) {
-		if (!add_welcome_parameter(server->pool, key, val))
+		if (!add_welcome_parameter(server, key, val))
 			goto failed_store;
 	}
 

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -138,6 +138,18 @@ bool varcache_set(VarCache *cache, const char *key, const char *value)
 	return true;
 }
 
+void varcache_merge(VarCache *dst, const VarCache *src)
+{
+	const struct var_lookup *lk, *tmp;
+	const struct PStr *val;
+
+	HASH_ITER(hh, lookup_map, lk, tmp) {
+		val = src->var_list[lk->idx];
+		if (val)
+			varcache_set(dst, lk->name, val->str);
+	}
+}
+
 static bool variable_is_guc_list_quote(const char *key)
 {
 	if (strcasecmp("search_path", key) == 0)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -493,6 +493,80 @@ def test_track_extra_parameters(bouncer):
             assert result2[0] == test_expected[key][1]
 
 
+def _reject_backend_after_timezone(listener, rejection_processed):
+    with listener.accept()[0] as backend, backend.makefile("rb") as stream:
+        startup_length = struct.unpack("!I", stream.read(4))[0]
+        stream.read(startup_length - 4)
+
+        def message(message_type, payload):
+            return message_type + struct.pack("!I", len(payload) + 4) + payload
+
+        authentication_ok = message(b"R", struct.pack("!I", 0))
+        parameter_status = message(b"S", b"TimeZone\0Europe/Paris\0")
+        fatal_error = message(b"E", b"SFATAL\0C08006\0Mtest backend rejected\0\0")
+        backend.sendall(authentication_ok + parameter_status + fatal_error)
+
+        # Wait until PgBouncer processes the error and closes the connection.
+        stream.read()
+    rejection_processed.set()
+
+
+async def test_rejected_backend_does_not_refresh_cached_timezone(bouncer, pg):
+    rejected_host = "127.0.0.2"
+    config = f"""
+    [databases]
+    postgres = host={pg.host},{rejected_host} port={pg.port} load_balance_hosts=round-robin
+
+    [pgbouncer]
+    listen_addr = {bouncer.host}
+    admin_users = pgbouncer
+    auth_type = trust
+    auth_file = {bouncer.auth_path}
+    listen_port = {bouncer.port}
+    logfile = {bouncer.log_path}
+    pool_mode = session
+    server_login_retry = 10
+    server_tls_sslmode = disable
+    """
+
+    rejection_processed = threading.Event()
+    pending_query = None
+    with socket.socket() as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind((rejected_host, pg.port))
+        listener.listen()
+        fake_backend = threading.Thread(
+            target=_reject_backend_after_timezone,
+            args=(listener, rejection_processed),
+            daemon=True,
+        )
+        fake_backend.start()
+
+        try:
+            with (
+                bouncer.run_with_config(config),
+                bouncer.conn(dbname="postgres", user="puser1") as accepted,
+            ):
+                # Keep the admitted server occupied so the next query opens
+                # the fake backend.
+                accepted.execute("SELECT 1")
+                accepted_timezone = accepted.info.parameter_status("TimeZone")
+                pending_query = bouncer.asql(
+                    "SELECT 1", dbname="postgres", user="puser1", connect_timeout=15
+                )
+                assert await asyncio.to_thread(rejection_processed.wait, 5)
+
+                with bouncer.conn(dbname="postgres", user="puser1") as later:
+                    assert later.info.parameter_status("TimeZone") == accepted_timezone
+        finally:
+            if pending_query is not None and not pending_query.done():
+                pending_query.cancel()
+            if pending_query is not None:
+                await asyncio.gather(pending_query, return_exceptions=True)
+            fake_backend.join(timeout=5)
+            assert not fake_backend.is_alive()
+
+
 def test_timezone_change_after_database_alter(bouncer, pg):
     config = f"""
     [databases]

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -493,6 +493,39 @@ def test_track_extra_parameters(bouncer):
             assert result2[0] == test_expected[key][1]
 
 
+def test_timezone_change_after_database_alter(bouncer, pg):
+    config = f"""
+    [databases]
+    postgres = host={pg.host} port={pg.port}
+
+    [pgbouncer]
+    listen_addr = {bouncer.host}
+    admin_users = pgbouncer
+    auth_type = trust
+    auth_file = {bouncer.auth_path}
+    listen_port = {bouncer.port}
+    logfile = {bouncer.log_path}
+    pool_mode = session
+    query_wait_notify = 1
+    """
+
+    with bouncer.run_with_config(config):
+        pg.sql("ALTER DATABASE postgres RESET timezone")
+        bouncer.admin("reconnect postgres")
+        initial_timezone = bouncer.sql_value("SHOW timezone", user="puser1")
+
+        try:
+            pg.sql("ALTER DATABASE postgres SET timezone TO 'Europe/Paris'")
+            bouncer.admin("reconnect postgres")
+            updated_timezone = bouncer.sql_value("SHOW timezone", user="puser1")
+
+            assert initial_timezone != updated_timezone
+            assert updated_timezone == pg.sql_value("SHOW timezone", dbname="postgres")
+        finally:
+            pg.sql("ALTER DATABASE postgres RESET timezone")
+            bouncer.admin("reconnect postgres")
+
+
 async def test_wait_close(bouncer):
     with bouncer.cur(dbname="p3") as cur:
         cur.execute("select 1")

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -512,12 +512,16 @@ def test_timezone_change_after_database_alter(bouncer, pg):
     with bouncer.run_with_config(config):
         pg.sql("ALTER DATABASE postgres RESET timezone")
         bouncer.admin("reconnect postgres")
-        initial_timezone = bouncer.sql_value("SHOW timezone", dbname="postgres", user="puser1")
+        initial_timezone = bouncer.sql_value(
+            "SHOW timezone", dbname="postgres", user="puser1"
+        )
 
         try:
             pg.sql("ALTER DATABASE postgres SET timezone TO 'Europe/Paris'")
             bouncer.admin("reconnect postgres")
-            updated_timezone = bouncer.sql_value("SHOW timezone", dbname="postgres", user="puser1")
+            updated_timezone = bouncer.sql_value(
+                "SHOW timezone", dbname="postgres", user="puser1"
+            )
 
             assert initial_timezone != updated_timezone
             assert updated_timezone == pg.sql_value("SHOW timezone", dbname="postgres")

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -512,12 +512,12 @@ def test_timezone_change_after_database_alter(bouncer, pg):
     with bouncer.run_with_config(config):
         pg.sql("ALTER DATABASE postgres RESET timezone")
         bouncer.admin("reconnect postgres")
-        initial_timezone = bouncer.sql_value("SHOW timezone", user="puser1")
+        initial_timezone = bouncer.sql_value("SHOW timezone", dbname="postgres", user="puser1")
 
         try:
             pg.sql("ALTER DATABASE postgres SET timezone TO 'Europe/Paris'")
             bouncer.admin("reconnect postgres")
-            updated_timezone = bouncer.sql_value("SHOW timezone", user="puser1")
+            updated_timezone = bouncer.sql_value("SHOW timezone", dbname="postgres", user="puser1")
 
             assert initial_timezone != updated_timezone
             assert updated_timezone == pg.sql_value("SHOW timezone", dbname="postgres")


### PR DESCRIPTION
## Summary

Fixes #1255 by keeping the pool's cached server parameters current after PostgreSQL reports a changed database setting.

When a database-level `TimeZone` setting changes, the existing welcome packet remains valid for already-connected clients, but the cached defaults used for new clients must be refreshed. PgBouncer now updates `orig_vars` whenever startup `ParameterStatus` messages arrive, even after the pool welcome message is ready. New sessions therefore receive the database's current timezone instead of a stale value from the first connection.

## Testing

- Added a regression test covering `ALTER DATABASE ... SET timezone`, PgBouncer reconnect, and restoration with `RESET timezone`.
- `git diff --check` passed.
- Full build and test validation will run in CI.

## Author

Karunakar Kotha

Questions: kkotha@microsft.com