### PR TITLE
Add pam_start_confdir setting and add tests for PAM auth

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -226,6 +226,7 @@ jobs:
           useradd -m user
           chown -R user .
           echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+          echo -e 'auth required pam_permit.so\naccount required pam_permit.so' > /etc/pam.d/pgbouncer
       - name: Build
         run: su user -c "MESON_ARGS='$MESON_ARGS' CONFIGURE_ARGS='$CONFIGURE_ARGS' PATH=/venv/bin:\$PATH sh ci/run.sh build $BUILD_SYSTEM"
       - name: Test

--- a/config.mak.in
+++ b/config.mak.in
@@ -70,6 +70,8 @@ WINDRES = @WINDRES@
 
 enable_debug = @enable_debug@
 ldap_support = @ldap_support@
+pam_support = @pam_support@
+pam_start_confdir_support = @pam_start_confdir_support@
 tls_support = @tls_support@
 
 host_cpu = @host_cpu@

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ PKG_CHECK_MODULES(LIBEVENT, libevent)
 
 dnl Check for PAM authentication support
 pam_support=no
+pam_start_confdir_support=no
 AC_ARG_WITH(pam,
   AS_HELP_STRING([--with-pam], [build with PAM support]),
   [ PAM=
@@ -65,13 +66,20 @@ AC_ARG_WITH(pam,
         AC_CHECK_HEADERS(security/pam_appl.h, [have_pam_header=t])
         AC_CHECK_HEADERS(pthread.h, [have_pthreads=yes])
         AC_SEARCH_LIBS(pam_start, pam, [have_libpam=t])
+        AC_SEARCH_LIBS(pam_start_confdir, pam, [have_pam_start_confdir=t])
         AC_SEARCH_LIBS(pthread_create, pthread, [], [have_pthreads=no])
         if test x"${have_pthreads}" != xyes; then
            AC_MSG_ERROR([pthread library should be available for PAM support])
         fi
         if test x"${have_pam_header}" != x -a x"${have_libpam}" != x -a x"${have_pthreads}" = xyes; then
           pam_support=yes
+          AC_SUBST(pam_support)
           AC_DEFINE(HAVE_PAM, 1, [PAM support])
+        fi
+        if test x"${have_pam_start_confdir}" != x; then
+	  pam_start_confdir_support=yes
+          AC_SUBST(pam_start_confdir_support)
+          AC_DEFINE(HAVE_PAM_START_CONFDIR, 1, [HAVE_PAM_START_CONFDIR support])
         fi
     fi
   ], [])

--- a/doc/config.md
+++ b/doc/config.md
@@ -566,6 +566,10 @@ authentication is configured via `auth_hba_file`.)  Example:
 
     auth_ldap_options = ldapurl="ldap://127.0.0.1:12345/dc=example,dc=net?uid?sub"
 
+### auth_pam_confdir
+
+PAM connection option to allow alternative directory for `/etc/pam.d`.
+
 ## Log settings
 
 ### syslog

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -152,6 +152,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Authentication database that can be set globally to run "auth_query".
 ;auth_dbname =
 
+;; Alternative location for /etc/pam.d to use when running pam authentication
+; auth_pam_confdir =
+
 ;;;
 ;;; Users allowed into database 'pgbouncer'
 ;;;

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -943,6 +943,8 @@ extern char *cf_server_tls13_ciphers;
 
 extern int cf_max_prepared_statements;
 
+extern char *cf_auth_pam_confdir;
+
 extern const struct CfLookup pool_mode_map[];
 extern const struct CfLookup load_balance_hosts_map[];
 

--- a/meson.build
+++ b/meson.build
@@ -381,7 +381,12 @@ endif
 if pam.found()
   cdata.set('HAVE_PAM', 1, description: 'PAM support.')
   cdata.set('HAVE_SECURITY_PAM_APPL_H', 1)
+
+
 endif
+
+cdata.set('HAVE_' + 'pam_start_confdir'.to_upper(),
+          cc.has_function('pam_start_confdir', dependencies: pam) ? 1 : false)
 
 # ----------------------------------------------------------------------
 # LDAP (mirrors --with-ldap)

--- a/meson.build
+++ b/meson.build
@@ -381,8 +381,6 @@ endif
 if pam.found()
   cdata.set('HAVE_PAM', 1, description: 'PAM support.')
   cdata.set('HAVE_SECURITY_PAM_APPL_H', 1)
