### PR TITLE
meson: Add reproducible pgdist target

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -46,8 +46,10 @@ jobs:
         include:
           # Keep the autoconf build exercised (while both build systems coexist)
           # on the same stock Ubuntu runner rather than a separate distro. This
-          # also produces the release dist tarball, which (unlike meson's) bundles
-          # the generated `configure` so it can be built without autoconf tools.
+          # also produces the release dist tarball, which bundles the generated
+          # `configure` so it can be built without autoconf tools. The meson
+          # `pgdist` target produces an equivalent tarball, so this can move to
+          # meson once the autoconf build is retired.
           - name: autoconf
             build_system: autoconf
             configure_args: "--with-cares --with-pam --with-ldap"
@@ -55,6 +57,7 @@ jobs:
           - name: cares-pam-ldap
             build_system: meson
             meson_args: "-Dcares=enabled -Dpam=enabled -Dldap=enabled"
+            dist: "yes"
           - name: no-evdns-no-openssl
             build_system: meson
             meson_args: "-Dcares=disabled -Devdns=false -Dopenssl=disabled"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -54,11 +54,17 @@ install.autoconf)
 	make -j"$jobs" install
 	;;
 dist.meson)
-	# gztar to match the artifact glob (meson defaults to xztar). --no-tests
-	# because the test suite already ran against this checkout; the tarball
-	# itself is verified below by building from a fresh extraction instead.
-	meson dist -C build --no-tests --formats gztar
-	mkdir -p dist && cp build/meson-dist/pgbouncer-*.tar.gz dist/
+	# pgdist, not `meson dist`: the latter is not reproducible, so meson.build
+	# makes it fail. pgdist uses git archive and emits gztar, matching the
+	# artifact glob and the autoconf tarball.
+	#
+	# autogen.sh because pgdist bundles the generated autoconf bootstrap files
+	# (configure, config.guess, ...) into the tarball, and a meson-only job has
+	# not otherwise generated them.
+	./autogen.sh
+	meson compile -C build -v pgdist
+	mkdir -p dist && cp build/pgbouncer-*.tar.gz dist/
+	# Build from a fresh extraction of the tarball, as the autoconf path does.
 	tar -x -f dist/pgbouncer-*.tar.gz -C dist
 	cd dist/pgbouncer-*/
 	# shellcheck disable=SC2086

--- a/meson.build
+++ b/meson.build
@@ -726,6 +726,67 @@ if ctags.found()
 endif
 
 # ----------------------------------------------------------------------
+# dist (adapted from PostgreSQL)
+# ----------------------------------------------------------------------
+
+# Meson has its own distribution building command (meson dist), but we
+# are not using that at this point.  The main problem is that, the way
+# they have implemented it, it is not deterministic.  Also, we want it
+# to be equivalent to the "make" version for the time being.  But the
+# target name "dist" in meson is reserved for that reason, so we call
+# the custom target "pgdist".
+
+git = find_program('git', required: false, native: true, disabler: true)
+
+distdir = meson.project_name() + '-' + meson.project_version()
+
+# Generated files that are not in git but must ship in the tarball, so
+# it can be built without autoconf/automake installed.  Keep in sync
+# with EXTRA_DIST in the Makefile.
+extra_dist = ['config.guess', 'config.sub', 'configure', 'install-sh',
+              'lib/usual/config.h.in']
+
+# git archive applies --prefix to the --add-file that follows it, so
+# each extra file needs its own --prefix carrying that file's
+# directory.  A trailing --prefix restores the plain distdir for
+# anything after.
+git_archive_args = []
+foreach f : extra_dist
+  dirname = fs.parent(f)
+  if dirname == '.'
+    dirname = ''
+  else
+    dirname += '/'
+  endif
+  git_archive_args += ['--prefix', '@0@/@1@'.format(distdir, dirname),
+                       '--add-file', f]
+endforeach
+
+tar_gz = custom_target('tar.gz',
+  build_always_stale: true,
+  command: [git, '-C', '@SOURCE_ROOT@',
+            '-c', 'core.autocrlf=false',
+            'archive',
+            '--format', 'tar.gz',
+            '-9',
+            '--prefix', distdir + '/',
+            '-o', meson.project_build_root() / '@OUTPUT@',
+            get_option('PG_GIT_REVISION')] + git_archive_args
+           + ['--prefix', distdir + '/'],
+  output: distdir + '.tar.gz',
+)
+
+alias_target('pgdist', [tar_gz])
+
+# Make the standard "dist" command fail, to prevent accidental use.
+# But not if we are in a subproject, in case the parent project wants
+# to create a dist using the standard Meson command.
+if not meson.is_subproject()
+  meson.add_dist_script(python, '-c',
+                        'import sys; sys.exit("Use \'meson compile pgdist\' instead of \'meson dist\'")')
+endif
+
+# ----------------------------------------------------------------------
 # Configuration summary
 # ----------------------------------------------------------------------
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,3 +32,8 @@ option('openssl', type: 'feature', value: 'auto',
 
 option('systemd', type: 'feature', value: 'auto',
        description: 'Build with systemd support')
+
+# Packaging options
+
+option('PG_GIT_REVISION', type: 'string', value: 'HEAD',
+       description: 'git revision to be packaged by the pgdist target')


### PR DESCRIPTION
When the meson build system was integrated, it did not integrate from pull request #1077 the way the distribution tarball is built under meson, but instead used the standard `meson dist`. The problem is that meson's built-in `meson dist` is not deterministic, so this would be a regression.

This PR adds a custom target "pgdist" that builds the distribution tarball directory using "git archive", mirroring the existing "make dist" rule (details adapted from PostgreSQL).  It also bundles the generated autoconf bootstrap files.  The tarballs generated by pgdist are now fully reproducible and identical to what make dist produces.

(This required the fix for #1498.)

This allows the following steps in the future:
- If the primary build system is to be switched to meson, but autoconf is kept for the time being, then we can build the tarball using meson without regression.
- If we no longer want to ship with the autoconf bootstrap files, then we get a tarball that is fully reproducible from the git repository alone.
- If we drop the autoconf build system, the meson one provides equivalent functionality for the tarball building.

