### PR TITLE
Configure pytest async fixture loop scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ markers = [
 timeout = 30
 
 asyncio_mode = 'auto'
+asyncio_default_fixture_loop_scope = 'function'
 
 # Make test discovery quicker
 norecursedirs = [


### PR DESCRIPTION
## Summary

Fixes #1330 by explicitly setting pytest-asyncio's default fixture loop scope to `function`. This removes the deprecation warning and makes the test suite's future async fixture behavior explicit.

The previously reported missing `await` calls in async tests are already fixed upstream; this PR contains only the remaining configuration cleanup.

## Testing

- Confirmed the setting is accepted by pytest and pytest-asyncio.
- Full test execution was blocked locally because PostgreSQL `initdb` is unavailable in the environment.
- Existing upstream CI will provide the complete PostgreSQL-backed validation.

## Author and contact

Author: Karunakar Kotha

Contact: kkotha@microsft.com





