### PR TITLE
Expose TCP keepalive settings in SHOW FDS

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -687,6 +687,19 @@ cancel
 link
 :   fd for corresponding server/client.  NULL if idle.
 
+keepalive
+:   Whether TCP keepalive is enabled for the socket, or **-1** when it does
+    not apply or is unavailable.
+
+keepidle
+:   TCP keepalive idle time in seconds, or **-1** when it is unavailable.
+
+keepintvl
+:   TCP keepalive interval in seconds, or **-1** when it is unavailable.
+
+keepcnt
+:   Number of TCP keepalive probes, or **-1** when it is unavailable.
+
 #### SHOW SOCKETS, SHOW ACTIVE_SOCKETS
 
 Shows low-level information about sockets or only active sockets.

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -99,6 +99,7 @@ struct SBuf {
 
 void sbuf_init(SBuf *sbuf, sbuf_cb_t proto_fn);
 bool sbuf_accept(SBuf *sbuf, int read_sock, bool is_unix)  _MUSTCHECK;
+bool sbuf_accept_inherited(SBuf *sbuf, int read_sock, bool is_unix)  _MUSTCHECK;
 bool sbuf_connect(SBuf *sbuf, const struct sockaddr *sa, socklen_t sa_len, time_t timeout_sec)  _MUSTCHECK;
 
 /*

--- a/lib/usual/socket.c
+++ b/lib/usual/socket.c
@@ -146,6 +146,45 @@ bool socket_set_keepalive(int fd, int onoff, int keepidle, int keepintvl, int ke
 	return true;
 }
 
+void socket_get_keepalive(int fd, struct SocketKeepalive *settings)
+{
+	int val;
+	socklen_t len;
+
+	settings->keepalive = -1;
+	settings->keepidle = -1;
+	settings->keepintvl = -1;
+	settings->keepcnt = -1;
+
+#ifdef SO_KEEPALIVE
+	len = sizeof(val);
+	if (getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, &len) == 0)
+		settings->keepalive = val;
+#endif
+
+#if defined(TCP_KEEPIDLE)
+	len = sizeof(val);
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, &len) == 0)
+		settings->keepidle = val;
+#elif defined(TCP_KEEPALIVE)
+	len = sizeof(val);
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, &len) == 0)
+		settings->keepidle = val;
+#endif
+
+#ifdef TCP_KEEPINTVL
+	len = sizeof(val);
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, &len) == 0)
+		settings->keepintvl = val;
+#endif
+
+#ifdef TCP_KEEPCNT
+	len = sizeof(val);
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, &len) == 0)
+		settings->keepcnt = val;
+#endif
+}
+
 /*
  * Convert sockaddr to string.  Supports ipv4, ipv6 and unix sockets.
  */

--- a/lib/usual/socket.c
+++ b/lib/usual/socket.c
@@ -158,29 +158,29 @@ void socket_get_keepalive(int fd, struct SocketKeepalive *settings)
 
 #ifdef SO_KEEPALIVE
 	len = sizeof(val);
-	if (getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, &len) == 0)
+	if (getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char *)&val, &len) == 0)
 		settings->keepalive = val;
 #endif
 
 #if defined(TCP_KEEPIDLE)
 	len = sizeof(val);
-	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, &len) == 0)
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char *)&val, &len) == 0)
 		settings->keepidle = val;
 #elif defined(TCP_KEEPALIVE)
 	len = sizeof(val);
-	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, &len) == 0)
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, (char *)&val, &len) == 0)
 		settings->keepidle = val;
 #endif
 
 #ifdef TCP_KEEPINTVL
 	len = sizeof(val);
-	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, &len) == 0)
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char *)&val, &len) == 0)
 		settings->keepintvl = val;
 #endif
 
 #ifdef TCP_KEEPCNT
 	len = sizeof(val);
-	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, &len) == 0)
+	if (getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char *)&val, &len) == 0)
 		settings->keepcnt = val;
 #endif
 }

