### PR TITLE
feat: add cleanup_server_connections for targeted session-state cleanup

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -667,6 +667,31 @@ state after each transaction.
 
 Default: 0
 
+### cleanup_server_connections
+
+In transaction or statement pooling mode a server connection is shared between
+many clients.  Session state that one client leaves behind, such as a `SET`, a
+changed role or authorization, or a prepared statement, otherwise carries over
+to whichever client gets the connection next, causing errors that are hard to
+trace back to their source.
+
+When enabled, PgBouncer notices that a client changed such state and resets
+only that connection before reusing it, so nothing leaks between clients.
+Connections that were not changed are reused as-is, so unlike
+`server_reset_query_always` there is no reset cost on the common path.
+
+Detection is best-effort.  State changed in ways PgBouncer cannot observe (for
+example through `set_config()` or advisory locks) is not cleaned up, and some
+cases cause an extra reset.  Tracked parameters
+(`track_extra_parameters`) still work as before; their values are restored for
+each client.
+
+While `server_reset_query_always` is enabled its full reset already covers
+this and so `cleanup_server_connections` setting has no effect.
+Changes take effect on reload.
+
+Default: 0
+
 ### server_check_delay
 
 How long to keep released connections available for immediate re-use, without running

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -189,6 +189,11 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; is off, server_reset_query is used only for session-pooling.
 ;server_reset_query_always = 0
 
+;; In transaction/statement pooling, clean connections that a client
+;; altered session state on (targeted RESET) instead of leaking it to the
+;; next client.  No effect while server_reset_query_always is enabled.
+;cleanup_server_connections = 0
+
 ;; Comma-separated list of parameters to track per client.  The
 ;; Postgres parameters listed here will be cached per client by
 ;; pgbouncer and restored in server every time the client runs a query.

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -715,6 +715,9 @@ struct PgSocket {
 	bool resetting : 1;		/* server: executing reset query from auth login; don't release on flush */
 	bool copy_mode : 1;		/* server: in copy stream, ignores Sync packets until CopyDone/CopyFail;
 					   client: in copy-in stream, expecting CopyData/CopyDone/CopyFail */
+	bool dirty_set : 1;		/* server: client ran SET; RESET ALL on release */
+	bool dirty_prepare : 1;		/* server: client ran SQL-level PREPARE; DEALLOCATE ALL on release */
+	bool dirty_session_authorization : 1;	/* server: session authorization differs from login user */
 
 	bool wait_for_welcome : 1;	/* client: no server yet in pool, cannot send welcome msg */
 	bool startup_message_received : 1;	/* client: the StartupMessage has been processed, so all
@@ -861,6 +864,15 @@ extern usec_t cf_server_lifetime;
 extern usec_t cf_server_idle_timeout;
 extern char *cf_server_reset_query;
 extern int cf_server_reset_query_always;
+extern int cf_cleanup_server_connections;
+
+/* server_reset_query_always already resets every release, superseding the
+ * targeted cleanup; the configured value is kept and reactivates when
+ * server_reset_query_always is disabled again */
+static inline bool cleanup_server_connections_active(void)
+{
+	return cf_cleanup_server_connections && !cf_server_reset_query_always;
+}
 extern char *cf_server_check_query;
 extern bool empty_server_check_query;
 extern usec_t cf_server_check_delay;

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,7 @@ int cf_max_user_client_connections;
 
 char *cf_server_reset_query;
 int cf_server_reset_query_always;
+int cf_cleanup_server_connections;
 char *cf_server_check_query;
 bool empty_server_check_query;
 usec_t cf_server_check_delay;
@@ -333,6 +334,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("server_login_retry", CF_TIME_USEC, cf_server_login_retry, 0, "15"),
 	CF_ABS("server_reset_query", CF_STR, cf_server_reset_query, 0, "DISCARD ALL"),
 	CF_ABS("server_reset_query_always", CF_INT, cf_server_reset_query_always, 0, "0"),
+	CF_ABS("cleanup_server_connections", CF_INT, cf_cleanup_server_connections, 0, "0"),
 	CF_ABS("server_round_robin", CF_INT, cf_server_round_robin, 0, "0"),
 	CF_ABS("server_tls13_ciphers", CF_STR, cf_server_tls13_ciphers, 0, NULL),
 	CF_ABS("server_tls_ca_file", CF_STR, cf_server_tls_ca_file, 0, ""),
@@ -521,6 +523,9 @@ bool load_config(void)
 
 	/* kill dbs */
 	config_postprocess();
+
+	if (cf_cleanup_server_connections && cf_server_reset_query_always)
+		log_warning("cleanup_server_connections has no effect while server_reset_query_always is enabled");
 
 	/* reopen logfile */
 	if (main_config.loaded)

--- a/src/objects.c
+++ b/src/objects.c
@@ -1162,15 +1162,45 @@ bool clear_outstanding_requests_until(PgSocket *server, const char types[])
 	return true;
 }
 