-
-
 endif
 
 cdata.set('HAVE_' + 'pam_start_confdir'.to_upper(),

--- a/src/main.c
+++ b/src/main.c
@@ -210,6 +210,9 @@ char *cf_server_tls13_ciphers;
 int cf_max_prepared_statements;
 
 int cf_scram_iterations;
+#ifdef HAVE_PAM_START_CONFDIR
+char *cf_auth_pam_confdir;
+#endif
 
 /*
  * config file description
@@ -369,6 +372,9 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("user", CF_STR, global_username, CF_NO_RELOAD, NULL),
 #endif
 	CF_ABS("verbose", CF_INT, cf_verbose, 0, NULL),
+#ifdef HAVE_PAM_START_CONFDIR
+	CF_ABS("auth_pam_confdir", CF_STR, cf_auth_pam_confdir, 0, NULL),
+#endif
 
 	{NULL}
 };

--- a/src/pam.c
+++ b/src/pam.c
@@ -365,7 +365,11 @@ static bool pam_check_passwd(struct pam_auth_request *request)
 		.appdata_ptr = request
 	};
 
+#ifdef HAVE_PAM_START_CONFDIR
+	rc = pam_start_confdir(PGBOUNCER_PAM_SERVICE, request->username, &pam_conv, cf_auth_pam_confdir, &hpam);
+#else
 	rc = pam_start(PGBOUNCER_PAM_SERVICE, request->username, &pam_conv, &hpam);
+#endif
 	if (rc != PAM_SUCCESS) {
 		log_warning("pam_start() failed: %s", pam_strerror(NULL, rc));
 		return false;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@ from .utils import (
     LDAP_SUPPORT,
     LINUX,
     LONG_PASSWORD,
+    PAM,
     PG_SUPPORTS_SCRAM,
     TEST_DIR,
     TLS_SUPPORT,
@@ -200,6 +201,16 @@ async def bouncer(pg, tmp_path):
 
     yield bouncer
 
+    await bouncer.cleanup()
+
+
+@pytest.fixture
+async def bouncer_with_pam(pg, tmp_path):
+    bouncer = Bouncer(pg, tmp_path / "bouncer")
+    pam = PAM(tmp_path)
+    bouncer.pam = pam
+    await bouncer.start()
+    yield bouncer
     await bouncer.cleanup()
 
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1526,6 +1526,13 @@ async def test_auth_query_login_large_packets(bouncer):
     reason="pgbouncer is built without pam_start_confdir support",
 )
 def test_pam_negative(bouncer, tmp_path):
+    """
+    Negative test of pgbouncer PAM authentication system
+
+    This test uses the pam_deny.so submodule to execute a basic negative test of
+    the pgbouncer PAM system. pam_deny basically just returns "no" to any authentication
+    request so we just assume that we are not able to connect.
+    """
     pam_d = tmp_path / "pam.d"
     pam_d.mkdir()
     pam_pgbouncer_conf = pam_d / "pgbouncer"
@@ -1557,9 +1564,11 @@ account  required pam_deny.so
         pytest.raises(
             psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
+        bouncer.log_contains(
+            "WARNING pam_authenticate() failed: Authentication failure"
+        ),
     ):
-        bouncer.sql(
-            query=";",
+        bouncer.test(
             user="postgres",
             dbname="postgres",
             password="fakepass",
@@ -1572,6 +1581,13 @@ account  required pam_deny.so
     reason="pgbouncer is built without pam_start_confdir support",
 )
 def test_pam_positive(bouncer, tmp_path):
+    """
+    Positive test of pgbouncer PAM authentication system
+
+    This test uses the pam_permit.so submodule to execute a basic positive test of
+    the pgbouncer PAM system. pam_permit basically just returns "yes" to any authentication
+    request so we just assume that we are able to connect.
+    """
     pam_d = tmp_path / "pam.d"
     pam_d.mkdir()
     pam_pgbouncer_conf = pam_d / "pgbouncer"
@@ -1600,8 +1616,7 @@ account  required pam_permit.so
         auth_pam_confdir = {pam_d}
     """
     with bouncer.run_with_config(config):
-        bouncer.sql(
-            query=";",
+        bouncer.test(
             user="postgres",
             dbname="postgres",
             host="localhost",
@@ -1615,6 +1630,14 @@ account  required pam_permit.so
     reason="pgbouncer is built without pam_start_confdir support",
 )
 def test_pam_exec(bouncer, tmp_path):
+    """
+    Test PAM auth functionality via pam_exec module
+
+    This test executes fine grained tests of the PAM auth system via the pam_exec.so
+    module. This module allows you to use a shell script (or any binary) for authentication.
+    In this case we are just validating some of the items that we expect pgbouncer to pass
+    from the client to PAM such as username and password.
+    """
     pam_exec_script_sh = tmp_path / "pam_exec_script.sh"
     with open(pam_exec_script_sh, "w") as of_pam_exec_script_sh:
         of_pam_exec_script_sh.write("""#! /bin/sh
@@ -1625,9 +1648,18 @@ read pam_passwd
 
 if [ "$PAM_USER" != "postgres" ]; then
     exit 1
-fi
-if [ "$pam_passwd" != "password3" ]; then
+elif [ "$pam_passwd" != "password3" ]; then
     exit 3
+elif [ "$PAM_RUSER" != "" ]; then
+    exit 4
+elif [ "$PAM_SERVICE" != "pgbouncer" ]; then
+    exit 5
+elif [ "$PAM_TTY" != "" ]; then
+    exit 6
+elif [ "$PAM_TYPE" != "auth" ]; then
+    exit 7
+elif [ "$PAM_RHOST" != "127.0.0.1" ]; then
+    exit 8
 fi
 exit 0
 """)
@@ -1659,26 +1691,34 @@ account  required pam_permit.so
         auth_pam_confdir = {pam_d}
     """
     with bouncer.run_with_config(config):
-        bouncer.sql(
-            query=";",
+        bouncer.test(
             user="postgres",
             dbname="postgres",
             password="password3",
         )
-        with pytest.raises(
-            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+
+        with (
+            pytest.raises(
+                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+            ),
+            bouncer.log_contains(
+                "WARNING pam_conversation(): PAM error: /bin/sh failed: exit code 3"
+            ),
         ):
-            bouncer.sql(
-                query=";",
+            bouncer.test(
                 user="postgres",
                 dbname="postgres",
                 password="badpassword",
             )
-        with pytest.raises(
-            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+        with (
+            pytest.raises(
+                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+            ),
+            bouncer.log_contains(
+                "WARNING pam_conversation(): PAM error: /bin/sh failed: exit code 1"
+            ),
         ):
-            bouncer.sql(
-                query=";",
+            bouncer.test(
                 user="baduser",
                 dbname="postgres",
                 password="badpassword",

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -12,6 +12,8 @@ from .utils import (
     LDAP_SUPPORT,
     LONG_PASSWORD,
     MACOS,
+    PAM_START_CONFDIR_SUPPORT,
+    PAM_SUPPORT,
     PG_SUPPORTS_SCRAM,
     TLS_SUPPORT,
     WINDOWS,
@@ -1516,3 +1518,168 @@ async def test_auth_query_login_large_packets(bouncer):
     bouncer.test(user="longpass", password=LONG_PASSWORD)
     with pytest.raises(psycopg.OperationalError, match="authentication failed"):
         bouncer.test(user="longpass", password="X" + LONG_PASSWORD)
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_START_CONFDIR_SUPPORT,
+    reason="pgbouncer is built without pam_start_confdir support",
+)
+def test_pam_negative(bouncer, tmp_path):
+    pam_d = tmp_path / "pam.d"
+    pam_d.mkdir()
+    pam_pgbouncer_conf = pam_d / "pgbouncer"
+    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
+        of_pam_pgbouncer_conf.write("""
+auth     required pam_deny.so
+account  required pam_deny.so
+""")
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = pam
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {pam_d}
+    """
+    with (
+        bouncer.run_with_config(config),
+        pytest.raises(
+            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+        ),
+    ):
+        bouncer.sql(
+            query=";",
+            user="postgres",
+            dbname="postgres",
+            password="fakepass",
+        )
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_START_CONFDIR_SUPPORT,
+    reason="pgbouncer is built without pam_start_confdir support",
+)
+def test_pam_positive(bouncer, tmp_path):
+    pam_d = tmp_path / "pam.d"
+    pam_d.mkdir()
+    pam_pgbouncer_conf = pam_d / "pgbouncer"
+    pam_pgbouncer_conf.touch()
+    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
+        of_pam_pgbouncer_conf.write("""
+auth     required pam_permit.so
+account  required pam_permit.so
+""")
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = pam
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {pam_d}
+    """
+    with bouncer.run_with_config(config):
+        bouncer.sql(
+            query=";",
+            user="postgres",
+            dbname="postgres",
+            host="localhost",
+            password="fakepass",
+        )
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_START_CONFDIR_SUPPORT,
+    reason="pgbouncer is built without pam_start_confdir support",
+)
+def test_pam_exec(bouncer, tmp_path):
+    pam_exec_script_sh = tmp_path / "pam_exec_script.sh"
+    with open(pam_exec_script_sh, "w") as of_pam_exec_script_sh:
+        of_pam_exec_script_sh.write("""#! /bin/sh
+
+set -x
+
+read pam_passwd
+
+if [ "$PAM_USER" != "postgres" ]; then
+    exit 1
+fi
+if [ "$pam_passwd" != "password3" ]; then
+    exit 3
+fi
+exit 0
+""")
+
+    pam_d = tmp_path / "pam.d"
+    pam_d.mkdir()
+    pam_pgbouncer_conf = pam_d / "pgbouncer"
+    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
+        of_pam_pgbouncer_conf.write(f"""
+auth     required pam_exec.so debug expose_authtok log={tmp_path}/pam.log /bin/sh {pam_exec_script_sh}
+account  required pam_permit.so
+""")
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = pam
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {pam_d}
+    """
+    with bouncer.run_with_config(config):
+        bouncer.sql(
+            query=";",
+            user="postgres",
+            dbname="postgres",
+            password="password3",
+        )
+        with pytest.raises(
+            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+        ):
+            bouncer.sql(
+                query=";",
+                user="postgres",
+                dbname="postgres",
+                password="badpassword",
+            )
+        with pytest.raises(
+            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+        ):
+            bouncer.sql(
+                query=";",
+                user="baduser",
+                dbname="postgres",
+                password="badpassword",
+            )

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1561,11 +1561,119 @@ account  required pam_deny.so
     """
     with (
         bouncer.run_with_config(config),
+        bouncer.log_contains(
+            re_string="WARNING pam_authenticate\\(\\) failed: Authentication failure",
+            times=1,
+        ),
         pytest.raises(
             psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
+    ):
+        bouncer.test(
+            user="postgres",
+            dbname="postgres",
+            password="fakepass",
+        )
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_START_CONFDIR_SUPPORT,
+    reason="pgbouncer is built without pam_start_confdir support",
+)
+def test_pam_negative_pam_start(bouncer, tmp_path):
+    """
+    Negative test of pam_start execption handling
+
+    Test forces a pam_start_confdir to exit with a non PAM_SUCCESS return code.
+    It does this by creating a pam.d directory in the tests temp path, pointing
+    pam_start_confdir to this directory, but then not putting a pgbouncer service file
+    in the directory.
+    """
+    pam_d = tmp_path / "pam.d"
+    pam_d.mkdir()
+
+    # Leave out pam service file to instigate pam_start failure
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = pam
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {pam_d}
+    """
+    with (
+        bouncer.run_with_config(config),
         bouncer.log_contains(
-            "WARNING pam_authenticate() failed: Authentication failure"
+            re_string="WARNING pam_start\\(\\) failed: Critical error",
+            times=1,
+        ),
+        pytest.raises(
+            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+        ),
+    ):
+        bouncer.test(
+            user="postgres",
+            dbname="postgres",
+            password="fakepass",
+        )
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_START_CONFDIR_SUPPORT,
+    reason="pgbouncer is built without pam_start_confdir support",
+)
+def test_pam_negative_account(bouncer, tmp_path):
+    """
+    Negative test of pam_acct_mgmt execption handling
+
+    Test forces a non PAM_SUCCESS return code from pam_acct_mgmt by setting up the
+    pgbouncer pam service to permit all auth but deny all account.
+    """
+    pam_d = tmp_path / "pam.d"
+    pam_d.mkdir()
+    pam_pgbouncer_conf = pam_d / "pgbouncer"
+    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
+        of_pam_pgbouncer_conf.write("""
+auth     required pam_permit.so
+account  required pam_deny.so
+""")
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer.pg.host} port={bouncer.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = pam
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {pam_d}
+    """
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(
+            "WARNING pam_acct_mgmt\\(\\) failed: Authentication failure"
+        ),
+        pytest.raises(
+            psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
     ):
         bouncer.test(
@@ -1646,20 +1754,20 @@ set -x
 
 read pam_passwd
 
-if [ "$PAM_USER" != "postgres" ]; then
+if [ "$PAM_RUSER" != "" ]; then
     exit 1
-elif [ "$pam_passwd" != "password3" ]; then
-    exit 3
-elif [ "$PAM_RUSER" != "" ]; then
-    exit 4
 elif [ "$PAM_SERVICE" != "pgbouncer" ]; then
-    exit 5
+    exit 2
 elif [ "$PAM_TTY" != "" ]; then
-    exit 6
+    exit 3
 elif [ "$PAM_TYPE" != "auth" ]; then
-    exit 7
+    exit 4
 elif [ "$PAM_RHOST" != "127.0.0.1" ]; then
-    exit 8
+    exit 5
+elif [ "$PAM_USER" != "postgres" ]; then
+    exit 6
+elif [ "$pam_passwd" != "password3" ]; then
+    exit 7
 fi
 exit 0
 """)

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -12,6 +12,7 @@ from .utils import (
     LDAP_SUPPORT,
     LONG_PASSWORD,
     MACOS,
+    PAM_PGBOUNCER_CONF_TEST_CONFIGURED,
     PAM_START_CONFDIR_SUPPORT,
     PAM_SUPPORT,
     PG_SUPPORTS_SCRAM,
@@ -1525,7 +1526,7 @@ async def test_auth_query_login_large_packets(bouncer):
     not PAM_START_CONFDIR_SUPPORT,
     reason="pgbouncer is built without pam_start_confdir support",
 )
-def test_pam_negative(bouncer, tmp_path):
+def test_pam_negative(bouncer_with_pam):
     """
     Negative test of pgbouncer PAM authentication system
 
@@ -1533,35 +1534,33 @@ def test_pam_negative(bouncer, tmp_path):
     the pgbouncer PAM system. pam_deny basically just returns "no" to any authentication
     request so we just assume that we are not able to connect.
     """
-    pam_d = tmp_path / "pam.d"
-    pam_d.mkdir()
-    pam_pgbouncer_conf = pam_d / "pgbouncer"
-    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
-        of_pam_pgbouncer_conf.write("""
+
+    pam_config_file = """
 auth     required pam_deny.so
 account  required pam_deny.so
-""")
+"""
+    bouncer_with_pam.pam.create_pam_service_file(pam_config_file)
 
     config = f"""
         [databases]
         postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
-            host={bouncer.pg.host} port={bouncer.pg.port}
+            host={bouncer_with_pam.pg.host} port={bouncer_with_pam.pg.port}
         [pgbouncer]
         auth_query = SELECT 1
         auth_user = pswcheck
         stats_users = stats
-        listen_addr = {bouncer.host}
-        admin_users = pgbouncer
+        listen_addr = {bouncer_with_pam.host}
+        admin_users = pgbouncer_with_pam
         auth_type = pam
-        auth_file = {bouncer.auth_path}
-        listen_port = {bouncer.port}
-        logfile = {bouncer.log_path}
+        auth_file = {bouncer_with_pam.auth_path}
+        listen_port = {bouncer_with_pam.port}
+        logfile = {bouncer_with_pam.log_path}
         auth_dbname = postgres
-        auth_pam_confdir = {pam_d}
+        auth_pam_confdir = {bouncer_with_pam.pam.pam_config_dir}
     """
     with (
-        bouncer.run_with_config(config),
-        bouncer.log_contains(
+        bouncer_with_pam.run_with_config(config),
+        bouncer_with_pam.log_contains(
             re_string="WARNING pam_authenticate\\(\\) failed: Authentication failure",
             times=1,
         ),
@@ -1569,7 +1568,7 @@ account  required pam_deny.so
             psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
     ):
-        bouncer.test(
+        bouncer_with_pam.test(
             user="postgres",
             dbname="postgres",
             password="fakepass",
@@ -1581,7 +1580,7 @@ account  required pam_deny.so
     not PAM_START_CONFDIR_SUPPORT,
     reason="pgbouncer is built without pam_start_confdir support",
 )
-def test_pam_negative_pam_start(bouncer, tmp_path):
+def test_pam_negative_pam_start(bouncer_with_pam):
     """
     Negative test of pam_start execption handling
 
@@ -1590,31 +1589,29 @@ def test_pam_negative_pam_start(bouncer, tmp_path):
     pam_start_confdir to this directory, but then not putting a pgbouncer service file
     in the directory.
     """
-    pam_d = tmp_path / "pam.d"
-    pam_d.mkdir()
 
     # Leave out pam service file to instigate pam_start failure
 
     config = f"""
         [databases]
         postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
-            host={bouncer.pg.host} port={bouncer.pg.port}
+            host={bouncer_with_pam.pg.host} port={bouncer_with_pam.pg.port}
         [pgbouncer]
         auth_query = SELECT 1
         auth_user = pswcheck
         stats_users = stats
-        listen_addr = {bouncer.host}
-        admin_users = pgbouncer
+        listen_addr = {bouncer_with_pam.host}
+        admin_users = pgbouncer_with_pam
         auth_type = pam
-        auth_file = {bouncer.auth_path}
-        listen_port = {bouncer.port}
-        logfile = {bouncer.log_path}
+        auth_file = {bouncer_with_pam.auth_path}
+        listen_port = {bouncer_with_pam.port}
+        logfile = {bouncer_with_pam.log_path}
         auth_dbname = postgres
-        auth_pam_confdir = {pam_d}
+        auth_pam_confdir = {bouncer_with_pam.pam.pam_config_dir}
     """
     with (
-        bouncer.run_with_config(config),
-        bouncer.log_contains(
+        bouncer_with_pam.run_with_config(config),
+        bouncer_with_pam.log_contains(
             re_string="WARNING pam_start\\(\\) failed: Critical error",
             times=1,
         ),
@@ -1622,7 +1619,7 @@ def test_pam_negative_pam_start(bouncer, tmp_path):
             psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
     ):
-        bouncer.test(
+        bouncer_with_pam.test(
             user="postgres",
             dbname="postgres",
             password="fakepass",
@@ -1634,49 +1631,46 @@ def test_pam_negative_pam_start(bouncer, tmp_path):
     not PAM_START_CONFDIR_SUPPORT,
     reason="pgbouncer is built without pam_start_confdir support",
 )
-def test_pam_negative_account(bouncer, tmp_path):
+def test_pam_negative_account(bouncer_with_pam):
     """
     Negative test of pam_acct_mgmt execption handling
 
     Test forces a non PAM_SUCCESS return code from pam_acct_mgmt by setting up the
     pgbouncer pam service to permit all auth but deny all account.
     """
-    pam_d = tmp_path / "pam.d"
-    pam_d.mkdir()
-    pam_pgbouncer_conf = pam_d / "pgbouncer"
-    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
-        of_pam_pgbouncer_conf.write("""
+    pam_config_file = """
 auth     required pam_permit.so
 account  required pam_deny.so
-""")
+"""
+    bouncer_with_pam.pam.create_pam_service_file(pam_config_file)
 
     config = f"""
         [databases]
         postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
-            host={bouncer.pg.host} port={bouncer.pg.port}
+            host={bouncer_with_pam.pg.host} port={bouncer_with_pam.pg.port}
         [pgbouncer]
         auth_query = SELECT 1
         auth_user = pswcheck
         stats_users = stats
-        listen_addr = {bouncer.host}
-        admin_users = pgbouncer
+        listen_addr = {bouncer_with_pam.host}
+        admin_users = pgbouncer_with_pam
         auth_type = pam
-        auth_file = {bouncer.auth_path}
-        listen_port = {bouncer.port}
-        logfile = {bouncer.log_path}
+        auth_file = {bouncer_with_pam.auth_path}
+        listen_port = {bouncer_with_pam.port}
+        logfile = {bouncer_with_pam.log_path}
         auth_dbname = postgres
-        auth_pam_confdir = {pam_d}
+        auth_pam_confdir = {bouncer_with_pam.pam.pam_config_dir}
     """
     with (
-        bouncer.run_with_config(config),
-        bouncer.log_contains(
+        bouncer_with_pam.run_with_config(config),
+        bouncer_with_pam.log_contains(
             "WARNING pam_acct_mgmt\\(\\) failed: Authentication failure"
         ),
         pytest.raises(
             psycopg.OperationalError, match="FATAL:  PAM authentication failed"
         ),
     ):
-        bouncer.test(
+        bouncer_with_pam.test(
             user="postgres",
             dbname="postgres",
             password="fakepass",
@@ -1688,7 +1682,7 @@ account  required pam_deny.so
     not PAM_START_CONFDIR_SUPPORT,
     reason="pgbouncer is built without pam_start_confdir support",
 )
-def test_pam_positive(bouncer, tmp_path):
+def test_pam_positive(bouncer_with_pam):
     """
     Positive test of pgbouncer PAM authentication system
 
@@ -1696,35 +1690,38 @@ def test_pam_positive(bouncer, tmp_path):
     the pgbouncer PAM system. pam_permit basically just returns "yes" to any authentication
     request so we just assume that we are able to connect.
     """
-    pam_d = tmp_path / "pam.d"
-    pam_d.mkdir()
-    pam_pgbouncer_conf = pam_d / "pgbouncer"
-    pam_pgbouncer_conf.touch()
-    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
-        of_pam_pgbouncer_conf.write("""
+    pam_config_file = """
 auth     required pam_permit.so
 account  required pam_permit.so
-""")
+    """
+    bouncer_with_pam.pam.create_pam_service_file(pam_config_file)
 
     config = f"""
         [databases]
         postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
-            host={bouncer.pg.host} port={bouncer.pg.port}
+            host={bouncer_with_pam.pg.host} port={bouncer_with_pam.pg.port}
         [pgbouncer]
         auth_query = SELECT 1
         auth_user = pswcheck
         stats_users = stats
-        listen_addr = {bouncer.host}
-        admin_users = pgbouncer
+        listen_addr = {bouncer_with_pam.host}
+        admin_users = pgbouncer_with_pam
         auth_type = pam
-        auth_file = {bouncer.auth_path}
-        listen_port = {bouncer.port}
-        logfile = {bouncer.log_path}
+        auth_file = {bouncer_with_pam.auth_path}
+        listen_port = {bouncer_with_pam.port}
+        logfile = {bouncer_with_pam.log_path}
         auth_dbname = postgres
-        auth_pam_confdir = {pam_d}
+        auth_pam_confdir = {bouncer_with_pam.pam.pam_config_dir}
+        verbose = 1
     """
-    with bouncer.run_with_config(config):
-        bouncer.test(
+    with (
+        bouncer_with_pam.run_with_config(config),
+        bouncer_with_pam.log_contains(
+            "DEBUG pam_auth_worker\\(\\): authentication completed, status=2",
+            1,
+        ),
+    ):
+        bouncer_with_pam.test(
             user="postgres",
             dbname="postgres",
             host="localhost",
@@ -1737,7 +1734,7 @@ account  required pam_permit.so
     not PAM_START_CONFDIR_SUPPORT,
     reason="pgbouncer is built without pam_start_confdir support",
 )
-def test_pam_exec(bouncer, tmp_path):
+def test_pam_exec(bouncer_with_pam, tmp_path):
     """
     Test PAM auth functionality via pam_exec module
 
@@ -1772,14 +1769,94 @@ fi
 exit 0
 """)
 
-    pam_d = tmp_path / "pam.d"
-    pam_d.mkdir()
-    pam_pgbouncer_conf = pam_d / "pgbouncer"
-    with open(pam_pgbouncer_conf, "w") as of_pam_pgbouncer_conf:
-        of_pam_pgbouncer_conf.write(f"""
+    pam_service_file_contents = f"""
 auth     required pam_exec.so debug expose_authtok log={tmp_path}/pam.log /bin/sh {pam_exec_script_sh}
 account  required pam_permit.so
-""")
+"""
+
+    bouncer_with_pam.pam.create_pam_service_file(pam_service_file_contents)
+
+    config = f"""
+        [databases]
+        postgres = auth_query='SELECT usename, passwd FROM pg_shadow where usename = $1'\
+            host={bouncer_with_pam.pg.host} port={bouncer_with_pam.pg.port}
+        [pgbouncer]
+        auth_query = SELECT 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer_with_pam.host}
+        admin_users = pgbouncer_with_pam
+        auth_type = pam
+        auth_file = {bouncer_with_pam.auth_path}
+        listen_port = {bouncer_with_pam.port}
+        logfile = {bouncer_with_pam.log_path}
+        auth_dbname = postgres
+        auth_pam_confdir = {bouncer_with_pam.pam.pam_config_dir}
+        verbose = 1
+    """
+    with bouncer_with_pam.run_with_config(config):
+        with bouncer_with_pam.log_contains(
+            "DEBUG pam_auth_worker\\(\\): authentication completed, status=2",
+            1,
+        ):
+            bouncer_with_pam.test(
+                user="postgres",
+                dbname="postgres",
+                password="password3",
+            )
+
+        with (
+            bouncer_with_pam.log_contains(
+                "WARNING pam_conversation\\(\\): PAM error: /bin/sh failed: exit code 7",
+                1,
+            ),
+            pytest.raises(
+                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+            ),
+        ):
+            bouncer_with_pam.test(
+                user="postgres",
+                dbname="postgres",
+                password="badpassword",
+            )
+        with (
+            bouncer_with_pam.log_contains(
+                "WARNING pam_conversation\\(\\): PAM error: /bin/sh failed: exit code 6",
+                1,
+            ),
+            pytest.raises(
+                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
+            ),
+        ):
+            bouncer_with_pam.test(
+                user="baduser",
+                dbname="postgres",
+                password="badpassword",
+            )
+
+
+@pytest.mark.skipif(not PAM_SUPPORT, reason="pgbouncer is built without PAM support")
+@pytest.mark.skipif(
+    not PAM_PGBOUNCER_CONF_TEST_CONFIGURED,
+    reason="test requires a config file placed in /etc/pam.d/pgbouncer which permits all via ",
+)
+def test_pam_system(bouncer, tmp_path):
+    """
+    Positive test of PAM using default confdir
+
+    This test assumes that the system has been set up with a `/etc/pam.d/pgbouncer` file
+    to permit all auth requests. Designed to ensure that the default functionality works
+    at a basic level. Other tests that utilitize temp, non system confdir test the PAM system
+    in a more fine grained way without making assumptions about what has been set up on the root
+    system. This is similar to how the test is set up in postgres
+    `src/interfaces/libpq/t/004_load_balance_dns.pl`. The contents of /etc/pam.d/pgbouncer should
+    be:
+
+    ```
+    auth required pam_permit.so
+    account required pam_permit.so
+    ```
+    """
 
     config = f"""
         [databases]
@@ -1796,38 +1873,18 @@ account  required pam_permit.so
         listen_port = {bouncer.port}
         logfile = {bouncer.log_path}
         auth_dbname = postgres
-        auth_pam_confdir = {pam_d}
+        verbose = 1
     """
-    with bouncer.run_with_config(config):
+    with (
+        bouncer.run_with_config(config),
+        bouncer.log_contains(
+            "DEBUG pam_auth_worker\\(\\): authentication completed, status=2",
+            1,
+        ),
+    ):
         bouncer.test(
             user="postgres",
             dbname="postgres",
-            password="password3",
+            host="localhost",
+            password="fakepass",
         )
-
-        with (
-            pytest.raises(
-                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
-            ),
-            bouncer.log_contains(
-                "WARNING pam_conversation(): PAM error: /bin/sh failed: exit code 3"
-            ),
-        ):
-            bouncer.test(
-                user="postgres",
-                dbname="postgres",
-                password="badpassword",
-            )
-        with (
-            pytest.raises(
-                psycopg.OperationalError, match="FATAL:  PAM authentication failed"
-            ),
-            bouncer.log_contains(
-                "WARNING pam_conversation(): PAM error: /bin/sh failed: exit code 1"
-            ),
-        ):
-            bouncer.test(
-                user="baduser",
-                dbname="postgres",
-                password="badpassword",
-            )

--- a/test/utils.py
+++ b/test/utils.py
@@ -228,6 +228,20 @@ def get_ldap_support():
 LDAP_SUPPORT = get_ldap_support()
 
 
+def get_pam_support():
+    return get_build_feature("pam_support", "HAVE_PAM")
+
+
+PAM_SUPPORT = get_pam_support()
+
+
+def get_pam_start_confdir_support():
+    return get_build_feature("pam_start_confdir_support", "HAVE_PAM_START_CONFDIR")
+
+
+PAM_START_CONFDIR_SUPPORT = get_pam_start_confdir_support()
+
+
 def get_tls_support():
     return get_build_feature("tls_support", "USUAL_LIBSSL_FOR_TLS")
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -242,6 +242,20 @@ def get_pam_start_confdir_support():
 PAM_START_CONFDIR_SUPPORT = get_pam_start_confdir_support()
 
 
+def validate_pam_pgbouncer_test_config():
+    pgbouncer_pam_config_fp = Path("/etc/pam.d/pgbouncer")
+    if not pgbouncer_pam_config_fp.exists():
+        return False
+
+    expected_file_contents = (
+        "auth required pam_permit.so\naccount required pam_permit.so\n"
+    )
+    return expected_file_contents == pgbouncer_pam_config_fp.read_text()
+
+
+PAM_PGBOUNCER_CONF_TEST_CONFIGURED = validate_pam_pgbouncer_test_config()
+
+
 def get_tls_support():
     return get_build_feature("tls_support", "USUAL_LIBSSL_FOR_TLS")
 
@@ -1329,6 +1343,18 @@ class Bouncer(QueryRunner):
             with self.ini_path.open("w") as f:
                 f.write(config_old)
             self.admin("RELOAD")
+
+
+class PAM:
+    def __init__(self, config_dir):
+        self.pam_config_dir = config_dir / "pam.d"
+        self.pam_config_dir.mkdir()
+
+    def create_pam_service_file(self, contents):
+        pam_config_file_path = self.pam_config_dir / "pgbouncer"
+        with pam_config_file_path.open(mode="w") as pam_config_file_path_of:
+            pam_config_file_path_of.write(contents)
+        return pam_config_file_path_of
 
 
 class OpenLDAP:


### PR DESCRIPTION
This commit adds test coverage over PAM authentication. In order to do this without root access to the system it makes use of pam_start_confdir [0] function that is avaiable in linux-pam from 1.4.0 [1]. Additionally it adds an auth_pam_confdir in order to allow the confdir parameter to pam_start_confdir to be exposed via pgbouncer configuration. Older non EOL'd linux distros (rocky8) for example, do not support pam_start_confdir. Besides being useful for pgbouncer testing switching to pam_start_confdir is potentially also helpful for end users who want to use PAM but also are not able to have root permissions over their systems.

Much of this work is based on my patch to add similar testing into postgres [2]. Much of the code and methodology is shared.

[0] https://man7.org/linux/man-pages/man3/pam_start.3.html
[1] https://github.com/linux-pam/linux-pam/blob/fb8a69f353b33ef14e36090bc77d0a2007de85a8/NEWS#L192
[2] https://www.postgresql.org/message-id/flat/CAKK5BkHsWCMLS4B8N=9juny1kCzkoHFXHkesEA=-ng4pRAHdUw@mail.gmail.com