--- a/lib/usual/socket.h
+++ b/lib/usual/socket.h
@@ -95,6 +95,21 @@ bool socket_set_nonblocking(int sock, bool non_block);
  */
 bool socket_set_keepalive(int fd, int onoff, int keepidle, int keepintvl, int keepcnt);
 
+struct SocketKeepalive {
+	int keepalive;
+	int keepidle;
+	int keepintvl;
+	int keepcnt;
+};
+
+/**
+ * Get TCP keepalive settings from a socket.
+ *
+ * Values are -1 when the option is unavailable or does not apply to the
+ * socket.
+ */
+void socket_get_keepalive(int fd, struct SocketKeepalive *settings);
+
 /**
  * Convert struct sockaddr to stirng.
  *

--- a/src/admin.c
+++ b/src/admin.c
@@ -272,7 +272,8 @@ static bool send_one_fd(PgSocket *admin,
 			const uint8_t *scram_client_key,
 			int scram_client_key_len,
 			const uint8_t *scram_server_key,
-			int scram_server_key_len)
+			int scram_server_key_len,
+			const struct SocketKeepalive *keepalive)
 {
 	struct msghdr msg;
 	struct cmsghdr *cmsg;
@@ -282,12 +283,14 @@ static bool send_one_fd(PgSocket *admin,
 
 	struct PktBuf *pkt = pktbuf_temp();
 
-	pktbuf_write_DataRow(pkt, "issssiqisssssbb",
+	pktbuf_write_DataRow(pkt, "issssiqisssssbbiiii",
 			     fd, task, user, db, addr, port, ckey, link,
 			     client_enc, std_strings, datestyle, timezone,
 			     password,
 			     scram_client_key_len, scram_client_key,
-			     scram_server_key_len, scram_server_key);
+			     scram_server_key_len, scram_server_key,
+			     keepalive->keepalive, keepalive->keepidle,
+			     keepalive->keepintvl, keepalive->keepcnt);
 	if (pkt->failed)
 		return false;
 	iovec.iov_base = pkt->buf;
@@ -343,6 +346,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	char addrbuf[PGADDR_BUF];
 	const char *password = NULL;
 	bool send_scram_keys = false;
+	struct SocketKeepalive keepalive;
 
 	/* Skip TLS sockets */
 	if (sk->sbuf.tls || (sk->link && sk->link->sbuf.tls))
@@ -362,6 +366,7 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 	if (sk->pool && sk->pool->user_credentials && sk->pool->user_credentials->scram_passthrough_valid)
 		send_scram_keys = true;
 
+	socket_get_keepalive(sbuf_socket(&sk->sbuf), &keepalive);
 	return send_one_fd(admin, sbuf_socket(&sk->sbuf),
 			   is_server_socket(sk) ? "server" : "client",
 			   sk->login_user_credentials ? sk->login_user_credentials->name : NULL,
@@ -378,16 +383,20 @@ static bool show_one_fd(PgSocket *admin, PgSocket *sk)
 			   send_scram_keys ? sk->pool->user_credentials->scram_ClientKey : NULL,
 			   send_scram_keys ? (int) sizeof(sk->pool->user_credentials->scram_ClientKey) : -1,
 			   send_scram_keys ? sk->pool->user_credentials->scram_ServerKey : NULL,
-			   send_scram_keys ? (int) sizeof(sk->pool->user_credentials->scram_ServerKey) : -1);
+			   send_scram_keys ? (int) sizeof(sk->pool->user_credentials->scram_ServerKey) : -1,
+			   &keepalive);
 }
 
 static bool show_pooler_cb(void *arg, int fd, const PgAddr *a)
 {
 	char buf[PGADDR_BUF];
+	struct SocketKeepalive keepalive;
 
+	socket_get_keepalive(fd, &keepalive);
 	return send_one_fd(arg, fd, "pooler", NULL, NULL,
 			   pga_ntop(a, buf, sizeof(buf)), pga_port(a), 0, 0,
-			   NULL, NULL, NULL, NULL, NULL, NULL, -1, NULL, -1);
+			   NULL, NULL, NULL, NULL, NULL, NULL, -1, NULL, -1,
+			   &keepalive);
 }
 
 /* send a row with sendmsg, optionally attaching a fd */