+/* client altered session state that cleanup_server_connections resets on release */
+static bool server_session_dirty(PgSocket *server)
+{
+	return server->dirty_set || server->dirty_prepare ||
+	       server->dirty_session_authorization;
+}
+
 /* send reset query */
 static bool reset_on_release(PgSocket *server)
 {
 	bool res;
+	char cleanup_query[96];
+	const char *q = cf_server_reset_query;
 
 	Assert(server->state == SV_TESTED);
 
-	slog_debug(server, "resetting: %s", cf_server_reset_query);
-	SEND_generic(res, server, PqMsg_Query, "s", cf_server_reset_query);
+	/*
+	 * With cleanup_server_connections on, reset only what the client
+	 * altered instead of the server_reset_query.
+	 */
+	if (server_session_dirty(server) &&
+	    !cf_server_reset_query_always &&
+	    connection_pool_mode(server) != POOL_SESSION) {
+		slog_debug(server, "cleaning client-altered session state (set=%d, prepare=%d, session_authorization=%d)",
+			   server->dirty_set, server->dirty_prepare,
+			   server->dirty_session_authorization);
+		snprintf(cleanup_query, sizeof(cleanup_query), "%s%s%s%s",
+			 server->dirty_session_authorization ? "RESET SESSION AUTHORIZATION;" : "",
+			 server->dirty_set || server->dirty_session_authorization ? "RESET ROLE;" : "",
+			 server->dirty_set ? "RESET ALL;" : "",
+			 server->dirty_prepare ? "DEALLOCATE ALL;" : "");
+		q = cleanup_query;
+	}
+	server->dirty_set = false;
+	server->dirty_prepare = false;
+	server->dirty_session_authorization = false;
+
+	slog_debug(server, "resetting: %s", q);
+	SEND_generic(res, server, PqMsg_Query, "s", q);
 	if (!res)
 		disconnect_server(server, false, "reset query failed");
 	return res;
@@ -1221,8 +1251,9 @@ bool release_server(PgSocket *server)
 			server->link = NULL;
 		}
 
