### PR TITLE
Stabilize notify queue test on slow architectures

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -204,8 +204,9 @@ async def test_notify_queue(bouncer):
         notices_received.append(diag.message_primary)
 
     with bouncer.run_with_config(config):
+        # Leave enough time for the queued client to connect on slow platforms.
         sleep_future = bouncer.asql(
-            "SELECT pg_sleep(6)", dbname="postgres", user="puser1"
+            "SELECT pg_sleep(10)", dbname="postgres", user="puser1"
         )
         _, sleep_future = await asyncio.wait([sleep_future], timeout=1)
 
@@ -223,7 +224,7 @@ async def test_notify_queue(bouncer):
         assert expected_message == notices_received[0]
 
         sleep_future = bouncer.asql(
-            "SELECT pg_sleep(6)", dbname="postgres", user="puser1"
+            "SELECT pg_sleep(10)", dbname="postgres", user="puser1"
         )
         _, sleep_future = await asyncio.wait([sleep_future], timeout=1)
 


### PR DESCRIPTION
## Summary

Fixes #1427 by giving the positive `test_notify_queue` scenarios enough time for the queued client to connect on slower architectures such as s390x and ppc64.

The test starts a six-second `pg_sleep()` before connecting the second client. On slower builders, that client could connect after the sleep completed, so the expected queue notification was never generated. The positive scenarios now use a ten-second sleep, with a comment documenting the timing requirement. The negative scenario is unchanged.

## Testing

- Python compilation passed.
- Diff validation passed.
- Targeted pytest and Ruff were unavailable in the local environment.
- Upstream CI will provide PostgreSQL-backed validation.

## Author and contact

Author: Karunakar Kotha

Contact: kkotha@microsft.com