### PR TITLE
fix: honor RESUME during SHUTDOWN_WAIT_FOR_CLIENTS

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1222,7 +1222,7 @@ static bool admin_cmd_resume(PgSocket *admin, const char *arg)
 
 	if (!arg[0]) {
 		log_info("RESUME command issued");
-		if (cf_shutdown) {
+		if (cf_shutdown && cf_shutdown != SHUTDOWN_WAIT_FOR_CLIENTS) {
 			return admin_error(admin, "pooler is shutting down");
 		} else if (cf_pause_mode != P_NONE) {
 			full_resume();

--- a/src/main.c
+++ b/src/main.c
@@ -599,8 +599,8 @@ static void handle_sigusr1(int sock, short flags, void *arg)
 
 static void handle_sigusr2(int sock, short flags, void *arg)
 {
-	if (cf_shutdown) {
-		log_info("got SIGUSR2 while shutting down, ignoring");
+	if (cf_shutdown && cf_shutdown != SHUTDOWN_WAIT_FOR_CLIENTS) {
+		log_info("got SIGUSR2 while shutting down (mode=%d), ignoring", cf_shutdown);
 		return;
 	}
 	switch (cf_pause_mode) {

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -896,10 +896,31 @@ def test_shutdown_wait_for_clients(bouncer):
         bouncer.test(host=socket_directory)
 
 
-def test_resume_during_shutdown(bouncer):
+def test_resume_during_wait_for_clients_shutdown(bouncer):
+    """
+    RESUME must be honored during SHUTDOWN_WAIT_FOR_CLIENTS so that a pause
+    set just before (or after) the shutdown signal can be cleared. Otherwise
+    in-flight clients hang forever.
+    """
     with bouncer.cur() as cur, bouncer.admin_runner.cur() as admin_cur:
         cur.execute("SELECT 1")
+        admin_cur.execute("PAUSE")
         bouncer.admin("SHUTDOWN WAIT_FOR_CLIENTS")
+
+        admin_cur.execute("RESUME")
+
+        cur.execute("SELECT 2")
+        assert cur.fetchone() == (2,)
+
+
+def test_resume_during_wait_for_servers_shutdown(bouncer):
+    """
+    RESUME must still be refused during SHUTDOWN_WAIT_FOR_SERVERS, which is
+    explicitly draining servers in preparation for exit.
+    """
+    with bouncer.cur() as cur, bouncer.admin_runner.cur() as admin_cur:
+        cur.execute("SELECT 1")
+        bouncer.admin("SHUTDOWN WAIT_FOR_SERVERS")
 
         with pytest.raises(
             psycopg.errors.ProtocolViolation, match="pooler is shutting down"
@@ -907,15 +928,44 @@ def test_resume_during_shutdown(bouncer):
             admin_cur.execute("RESUME")
 
 
-def test_sigusr2_during_shutdown(bouncer):
+def test_sigusr2_during_wait_for_clients_shutdown(bouncer):
+    """
+    SIGUSR2 must clear an active pause even after the pgbouncer has entered
+    SHUTDOWN_WAIT_FOR_CLIENTS.
+    """
+    if WINDOWS:
+        pytest.skip("signals are POSIX-only")
+
     with bouncer.cur() as cur:
         cur.execute("SELECT 1")
+        bouncer.sigusr1()
+        time.sleep(1)
         bouncer.admin("SHUTDOWN WAIT_FOR_CLIENTS")
 
-        if not WINDOWS:
-            with bouncer.log_contains(r"got SIGUSR2 while shutting down, ignoring"):
-                bouncer.sigusr2()
-                time.sleep(1)
+        with bouncer.log_contains(r"got SIGUSR2, continuing from PAUSE"):
+            bouncer.sigusr2()
+            time.sleep(1)
+
+        cur.execute("SELECT 2")
+        assert cur.fetchone() == (2,)
+
+
+def test_sigusr2_during_wait_for_servers_shutdown(bouncer):
+    """
+    SIGUSR2 must be ignored under SHUTDOWN_WAIT_FOR_SERVERS, which is
+    intentionally draining servers.
+    """
+    if WINDOWS:
+        pytest.skip("signals are POSIX-only")
+
+    bouncer.admin("set pool_mode=transaction")
+    with bouncer.transaction() as cur:
+        cur.execute("SELECT 1")
+        bouncer.admin("SHUTDOWN WAIT_FOR_SERVERS")
+
+        with bouncer.log_contains(r"got SIGUSR2 while shutting down"):
+            bouncer.sigusr2()
+            time.sleep(1)
 
 
 def test_issue_1104(bouncer):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1210,6 +1210,9 @@ class Bouncer(QueryRunner):
     def sigquit(self):
         self.send_signal(signal.SIGQUIT)
 
+    def sigusr1(self):
+        self.send_signal(signal.SIGUSR1)
+
     def sigusr2(self):
         self.send_signal(signal.SIGUSR2)
 


### PR DESCRIPTION
## Issue
When orchestrating a standard PAUSE then RESUME flow we noticed that if a pgbouncer was shutting down, the RESUME wasn't being respected on a SIGTERM'd bouncer, stranding our paused clients and eventually reaching the `query_wait_timeout`.

`SHUTDOWN_WAIT_FOR_CLIENTS` is documented as a shutdown mode that keeps handing pool connections to still-connected clients until they voluntarily disconnect. However handling of the RESUME command or equivalent signal both currently refuse any attempt to clear `cf_pause_mode` whenever `cf_shutdown` is set, regardless of which shutdown mode is active. PAUSE *after* SIGTERM is fully supported, the resume half is not supported.

## Fix
In both `handle_sigusr2` and `admin_cmd_resume`, refuse RESUME only when `cf_shutdown` is not `SHUTDOWN_WAIT_FOR_CLIENTS`.

## Handling different SHUTDOWNs

- `SHUTDOWN_WAIT_FOR_SERVERS` still refuses RESUME (purpose is to drain servers before exit)
- `SHUTDOWN_IMMEDIATE` still refuses RESUME (it's already exiting)
- `SHUTDOWN_WAIT_FOR_CLIENTS` accepts RESUME