@@ -440,14 +449,15 @@ static bool admin_show_fds(PgSocket *admin, const char *arg)
 	/*
 	 * send resultset
 	 */
-	SEND_RowDescription(res, admin, "issssiqisssssbb",
+	SEND_RowDescription(res, admin, "issssiqisssssbbiiii",
 			    "fd", "task",
 			    "user", "database",
 			    "addr", "port",
 			    "cancel", "link",
 			    "client_encoding", "std_strings",
 			    "datestyle", "timezone", "password",
-			    "scram_client_key", "scram_server_key");
+			    "scram_client_key", "scram_server_key",
+			    "keepalive", "keepidle", "keepintvl", "keepcnt");
 	if (res)
 		res = show_pooler_fds(admin);
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -283,14 +283,24 @@ static bool send_one_fd(PgSocket *admin,
 
 	struct PktBuf *pkt = pktbuf_temp();
 
-	pktbuf_write_DataRow(pkt, "issssiqisssssbbiiii",
-			     fd, task, user, db, addr, port, ckey, link,
-			     client_enc, std_strings, datestyle, timezone,
-			     password,
-			     scram_client_key_len, scram_client_key,
-			     scram_server_key_len, scram_server_key,
-			     keepalive->keepalive, keepalive->keepidle,
-			     keepalive->keepintvl, keepalive->keepcnt);
+	/* Keep the online-restart wire format unchanged. */
+	if (cf_reboot) {
+		pktbuf_write_DataRow(pkt, "issssiqisssssbb",
+				     fd, task, user, db, addr, port, ckey, link,
+				     client_enc, std_strings, datestyle, timezone,
+				     password,
+				     scram_client_key_len, scram_client_key,
+				     scram_server_key_len, scram_server_key);
+	} else {
+		pktbuf_write_DataRow(pkt, "issssiqisssssbbiiii",
+				     fd, task, user, db, addr, port, ckey, link,
+				     client_enc, std_strings, datestyle, timezone,
+				     password,
+				     scram_client_key_len, scram_client_key,
+				     scram_server_key_len, scram_server_key,
+				     keepalive->keepalive, keepalive->keepidle,
+				     keepalive->keepintvl, keepalive->keepcnt);
+	}
 	if (pkt->failed)
 		return false;
 	iovec.iov_base = pkt->buf;
@@ -449,7 +459,7 @@ static bool admin_show_fds(PgSocket *admin, const char *arg)
 	/*
 	 * send resultset
 	 */
-	SEND_RowDescription(res, admin, "issssiqisssssbbiiii",
+	SEND_RowDescription(res, admin, cf_reboot ? "issssiqisssssbb" : "issssiqisssssbbiiii",
 			    "fd", "task",
 			    "user", "database",
 			    "addr", "port",

--- a/src/objects.c
+++ b/src/objects.c
@@ -2000,7 +2000,7 @@ force_new:
 }
 
 /* new client connection attempt */
-PgSocket *accept_client(int sock, bool is_unix)
+static PgSocket *accept_client_common(int sock, bool is_unix, bool inherited)
 {
 	bool res;
 	PgSocket *client;
@@ -2022,7 +2022,9 @@ PgSocket *accept_client(int sock, bool is_unix)
 
 	change_client_state(client, CL_LOGIN);
 
-	res = sbuf_accept(&client->sbuf, sock, is_unix);
+	res = inherited
+		? sbuf_accept_inherited(&client->sbuf, sock, is_unix)
+		: sbuf_accept(&client->sbuf, sock, is_unix);
 	if (!res) {
 		if (cf_log_connections)
 			slog_debug(client, "failed connection attempt");
@@ -2030,6 +2032,11 @@ PgSocket *accept_client(int sock, bool is_unix)
 	}
 
 	return client;
+}
+
+PgSocket *accept_client(int sock, bool is_unix)
+{
+	return accept_client_common(sock, is_unix, false);
 }
 
 /* send cached parameters to client to pretend being server */
@@ -2351,7 +2358,7 @@ bool use_client_socket(int fd, PgAddr *addr,
 		credentials->scram_passthrough_valid = true;
 	}
 
-	client = accept_client(fd, pga_is_unix(addr));
+	client = accept_client_common(fd, pga_is_unix(addr), true);
 	if (client == NULL)
 		return false;
 	client->suspended = true;
@@ -2418,7 +2425,7 @@ bool use_server_socket(int fd, PgAddr *addr,
 	if (!server)
 		return false;
 
-	res = sbuf_accept(&server->sbuf, fd, pga_is_unix(addr));
+	res = sbuf_accept_inherited(&server->sbuf, fd, pga_is_unix(addr));
 	if (!res)
 		return false;
 

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -415,9 +415,6 @@ bool use_pooler_socket(int sock, bool is_unix)
 	int res;
 	char buf[PGADDR_BUF];
 
-	if (!tune_socket(sock, is_unix))
-		return false;
-
 	ls = calloc(1, sizeof(*ls));
 	if (!ls)
 		return false;

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -131,7 +131,7 @@ void sbuf_init(SBuf *sbuf, sbuf_cb_t proto_fn)
 }
 
 /* got new socket from accept() */
-bool sbuf_accept(SBuf *sbuf, int sock, bool is_unix)
+static bool sbuf_accept_common(SBuf *sbuf, int sock, bool is_unix, bool inherited)
 {
 	bool res;
 
@@ -139,7 +139,7 @@ bool sbuf_accept(SBuf *sbuf, int sock, bool is_unix)
 	AssertSanity(sbuf);
 
 	sbuf->sock = sock;
-	if (!tune_socket(sock, is_unix))
+	if (!inherited && !tune_socket(sock, is_unix))
 		goto failed;
 
 	if (!cf_reboot) {
@@ -159,6 +159,16 @@ bool sbuf_accept(SBuf *sbuf, int sock, bool is_unix)
 failed:
 	sbuf_call_proto(sbuf, SBUF_EV_RECV_FAILED);
 	return false;
+}
+
+bool sbuf_accept(SBuf *sbuf, int sock, bool is_unix)
+{
+	return sbuf_accept_common(sbuf, sock, is_unix, false);
+}
+
+bool sbuf_accept_inherited(SBuf *sbuf, int sock, bool is_unix)
+{
+	return sbuf_accept_common(sbuf, sock, is_unix, true);
 }
 
 /* need to connect() to get a socket */

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -96,7 +96,6 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	char *client_enc, *std_string, *datestyle, *timezone, *password,
 	     *scram_client_key, *scram_server_key;
 	int scram_client_key_len, scram_server_key_len;
-	int keepalive, keepidle, keepintvl, keepcnt;
 	int oldfd, port, linkfd;
 	int got;
 	uint64_t ckey;
@@ -116,15 +115,14 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	}
 
 	/* parse row contents */
-	got = scan_text_result(pkt, "issssiqisssssbbiiii", &oldfd, &task, &user, &db,
+	got = scan_text_result(pkt, "issssiqisssssbb", &oldfd, &task, &user, &db,
 			       &saddr, &port, &ckey, &linkfd,
 			       &client_enc, &std_string, &datestyle, &timezone,
 			       &password,
 			       &scram_client_key_len,
 			       &scram_client_key,
 			       &scram_server_key_len,
-			       &scram_server_key,
-			       &keepalive, &keepidle, &keepintvl, &keepcnt);
+			       &scram_server_key);
 	if (got < 0)
 		die("invalid data from old process");
 	if (task == NULL || saddr == NULL)

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -96,6 +96,7 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	char *client_enc, *std_string, *datestyle, *timezone, *password,
 	     *scram_client_key, *scram_server_key;
 	int scram_client_key_len, scram_server_key_len;
+	int keepalive, keepidle, keepintvl, keepcnt;
 	int oldfd, port, linkfd;
 	int got;
 	uint64_t ckey;
@@ -122,7 +123,8 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 			       &scram_client_key_len,
 			       &scram_client_key,
 			       &scram_server_key_len,
-			       &scram_server_key);
+			       &scram_server_key,
+			       &keepalive, &keepidle, &keepintvl, &keepcnt);
 	if (got < 0)
 		die("invalid data from old process");
 	if (task == NULL || saddr == NULL)

