### PR TITLE
scram: use OpenSSL for PBKDF2 when available 

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -439,7 +439,7 @@ Default: 200
 The number of computational iterations to be performed when encrypting a
 password using SCRAM-SHA-256. A higher number of iterations provides additional
 protection against brute-force attacks on stored passwords, but makes
-authentication slower.
+authentication slower. This value must be at least 1.
 
 Default: 4096
 

--- a/lib/m4/usual.m4
+++ b/lib/m4/usual.m4
@@ -456,8 +456,8 @@ if test "$tls_support" = "auto" -o "$tls_support" = "libssl"; then
                     [[SSL_CTX *ctx = SSL_CTX_new(SSLv23_method());]])],
     [ tls_support=yes; AC_MSG_RESULT([found])],
     [ AC_MSG_ERROR([not found]) ])
-  dnl check LibreSSL-only APIs
-  AC_CHECK_FUNCS(SSL_CTX_use_certificate_chain_mem SSL_CTX_load_verify_mem asn1_time_parse)
+  dnl check optional OpenSSL and LibreSSL APIs
+  AC_CHECK_FUNCS(PKCS5_PBKDF2_HMAC SSL_CTX_use_certificate_chain_mem SSL_CTX_load_verify_mem asn1_time_parse)
   CPPFLAGS="$tmp_CPPFLAGS"
   LDFLAGS="$tmp_LDFLAGS"
   LIBS="$tmp_LIBS"

--- a/meson.build
+++ b/meson.build
@@ -326,6 +326,11 @@ if openssl.found()
   cdata.set('OPENSSL_API_COMPAT', '0x00908000L',
             description: 'OpenSSL API version in use, to silence deprecation warnings.')
 
