### PR TITLE
Treat a null user name from auth_query as a missing user

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -541,6 +541,16 @@ use a non-superuser that calls a SECURITY DEFINER function instead.
 Note that the query is run inside the target database.  So if a function
 is used, it needs to be installed into each database.
 
+The query must return two columns, the user name and the password
+(appropriately encrypted/hashed).  To report that the user does not
+exist, either return no rows or a row with a null value for the user.
+(The default query below returns no rows for a nonexistent user.  The
+variant with the null value is useful when the query calls a
+record-returning function, as in the example shown under
+[Examples](#examples) below.)  A null value in the password column
+means that the user exists but no password is available for it, so
+that no password that the client offers will be accepted.
+
 Default: `SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin`
 
 ### auth_dbname

--- a/src/client.c
+++ b/src/client.c
@@ -734,8 +734,11 @@ bool handle_auth_query_response(PgSocket *client, PktHdr *pkt)
 			return false;
 		}
 		if (length == (uint32_t)-1) {
-			disconnect_server(server, false, "auth_query response contained null user name");
-			return false;
+			/*
+			 * A null user name means the user does not
+			 * exist, so skip the row.
+			 */
+			break;
 		}
 		if (!mbuf_get_chars(&pkt->data, length, &username)) {
 			disconnect_server(server, false, "bad packet");

--- a/test/test_no_user.py
+++ b/test/test_no_user.py
@@ -89,3 +89,24 @@ def test_no_user_auth_user(bouncer):
         pytest.raises(psycopg.OperationalError, match="no such user"),
     ):
         bouncer.test(dbname="authdb", user="nosuchuser", password="whatever")
+
+
+def test_no_user_auth_user_null_row(bouncer):
+    """
+    An auth_query that reports a missing user as a null value rather
+    than with no rows must be treated the same as one returning no
+    rows.  The user_lookup() example in the documentation behaves this
+    way.
+    """
+    bouncer.admin(f"set auth_type='md5'")
+    bouncer.admin(
+        "set auth_query='SELECT (SELECT rolname FROM pg_authid WHERE rolname = $1), (SELECT rolpassword FROM pg_authid WHERE rolname = $1)'"
+    )
+    with (
+        bouncer.log_contains(r"closing because: no such user \(age"),
+        pytest.raises(psycopg.OperationalError, match="no such user"),
+    ):
+        bouncer.test(dbname="authdb", user="nosuchuser", password="whatever")
+
+    # An existing user still logs in through the same auth_query.
+    bouncer.test(dbname="authdb", user="someuser", password="anypasswd")


### PR DESCRIPTION
An `auth_query` that reports a missing user with a null value rather than with no rows disconnected the `auth_query` server connection with "auth_query response contained null user name".  But the `user_lookup()` example in the documentation behaved that way, so it was a bad example.  Furthermore, since commit 1824718, unauthenticated clients don't even see that message but just "bouncer config error", which is confusing in that context.

To fix, skip the row if a null user was returned.  That way, we get effectively the same behavior as auth_query returning no rows.

Also add some documentation about the accepted result shapes from `auth_query`.