-		if (*cf_server_reset_query && (cf_server_reset_query_always ||
-					       connection_pool_mode(server) == POOL_SESSION)) {
+		if ((*cf_server_reset_query &&
+		     (cf_server_reset_query_always || connection_pool_mode(server) == POOL_SESSION)) ||
+		    (cleanup_server_connections_active() && server_session_dirty(server))) {
 			/* notify reset is required */
 			newstate = SV_TESTED;
 		} else if (cf_server_check_delay == 0 && *cf_server_check_query) {

--- a/src/server.c
+++ b/src/server.c
@@ -45,6 +45,24 @@ static bool load_parameter(PgSocket *server, PktHdr *pkt, bool startup)
 		goto failed;
 	slog_debug(server, "S: param: %s = %s", key, val);
 
+	/*
+	 * Generally, the SET command tag doesn't name the parameter, but
+	 * session_authorization is GUC_REPORT so its ParameterStatus does.
+	 * Track it separately so RESET SESSION AUTHORIZATION is sent only
+	 * when authorization actually differs from the login user; a client
+	 * restoring the login user clears the flag again.
+	 */
+	if (!startup && cleanup_server_connections_active() && client
+	    && !server->setting_vars && !server->exec_on_connect
+	    && connection_pool_mode(server) != POOL_SESSION
+	    && strcmp(key, "session_authorization") == 0) {
+		server->dirty_session_authorization =
+			!server->login_user_credentials ||
+			strcmp(val, server->login_user_credentials->name) != 0;
+		if (server->dirty_session_authorization)
+			slog_debug(server, "client altered session authorization, cleanup scheduled on release");
+	}
+
 	varcache_set(&server->vars, key, val);
 
 	if (client) {
@@ -424,6 +442,7 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 	PgSocket *client = server->link;
 	bool async_response = false;
 	bool ignore_packet = false;
+	const char *tag = NULL;
 
 	Assert(!server->pool->db->admin);
 
@@ -536,6 +555,14 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 			if (!clear_outstanding_requests_until(server, (char[]) {PqMsg_CopyDone, '\0'}))
 				return false;
 		}
+
+		/* CommandComplete carries the command tag; read it once, as the
+		 * checks below share pkt->data. */
+		if (is_prepared_statements_enabled(server) || cleanup_server_connections_active()) {
+			if (!mbuf_get_string(&pkt->data, &tag))
+				return false;
+		}
+
 		/*
 		 * Clean up prepared statements if needed if the client sent a
 		 * DEALLOCATE ALL or a DISCARD ALL query. Not doing so would
@@ -545,16 +572,35 @@ static bool handle_server_work(PgSocket *server, PktHdr *pkt)
 		 */
 		if (is_prepared_statements_enabled(server)
 		    && (pkt->len == 1 + 4 + 15 || pkt->len == 1 + 4 + 12)) {	/* size of complete DEALLOCATE/DISCARD ALL */
-			const char *tag;
-			if (mbuf_get_string(&pkt->data, &tag)) {
-				if (strcmp(tag, "DEALLOCATE ALL") == 0 ||
-				    strcmp(tag, "DISCARD ALL") == 0) {
-					free_server_prepared_statements(server);
-					if (client)
-						free_client_prepared_statements(client);
-				}
-			} else {
-				return false;
+			if (strcmp(tag, "DEALLOCATE ALL") == 0 ||
+			    strcmp(tag, "DISCARD ALL") == 0) {
+				free_server_prepared_statements(server);
+				if (client)
+					free_client_prepared_statements(client);
+			}
+		}
+		/*
+		 * Flag client-issued SET/PREPARE so release_server cleans this
+		 * connection (cleanup_server_connections). SET counts even in a
+		 * transaction: its tag is indistinguishable from SET LOCAL and a
+		 * non-LOCAL SET survives COMMIT.
+		 *
+		 * SET of a tracked parameter is flagged too, because the command tag
+		 * never names the parameter, so we pay a reset.
+		 * The parameter is still correctly stored in the varcache and
+		 * re-applies the value on next checkout which skips cleanup
+		 * detection.
+		 */
+		if (cleanup_server_connections_active()
+		    && client && !server->setting_vars && !server->exec_on_connect
+		    && connection_pool_mode(server) != POOL_SESSION
+		    && (pkt->len == 1 + 4 + 4 || pkt->len == 1 + 4 + 8)) {	/* size of complete SET/PREPARE */
+			if (strcmp(tag, "SET") == 0) {
+				slog_debug(server, "client altered session state (SET), cleanup scheduled for release");
+				server->dirty_set = true;
+			} else if (strcmp(tag, "PREPARE") == 0) {
+				slog_debug(server, "client prepared a statement, cleanup scheduled for release");
+				server->dirty_prepare = true;
 			}
 		}
 		pop_outstanding_request(server, (char[]) {PqMsg_Execute, '\0'}, &ignore_packet);

--- a/test/test_cleanup.py
+++ b/test/test_cleanup.py
@@ -1,0 +1,412 @@
+import psycopg
+import pytest
+
+# Runs a scenario with cleanup off and on; `cleanup` drives both the config
+# and the expected outcome (leaks without the feature, cleaned with it).
+cleanup_off_and_on = pytest.mark.parametrize(
+    "cleanup", [False, True], ids=["off", "on"]
+)
+
+
+def cleanup_config(bouncer, pg, enabled, extra="", verbose=1, pool_mode="transaction"):
+    return f"""
+    [databases]
+    postgres = host={pg.host} port={pg.port} pool_size=1
+
+    [pgbouncer]
+    listen_addr = {bouncer.host}
+    auth_type = trust
+    admin_users = pgbouncer
+    auth_file = {bouncer.auth_path}
+    listen_port = {bouncer.port}
+    logfile = {bouncer.log_path}
+    auth_dbname = postgres
+    pool_mode = {pool_mode}
+    cleanup_server_connections = {enabled}
+    verbose = {verbose}
+    {extra}
+    """
+
+
+def cleanup_log(set=r"\d", prepare=r"\d", session_authorization=r"\d"):
+    return (
+        r"cleaning client-altered session state "
+        rf"\(set={set}, prepare={prepare}, session_authorization={session_authorization}\)"
+    )
+
+
+def cleanup_config_value(bouncer):
+    return next(
+        row[1]
+        for row in bouncer.admin("SHOW CONFIG")
+        if row[0] == "cleanup_server_connections"
+    )
+
+
+@cleanup_off_and_on
+@pytest.mark.parametrize("pool_mode", ["transaction", "statement"])
+def test_cleanup_set_read_only(bouncer, pg, cleanup, pool_mode):
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup), pool_mode=pool_mode)
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            cur.execute("SET default_transaction_read_only = on")
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            value = cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+            pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a  # same server connection either way
+        assert value == ("off" if cleanup else "on")
+
+
+def test_cleanup_tracked_set_and_internal_sync(bouncer, pg):
+    """An explicit client SET of a tracked parameter schedules exactly one cleanup; neither the startup parameter nor the checkout-time varcache re-apply adds a cleanup of its own (times=1 across the session)."""
+    config = cleanup_config(bouncer, pg, enabled=1)
+    with bouncer.run_with_config(config):
+        conn = bouncer.conn(
+            dbname="postgres",
+            user="puser1",
+            application_name="cleanup_startup",
+            autocommit=True,
+        )
+        try:
+            cur = conn.cursor()
+            with bouncer.log_contains(
+                cleanup_log(set=1, prepare=0, session_authorization=0),
+                times=1,
+            ):
+                application_name, pid_a = cur.execute(
+                    "SELECT current_setting('application_name'), pg_backend_pid()"
+                ).fetchone()
+                assert application_name == "cleanup_startup"
+
+                cur.execute("SET application_name = 'cleanup_explicit'")
+
+                application_name, pid_b = cur.execute(
+                    "SELECT current_setting('application_name'), pg_backend_pid()"
+                ).fetchone()
+        finally:
+            conn.close()
+
+        assert pid_b == pid_a
+        assert application_name == "cleanup_explicit"
+
+
+@cleanup_off_and_on
+def test_cleanup_set_role(bouncer, pg, cleanup):
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup))
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            cur.execute("SET ROLE puser1")
+
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            current_user = cur.execute("SELECT current_user").fetchall()[0][0]
+            pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a
+        assert current_user == ("postgres" if cleanup else "puser1")
+
+
+@cleanup_off_and_on
+def test_cleanup_session_authorization(bouncer, pg, cleanup):
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup))
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            cur.execute("SET SESSION AUTHORIZATION puser1")
+
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            session_user = cur.execute("SELECT session_user").fetchall()[0][0]
+            pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a
+        assert session_user == ("postgres" if cleanup else "puser1")
+
+
+def test_cleanup_set_role_with_tracked_is_superuser(bouncer, pg):
+    """SET ROLE must be cleaned even when is_superuser is tracked."""
+    config = cleanup_config(
+        bouncer,
+        pg,
+        enabled=1,
+        extra="track_extra_parameters = is_superuser",
+    )
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            with bouncer.log_contains(
+                cleanup_log(set=1, prepare=0, session_authorization=0),
+                times=1,
+            ):
+                cur.execute("SET ROLE puser1")
+                cur.execute("SELECT 1")  # sequence release-time cleanup
+
+        with bouncer.cur(dbname="postgres", user="postgres") as cur:
+            current_user = cur.execute("SELECT current_user").fetchall()[0][0]
+            pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a
+        assert current_user == "postgres"
+
+
+def test_cleanup_toggle_at_runtime(bouncer, pg):
+    with bouncer.run_with_config(cleanup_config(bouncer, pg, enabled=0)):
+        # disabled: poison leaks
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            cur.execute("SET default_transaction_read_only = on")
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            assert (
+                cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+                == "on"
+            )
+
+        # enable via ini rewrite + RELOAD
+        with bouncer.ini_path.open("w") as f:
+            f.write(cleanup_config(bouncer, pg, enabled=1))
+        bouncer.admin("reload")
+
+        # next SET is detected and cleaned on release, same server conn
+        with (
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+            bouncer.log_contains(cleanup_log(), times=1),
+        ):
+            cur.execute("SET default_transaction_read_only = on")
+            cur.execute("SELECT 1")  # sequence the release-time cleanup
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            assert (
+                cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+                == "off"
+            )
+            assert cur.execute("SELECT pg_backend_pid()").fetchall()[0][0] == pid_a
+
+        # disable via admin SET: detection stops, leak returns
+        bouncer.admin("set cleanup_server_connections = 0")
+        with bouncer.log_contains(cleanup_log(), times=0):
+            with bouncer.cur(dbname="postgres", user="puser1") as cur:
+                cur.execute("SET default_transaction_read_only = on")
+            with bouncer.cur(dbname="postgres", user="puser1") as cur:
+                assert (
+                    cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+                    == "on"
+                )
+
+
+def test_cleanup_superseded_by_server_reset_query_always(bouncer, pg):
+    """While server_reset_query_always is on, the full reset supersedes targeted cleanup; turning it off reactivates the configured cleanup without any further action."""
+    config = cleanup_config(
+        bouncer,
+        pg,
+        enabled=1,
+        extra="server_reset_query_always = 1",
+    )
+    with bouncer.run_with_config(config):
+        # The configured value is kept; the full reset does the cleaning.
+        assert cleanup_config_value(bouncer) == "1"
+        with (
+            bouncer.log_contains(cleanup_log(), times=0),
+            bouncer.log_contains(r"resetting: DISCARD ALL"),
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+        ):
+            cur.execute("SET default_transaction_read_only = on")
+            cur.execute("SELECT 1")  # sequence the release-time reset
+
+        # Disabling the full reset reactivates the targeted cleanup.
+        bouncer.admin("SET server_reset_query_always = 0")
+        with (
+            bouncer.log_contains(cleanup_log(), times=1),
+            bouncer.cur(dbname="postgres", user="puser1") as cur,
+        ):
+            cur.execute("SET default_transaction_read_only = on")
+            cur.execute("SELECT 1")  # sequence the release-time cleanup
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            assert (
+                cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+                == "off"
+            )
+
+
+def test_cleanup_independent_of_server_reset_query(bouncer, pg):
+    config = cleanup_config(
+        bouncer,
+        pg,
+        enabled=1,
+        extra="server_reset_query =",
+    )
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+            cur.execute("SET default_transaction_read_only = on")
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            value = cur.execute("SHOW default_transaction_read_only").fetchall()[0][0]
+            pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a
+        assert value == "off"
+
+
+@cleanup_off_and_on
+def test_cleanup_prepare(bouncer, pg, cleanup):
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup))
+    with bouncer.run_with_config(config):
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            cur.execute("PREPARE cleanup_test AS SELECT 1")
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            if cleanup:
+                cur.execute("PREPARE cleanup_test AS SELECT 1")  # name was freed
+            else:
+                with pytest.raises(psycopg.errors.DuplicatePreparedStatement):
+                    cur.execute("PREPARE cleanup_test AS SELECT 1")
+
+
+def test_cleanup_clean_connections_untouched(bouncer, pg):
+    config = cleanup_config(bouncer, pg, enabled=1)
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(cleanup_log(), times=0),
+    ):
+        for _ in range(3):
+            with bouncer.cur(dbname="postgres", user="puser1") as cur:
+                cur.execute("SELECT 1")
+
+
+def test_cleanup_set_local_in_transaction_cleaned(bouncer, pg):
+    """SET LOCAL also schedules cleanup: the tag is indistinguishable from a non-LOCAL SET."""
+    config = cleanup_config(bouncer, pg, enabled=1)
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(cleanup_log(), times=1),
+    ):
+        conn = bouncer.conn(dbname="postgres", user="puser1", autocommit=False)
+        try:
+            cur = conn.cursor()
+            cur.execute("SET LOCAL statement_timeout = 7777")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Checkout again inside the block: sequences the cleanup and
+        # verifies the setting is back at its default.
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            assert cur.execute("SHOW statement_timeout").fetchall()[0][0] == "0"
+
+
+@cleanup_off_and_on
+def test_cleanup_set_in_transaction(bouncer, pg, cleanup):
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup))
+    with bouncer.run_with_config(config):
+        conn = bouncer.conn(dbname="postgres", user="puser1", autocommit=False)
+        try:
+            cur = conn.cursor()
+            cur.execute("SET statement_timeout = 7777")
+            conn.commit()
+        finally:
+            conn.close()
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            value = cur.execute("SHOW statement_timeout").fetchall()[0][0]
+        assert value == ("0" if cleanup else "7777ms")
+
+
+@cleanup_off_and_on
+def test_cleanup_batch_end_transaction_then_set(bouncer, pg, cleanup):
+    """A SET after the transaction terminator in a single multi-statement query is outside the transaction and leaks without cleanup."""
+    config = cleanup_config(bouncer, pg, enabled=int(cleanup))
+    with bouncer.run_with_config(config):
+        conn = bouncer.conn(dbname="postgres", user="puser1", autocommit=True)
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN; COMMIT; SET statement_timeout = 7777")
+        finally:
+            conn.close()
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            value = cur.execute("SHOW statement_timeout").fetchall()[0][0]
+        assert value == ("0" if cleanup else "7777ms")
+
+
+def test_cleanup_batch_set_local_in_transaction_cleaned(bouncer, pg):
+    """A SET LOCAL inside a single-batch BEGIN...COMMIT still schedules cleanup; batching the transaction does not change detection."""
+    config = cleanup_config(bouncer, pg, enabled=1)
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(cleanup_log(), times=1),
+    ):
+        conn = bouncer.conn(dbname="postgres", user="puser1", autocommit=True)
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN; SET LOCAL statement_timeout = 7777; COMMIT")
+        finally:
+            conn.close()
+
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            assert cur.execute("SHOW statement_timeout").fetchall()[0][0] == "0"
+
+
+def test_cleanup_preserves_tracked_prepared_statements(bouncer, pg):
+    """A SET-only cleanup (RESET ALL) must not drop tracked protocol prepared statements; a PREPARE cleanup (DEALLOCATE ALL) must clear the cache so they are re-prepared instead of erroring."""
+    config = cleanup_config(
+        bouncer, pg, enabled=1, extra="max_prepared_statements = 10"
+    )
+    with bouncer.run_with_config(config):
+        conn1 = bouncer.conn(dbname="postgres", user="puser1")
+        try:
+            cur1 = conn1.cursor()
+            # Protocol-level prepared statement, tracked by pgbouncer.
+            cur1.execute("SELECT 'tracked'", prepare=True)
+
+            # A SET cleans with RESET ROLE/ALL and no DEALLOCATE ALL; pin
+            # the reset log, since transparent re-prepare would hide a wrong
+            # DEALLOCATE from the execute assertion alone.
+            with (
+                bouncer.log_contains(r"resetting: RESET ROLE;RESET ALL;", times=1),
+                bouncer.log_contains(r"DEALLOCATE ALL", times=0),
+            ):
+                with bouncer.cur(dbname="postgres", user="puser1") as cur2:
+                    cur2.execute("SET default_transaction_read_only = on")
+
+                # Sequences the release-time cleanup and asserts the
+                # tracked statement still executes.
+                assert (
+                    cur1.execute("SELECT 'tracked'", prepare=True).fetchall()[0][0]
+                    == "tracked"
+                )
+
+            # Another client poisons with SQL-level PREPARE; cleanup now
+            # includes DEALLOCATE ALL, wiping server-side statements.
+            with bouncer.cur(dbname="postgres", user="puser1") as cur2:
+                cur2.execute("PREPARE cleanup_test2 AS SELECT 2")
+
+            # cache dropped and re-prepared transparently; a stale cache
+            # would error here.
+            assert (
+                cur1.execute("SELECT 'tracked'", prepare=True).fetchall()[0][0]
+                == "tracked"
+            )
+        finally:
+            conn1.close()
+
+        # And the next client can reuse the SQL-level name.
+        with bouncer.cur(dbname="postgres", user="puser1") as cur:
+            cur.execute("PREPARE cleanup_test2 AS SELECT 2")
+
+
+def test_cleanup_protocol_prepared_statement_reused_across_clients(bouncer, pg):
+    config = cleanup_config(
+        bouncer, pg, enabled=1, extra="max_prepared_statements = 10"
+    )
+    with bouncer.run_with_config(config):
+        with bouncer.log_contains(cleanup_log(), times=0):
+            with bouncer.cur(dbname="postgres", user="puser1") as cur:
+                pid_a = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+                assert cur.execute("SELECT 2", prepare=True).fetchall()[0][0] == 2
+
+            with bouncer.cur(dbname="postgres", user="puser1") as cur:
+                assert cur.execute("SELECT 2", prepare=True).fetchall()[0][0] == 2
+                pid_b = cur.execute("SELECT pg_backend_pid()").fetchall()[0][0]
+
+        assert pid_b == pid_a  # same server connection, not replaced


