### PR TITLE
Make repeated SIGINT test tolerate connection errors

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -764,7 +764,10 @@ async def test_repeated_sigint(bouncer):
 
         # But new clients should be rejected, because we stopped listening for
         # new connections.
-        with pytest.raises(psycopg.OperationalError, match="Connection refused"):
+        with pytest.raises(
+            psycopg.OperationalError,
+            match=r"Connection refused|server closed the connection unexpectedly",
+        ):
             bouncer.test()
 
         # Second sigint should cause fast exit


### PR DESCRIPTION
## Summary
Make 	est_repeated_sigint accept both connection error messages that can occur while PgBouncer is shutting down on slower systems.

The test continues to require an expected connection failure, while accepting either Connection refused or server closed the connection unexpectedly from psycopg.

## Testing
- python -m py_compile test/test_misc.py
- git diff --check
- Focused pytest was blocked because PostgreSQL initdb is unavailable locally.

Fixes #1445