+  cdata.set('HAVE_PKCS5_PBKDF2_HMAC',
+            cc.has_function('PKCS5_PBKDF2_HMAC',
+                            prefix: '#include <openssl/evp.h>',
+                            dependencies: openssl) ? 1 : false)
+
   # LibreSSL-only helpers, used when present.
   foreach func : ['SSL_CTX_use_certificate_chain_mem', 'SSL_CTX_load_verify_mem', 'asn1_time_parse']
     cdata.set('HAVE_' + func.to_upper(),

--- a/src/main.c
+++ b/src/main.c
@@ -217,6 +217,8 @@ int cf_scram_iterations;
 
 static bool set_defer_accept(struct CfValue *cv, const char *val);
 #define DEFER_OPS {set_defer_accept, cf_get_int}
+static bool set_scram_iterations(struct CfValue *cv, const char *val);
+#define SCRAM_ITERATIONS_OPS {set_scram_iterations, cf_get_int}
 
 static const struct CfLookup auth_type_map[] = {
 	{ "any", AUTH_TYPE_ANY },
@@ -323,7 +325,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("reserve_pool_timeout", CF_TIME_USEC, cf_res_pool_timeout, 0, "5"),
 	CF_ABS("resolv_conf", CF_STR, cf_resolv_conf, CF_NO_RELOAD, ""),
 	CF_ABS("sbuf_loopcnt", CF_INT, cf_sbuf_loopcnt, 0, "5"),
-	CF_ABS("scram_iterations", CF_INT, cf_scram_iterations, 0, SCRAM_DEFAULT_ITERATIONS),
+	CF_ABS("scram_iterations", SCRAM_ITERATIONS_OPS, cf_scram_iterations, 0, SCRAM_DEFAULT_ITERATIONS),
 	CF_ABS("server_check_delay", CF_TIME_USEC, cf_server_check_delay, 0, "30"),
 	CF_ABS("server_check_query", CF_STR, cf_server_check_query, 0, "<empty>"),
 	CF_ABS("server_connect_timeout", CF_TIME_USEC, cf_server_connect_timeout, 0, "15"),
@@ -423,6 +425,23 @@ static bool set_defer_accept(struct CfValue *cv, const char *val)
 	if (ok && !!oldval != !!*p)
 		pooler_tune_accept(*p);
 	return ok;
+}
+
+static bool set_scram_iterations(struct CfValue *cv, const char *val)
+{
+	int *p = cv->value_p;
+	char *end;
+	long iterations;
+
+	errno = 0;
+	iterations = strtol(val, &end, 0);
+	if (end == val || *end != '\0' || errno != 0 ||
+	    iterations < 1 || iterations > INT_MAX) {
+		errno = EINVAL;
+		return false;
+	}
+	*p = (int)iterations;
+	return true;
 }
 
 static void set_dbs_dead(bool flag)

--- a/src/scram.c
+++ b/src/scram.c
@@ -28,11 +28,44 @@
 #include "common/scram-common.h"
 #include "common/hmac.h"
 
+#ifdef USUAL_LIBSSL_FOR_TLS
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#endif
+
 
 static bool calculate_client_proof(PgSocket *server,
 				   const PgCredentials *credentials,
 				   const char *client_final_message_without_proof,
 				   uint8_t *result);
+
+
+/*
+ * PBKDF2 for the SCRAM SaltedPassword.  Result is identical to
+ * scram_SaltedPassword(), which stays as the fallback and handles any
+ * digest other than SHA-256.
+ */
+static int calculate_salted_password(const char *password,
+				     pg_cryptohash_type hash_type, int key_length,
+				     const uint8 *salt, int saltlen, int iterations,
+				     uint8 *result, const char **errstr)
+{
+#ifdef USUAL_LIBSSL_FOR_TLS
+	if (hash_type == PG_SHA256) {
+		if (PKCS5_PBKDF2_HMAC(password, (int)strlen(password),
+				      salt, saltlen, iterations,
+				      EVP_sha256(), key_length, result) == 1)
+			return 0;
+
+		/* do not leave our error for the TLS code to report */
+		ERR_clear_error();
+		*errstr = "PBKDF2 failed";
+		return -1;
+	}
+#endif
+	return scram_SaltedPassword(password, hash_type, key_length,
+				    salt, saltlen, iterations, result, errstr);
+}
 
 
 /*
@@ -510,10 +543,10 @@ static bool calculate_client_proof(PgSocket *server,
 		 * Calculate SaltedPassword, and store it in 'state' so that we can
 		 * reuse it later in verify_server_signature.
 		 */
-		if (scram_SaltedPassword(prep_password, state->hash_type,
-					 state->key_length, state->salt, state->saltlen,
-					 state->iterations, state->SaltedPassword,
-					 &errstr) < 0 ||
+		if (calculate_salted_password(prep_password, state->hash_type,
+					      state->key_length, state->salt, state->saltlen,
+					      state->iterations, state->SaltedPassword,
+					      &errstr) < 0 ||
 		    scram_ClientKey(state->SaltedPassword, state->hash_type,
 				    state->key_length, ClientKey, &errstr) < 0) {
 			slog_error(server, "SCRAM key derivation failed: %s", errstr);
@@ -822,9 +855,9 @@ static bool build_adhoc_scram_secret(const char *plain_password, ScramState *sta
 	state->encoded_salt[encoded_len] = '\0';
 
 	/* Calculate StoredKey and ServerKey */
-	scram_SaltedPassword(password, state->hash_type, state->key_length, saltbuf, sizeof(saltbuf),
-			     state->iterations,
-			     salted_password, &errstr);
+	calculate_salted_password(password, state->hash_type, state->key_length, saltbuf, sizeof(saltbuf),
+				  state->iterations,
+				  salted_password, &errstr);
 	scram_ClientKey(salted_password, state->hash_type, state->key_length, state->StoredKey, &errstr);
 	scram_H(state->StoredKey, state->hash_type, state->key_length, state->StoredKey, &errstr);
 	scram_ServerKey(salted_password, state->hash_type, state->key_length, state->ServerKey, &errstr);
@@ -1188,7 +1221,7 @@ bool scram_verify_plain_password(PgSocket *client,
 		password = prep_password;
 
 	/* Compute Server Key based on the user-supplied plaintext password */
-	scram_SaltedPassword(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, salt, saltlen, iterations, salted_password, &errstr);
+	calculate_salted_password(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, salt, saltlen, iterations, salted_password, &errstr);
 	scram_ServerKey(salted_password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, computed_key, &errstr);
 
 	/*

--- a/src/scram.c
+++ b/src/scram.c
@@ -28,7 +28,7 @@
 #include "common/scram-common.h"
 #include "common/hmac.h"
 
-#ifdef USUAL_LIBSSL_FOR_TLS
+#if defined(USUAL_LIBSSL_FOR_TLS) && defined(HAVE_PKCS5_PBKDF2_HMAC)
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #endif
@@ -50,7 +50,7 @@ static int calculate_salted_password(const char *password,
 				     const uint8 *salt, int saltlen, int iterations,
 				     uint8 *result, const char **errstr)
 {
-#ifdef USUAL_LIBSSL_FOR_TLS
+#if defined(USUAL_LIBSSL_FOR_TLS) && defined(HAVE_PKCS5_PBKDF2_HMAC)
 	if (hash_type == PG_SHA256) {
 		if (PKCS5_PBKDF2_HMAC(password, (int)strlen(password),
 				      salt, saltlen, iterations,
@@ -206,6 +206,7 @@ static bool parse_scram_secret(const char *secret, int *iterations, char **salt,
 	char *iterations_str;
 	char *storedkey_str;
 	char *serverkey_str;
+	long iteration_count;
 	int decoded_len;
 	uint8_t *decoded_salt_buf;
 	uint8_t *decoded_stored_buf = NULL;
@@ -235,9 +236,10 @@ static bool parse_scram_secret(const char *secret, int *iterations, char **salt,
 		goto invalid_secret;
 
 	errno = 0;
-	*iterations = strtol(iterations_str, &p, 10);
-	if (*p || errno != 0)
+	iteration_count = strtol(iterations_str, &p, 10);
+	if (*p || errno != 0 || iteration_count < 1 || iteration_count > INT_MAX)
 		goto invalid_secret;
+	*iterations = (int)iteration_count;
 
 	/*
 	 * Verify that the salt is in Base64-encoded format, by decoding it,
@@ -855,12 +857,15 @@ static bool build_adhoc_scram_secret(const char *plain_password, ScramState *sta
 	state->encoded_salt[encoded_len] = '\0';
 
 	/* Calculate StoredKey and ServerKey */
-	calculate_salted_password(password, state->hash_type, state->key_length, saltbuf, sizeof(saltbuf),
-				  state->iterations,
-				  salted_password, &errstr);
-	scram_ClientKey(salted_password, state->hash_type, state->key_length, state->StoredKey, &errstr);
-	scram_H(state->StoredKey, state->hash_type, state->key_length, state->StoredKey, &errstr);
-	scram_ServerKey(salted_password, state->hash_type, state->key_length, state->ServerKey, &errstr);
+	if (calculate_salted_password(password, state->hash_type, state->key_length, saltbuf, sizeof(saltbuf),
+				      state->iterations,
+				      salted_password, &errstr) < 0 ||
+	    scram_ClientKey(salted_password, state->hash_type, state->key_length, state->StoredKey, &errstr) < 0 ||
+	    scram_H(state->StoredKey, state->hash_type, state->key_length, state->StoredKey, &errstr) < 0 ||
+	    scram_ServerKey(salted_password, state->hash_type, state->key_length, state->ServerKey, &errstr) < 0) {
+		log_error("SCRAM key derivation failed: %s", errstr);
+		goto failed;
+	}
 
 	free(prep_password);
 	return true;
@@ -1221,8 +1226,13 @@ bool scram_verify_plain_password(PgSocket *client,
 		password = prep_password;
 
 	/* Compute Server Key based on the user-supplied plaintext password */
-	calculate_salted_password(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, salt, saltlen, iterations, salted_password, &errstr);
-	scram_ServerKey(salted_password, PG_SHA256, SCRAM_SHA_256_KEY_LEN, computed_key, &errstr);
+	if (calculate_salted_password(password, PG_SHA256, SCRAM_SHA_256_KEY_LEN,
+				      salt, saltlen, iterations, salted_password, &errstr) < 0 ||
+	    scram_ServerKey(salted_password, PG_SHA256, SCRAM_SHA_256_KEY_LEN,
+			    computed_key, &errstr) < 0) {
+		slog_error(client, "SCRAM key derivation failed: %s", errstr);
+		goto failed;
+	}
 
 	/*
 	 * Compare the secret's Server Key with the one computed from the

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -111,6 +111,12 @@ def test_jdbc_extra_float_digits(bouncer):
     bouncer.admin("SET extra_float_digits = 2")
 
 
+@pytest.mark.parametrize("iterations", ["0", "2147483648"])
+def test_scram_iterations_must_be_valid(bouncer, iterations):
+    with pytest.raises(psycopg.OperationalError, match="SET failed"):
+        bouncer.admin(f"SET scram_iterations = {iterations}")
+
+
 def test_socket_id(bouncer) -> None:
     """Test that PgSocket id is assigned as expected for sockets."""
     config = f"""


### PR DESCRIPTION
PgBouncer derives the SCRAM `SaltedPassword` on the event loop. The event
loop is single threaded, so each login delays all other connections.

The bundled PostgreSQL fallback uses a software SHA-256. It costs 4.0 ms
of CPU for each login on aarch64 and 2.5 ms on x86_64. PR #1356
replaced the `libusual` SHA-256 with this fallback and made each login 1.3
times slower.

PgBouncer already links OpenSSL for TLS. OpenSSL gives the same result
8.3 times faster on aarch64 and 5.7 times faster on x86_64. On a CPU
with no SHA instructions it is 2.9 times faster, because the fallback
does 4 SHA-256 compressions for each iteration and OpenSSL does 2.

PBKDF2 is fully specified, so the output does not change. The fallback
stays for builds without OpenSSL.

This might be a little controversial, happy to discuss. SCRAM remains
a bane due to clients not often doing what PgBouncer does internally - 
caching - making any challenge expensive.