### PR DESCRIPTION
## Problem

In transaction and statement pooling a server connection is shared between many clients. Session state that one client leaves behind carries over to whichever client gets the connection next: a `SET` (including `SET default_transaction_read_only`, which produces confusing read-only errors for the next client), `SET ROLE`, `SET SESSION AUTHORIZATION`, or a SQL-level `PREPARE`. The resulting failures are intermittent and hard to trace back to their source, because they depend on which client last used the physical connection.

Today the only mitigation is `server_reset_query_always`, which runs the full `server_reset_query` (`DISCARD ALL` by default) on *every* release in transaction pooling. That fixes the leak but pays a reset round-trip on every connection handoff, including the general majority case that never alters any session state.

## What this adds

A new boolean `cleanup_server_connections` (default `0`, reloadable). When enabled, PgBouncer tracks whether a client altered session state on a server connection and, on release, resets *only* the connections that were altered with statements specific the session state that was altered. Connections that were not altered are released with no reset, so the common path keeps the no reset behaviour of plain transaction pooling.

## How it works

Detection, in `handle_server_work`, from the server's own responses:

- `SET` and SQL-level `PREPARE` command tags (`CommandComplete`) set `dirty_set` / `dirty_prepare`.
- The `session_authorization` `ParameterStatus` (it is `GUC_REPORT`) sets `dirty_session_authorization`, but only when the reported value differs from the login user, so restoring the login user clears the flag again.

