### PR TITLE
Track default_transaction_read_only in the varcache

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -244,7 +244,7 @@ PgBouncer knows that they should be maintained in the client variable cache and
 restored in the server whenever the client becomes active.
 
 If you need to specify multiple values, use a comma-separated list (e.g.
-`default_transaction_read_only, IntervalStyle`)
+`search_path, IntervalStyle`)
 
 Note: Most parameters cannot be tracked this way. The only parameters that can
 be tracked are ones that Postgres reports to the client. Postgres has

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -88,7 +88,15 @@ static void init_var_lookup_from_config(const char *cf_track_extra_parameters, i
 
 void init_var_lookup(const char *cf_track_extra_parameters)
 {
-	const char *names[] = { "DateStyle", "client_encoding", "TimeZone", "standard_conforming_strings", "application_name", NULL };
+	const char *names[] = {
+		"DateStyle",
+		"client_encoding",
+		"TimeZone",
+		"standard_conforming_strings",
+		"application_name",
+		"default_transaction_read_only",
+		NULL
+	};
 	int idx = 0;
 
 	struct var_lookup *lookup = NULL;

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -461,9 +461,6 @@ def test_track_extra_parameters(bouncer):
         "application_name": ["client1", "client2"],
     }
 
-    if not WINDOWS:
-        test_set["client_encoding"] = ["LATIN1", "LATIN5"]
-
     test_expected = {
         "intervalstyle": ["sql_standard", "postgres"],
         "standard_conforming_strings": ["on", "off"],
@@ -473,7 +470,13 @@ def test_track_extra_parameters(bouncer):
     }
 
     if not WINDOWS:
+        test_set["client_encoding"] = ["LATIN1", "LATIN5"]
         test_expected["client_encoding"] = ["LATIN1", "LATIN5"]
+
+    # default_transaction-read_only was not marked as GUC_REPORT until server version 14
+    if PG_MAJOR_VERSION >= 14:
+        test_set["default_transaction_read_only"] = ["true", "false"]
+        test_expected["default_transaction_read_only"] = ["on", "off"]
 
     with bouncer.cur(dbname="p1") as cur1, bouncer.cur(dbname="p1") as cur2:
         for key in test_set:
@@ -486,11 +489,17 @@ def test_track_extra_parameters(bouncer):
             cur1.execute(stmt)
             cur2.execute(stmt)
 
-            result1 = cur1.fetchone()
-            assert result1[0] == test_expected[key][0]
+            result1 = cur1.fetchone()[0]
+            expected1 = test_expected[key][0]
+            assert result1 == expected1, (
+                f'parameter {key}, expected "{expected1}", got "{result1}"'
+            )
 
-            result2 = cur2.fetchone()
-            assert result2[0] == test_expected[key][1]
+            result2 = cur2.fetchone()[0]
+            expected2 = test_expected[key][1]
+            assert result2 == expected2, (
+                f'parameter {key}, expected "{expected2}", got "{result2}"'
+            )
 
 
 async def test_wait_close(bouncer):
@@ -726,6 +735,25 @@ def test_equivalent_startup_param(bouncer):
     ):
         cur.execute("SELECT 1")
         cur.execute("SELECT 1")
+
+
+@pytest.mark.skipif(
+    "PG_MAJOR_VERSION < 14",
+    reason="default_transaction_read_only was not marked as GUC_REPORT before PG14",
+)
+def test_default_transaction_read_only(bouncer):
+    """
+    Test that "SET default_transaction_read_only = true" in one client connection
+    doesn't poison the pool with a read-only connection.
+    """
+    bouncer.admin(f"set pool_mode=transaction")
+
+    with bouncer.cur() as rocur:
+        rocur.execute("SET default_transaction_read_only = true")
+        assert rocur.execute("SHOW transaction_read_only").fetchone()[0] == "on"
+
+    with bouncer.cur() as rwcur:
+        assert rwcur.execute("SHOW transaction_read_only").fetchone()[0] == "off"
 
 
 @pytest.mark.skipif("WINDOWS", reason="Windows doesn't support sending SIGTERM")


### PR DESCRIPTION
Before this commit, if a client did `SET default_transaction_read_only = true` in transaction mode, the connection was returned to the pool in read only mode, causing subsequent write transaction to fail. This is a well-known problem, and the common work around is to add `default_transaction_read_only` to `track_extra_parameters`. However, we can easily fix it for everyone by adding it to the static list of variables that are always tracked.

`default_transaction_read_only` has been marked as `GUC_REPORT` since PostgreSQL 14. In older server versions, we still cannot track it, but that's OK.