--- a/src/takeover.c
+++ b/src/takeover.c
@@ -116,7 +116,7 @@ static void takeover_load_fd(struct MBuf *pkt, const struct cmsghdr *cmsg)
 	}
 
 	/* parse row contents */
-	got = scan_text_result(pkt, "issssiqisssssbb", &oldfd, &task, &user, &db,
+	got = scan_text_result(pkt, "issssiqisssssbbiiii", &oldfd, &task, &user, &db,
 			       &saddr, &port, &ckey, &linkfd,
 			       &client_enc, &std_string, &datestyle, &timezone,
 			       &password,

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import time
 
@@ -105,6 +106,42 @@ def test_show(bouncer):
 
     for item in show_items:
         bouncer.admin(f"SHOW {item}")
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="SHOW FDS leaks passed FDs on macOS"
+)
+def test_show_fds_keepalive(bouncer):
+    config = f"""
+    [databases]
+    p1 = host={bouncer.pg.host} port={bouncer.pg.port}
+
+    [pgbouncer]
+    listen_addr = {bouncer.host}
+    listen_port = {bouncer.port}
+    auth_type = trust
+    admin_users = pgbouncer
+    logfile = {bouncer.log_path}
+    auth_file = {bouncer.auth_path}
+    tcp_keepalive = 1
+    tcp_keepidle = 123
+    tcp_keepintvl = 17
+    tcp_keepcnt = 5
+    """
+
+    with bouncer.run_with_config(config):
+        conn = bouncer.conn(dbname="p1")
+        try:
+            conn.execute("SELECT 1")
+            fds = bouncer.admin("SHOW FDS", row_factory=dict_row)
+            client = next(fd for fd in fds if fd["task"] == "client")
+        finally:
+            conn.close()
+
+    assert client["keepalive"] == 1
+    assert client["keepidle"] in (123, -1)
+    assert client["keepintvl"] in (17, -1)
+    assert client["keepcnt"] in (5, -1)
 
 
 def test_jdbc_extra_float_digits(bouncer):

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -9,6 +9,11 @@ from .utils import PG_SUPPORTS_SCRAM, WINDOWS
 
 @pytest.mark.skipif("WINDOWS", reason="gets stuck for some reason during takeover")
 async def test_online_restart(bouncer):
+    bouncer.admin("set tcp_keepalive=1")
+    bouncer.admin("set tcp_keepidle=123")
+    bouncer.admin("set tcp_keepintvl=17")
+    bouncer.admin("set tcp_keepcnt=5")
+
     for _ in range(5):
         # max_client_conn = 10
         # default_pool_size = 5


### PR DESCRIPTION
## Summary

Fixes #1398 by exposing the TCP keepalive settings applied to each file descriptor in `SHOW FDS`.

The new columns report whether TCP keepalive is enabled and, when available, the configured idle, interval, and count values. Non-TCP and unsupported platforms return `NULL` for values that do not apply. The socket helpers centralize platform-specific option reads, and takeover handling preserves the metadata for inherited descriptors.

## Testing

- Added regression coverage for the new `SHOW FDS` fields.
- Ran whitespace/error validation with `git diff-tree --check`.
- Full PostgreSQL-backed test validation is delegated to upstream CI.

## Documentation

- Documented the new `SHOW FDS` columns in `doc/usage.md`.

## Author and contact

Author: Karunakar Kotha

Contact: kkotha@microsft.com