### PR TITLE
Export pgbevent.dll entry points via a .def file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,9 @@ bin_PROGRAMS += pgbevent
 endif
 
 pgbevent_SOURCES = win32/pgbevent.c win32/eventmsg.rc \
-		   win32/eventmsg.mc win32/MSG00001.bin
+		   win32/eventmsg.mc win32/MSG00001.bin win32/pgbevent.def
 pgbevent_EXT = .dll
-pgbevent_LINK = $(CC) -shared -Wl,--export-all-symbols -Wl,--add-stdcall-alias -o $@ $^
+pgbevent_LINK = $(CC) -shared -o $@ $^ $(srcdir)/win32/pgbevent.def
 
 # .rc->.o
 AM_LANGUAGES = RC

--- a/meson.build
+++ b/meson.build
@@ -628,12 +628,14 @@ pgbouncer = executable('pgbouncer',
 if windows
   pgbevent_res = win.compile_resources('win32/eventmsg.rc',
                                        include_directories: pgbouncer_incdirs)
-  shared_library('pgbevent',
+  shared_module('pgbevent',
     'win32/pgbevent.c',
     pgbevent_res,
     name_prefix: '',
     include_directories: pgbouncer_incdirs,
     install: true,
+    install_dir: get_option('bindir'),
+    vs_module_defs: 'win32/pgbevent.def',
   )
 endif
 

--- a/win32/pgbevent.def
+++ b/win32/pgbevent.def
@@ -1,0 +1,7 @@
+; regsvr32 looks these up with GetProcAddress. MinGW exports all symbols from
+; a DLL by default, but MSVC exports nothing unless told to. PRIVATE keeps
+; them out of an import library, which nothing needs (the DLL is only ever
+; loaded by the Event Log service and regsvr32, never linked against).
+EXPORTS
+    DllRegisterServer PRIVATE
+    DllUnregisterServer PRIVATE


### PR DESCRIPTION
pgbevent_LINK passed -Wl,--export-all-symbols -Wl,--add-stdcall-alias. clang (or rather lld) has no --add-stdcall-alias, so linking with clang fails when using the make build system.

Neither option was needed.  --export-all-symbols only matters when there are explicit exports to override, and there were none. --add-stdcall-alias only did anything on 32-bit x86.

To improve this, list the two entry points in a .def file instead.  It states the intent more clearly, reduces the exports from "everything" to only what we need, and will also work with possible MSVC support in the future.

While here, build pgbevent as a shared_module in the meson build, which is the more correct choice.

---

I borrowed a bit from #1542, but I arrived at this from the other end of getting clang to work with the makefiles.  (Which may be partially obsolete, but as long as it's there, we might as well clean it up, especially if it also helps other possible efforts.)