On release (`reset_on_release`), a dirty connection gets a targeted reset built from what actually changed, instead of the configured `server_reset_query`:

```
RESET SESSION AUTHORIZATION;   -- dirty_session_authorization
RESET ROLE;                    -- dirty_set || dirty_session_authorization
RESET ALL;                     -- dirty_set
DEALLOCATE ALL;                -- dirty_prepare
```

## Interactions

- **`server_reset_query_always`**: while it is enabled its full reset already runs on every release, so it supersedes this setting so `cleanup_server_connections` is effectively ignored.
- **Prepared-statement cache** (`max_prepared_statements > 0`): the `DEALLOCATE ALL` in a cleanup reset flows through the existing `DEALLOCATE ALL`/`DISCARD ALL` interception, which calls `free_server_prepared_statements`. So the cache is invalidated in lockstep and the next client re-prepares.
- **`server_reset_query`**: the generated cleanup does not include this and the setting is ignored.
- **Session pooling**: excluded.  The existing `server_reset_query` handles the reset as it does in session pooling today (on by default, `DISCARD ALL`; disabled by setting `server_reset_query` empty). This feature does not change session-mode behaviour.
- **Reload**: applied on `RELOAD`/`SET` with no restart and no effect on established connections; detection starts or stops with the next completed command.

## Limitations (best-effort detection)

- A `SET` inside a transaction schedules cleanup even if it was `SET LOCAL`, because the command tag cannot distinguish them, so such transactions pay one redundant reset. (A non-LOCAL `SET` does survive `COMMIT`, so under-detecting is not an option.)
- State altered without a distinctive command tag or `ParameterStatus` (for example `set_config()` or advisory locks) is not detected.
- Protocol-level named prepared statements (`Parse`, not SQL `PREPARE`) are not detected when the prepared-statement cache is off (`max_prepared_statements = 0`); with the cache on they are managed by the existing prepared-statement machinery.