### PR TITLE
Fix 'test_discard_all' failure with psycopg 3.3.5

### DIFF
--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -86,13 +86,13 @@ def test_discard_or_deallocate_all(bouncer, command):
 
         # Confirm that the prepared query is not available anymore on
         # client 1
-        result = conn1.pgconn.exec_prepared(b"mystmt", ())
+        with bouncer.log_contains("prepared statement did not exist"):
+            result = conn1.pgconn.exec_prepared(b"mystmt", ())
         assert result.status == pq.ExecStatus.FATAL_ERROR
         assert (
             b"prepared statement did not exist" in result.error_message
             or b"server closed the connection unexpectedly" in result.error_message
         )
-        assert bouncer.log_contains("prepared statement did not exist")
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -94,19 +94,17 @@ def test_discard_all(bouncer):
         # execute DISCARD ALL on client 1
         cur1.execute("DISCARD ALL")
 
-        # Run the prepared query again on server 2 and client 2
+        # Run the prepared query again on client 2
         cur2.execute(prepared_query)
 
-        # Confirm that the prepared query is not available anymore on
-        # client 1
-        with (
-            bouncer.log_contains("prepared statement did not exist"),
-            pytest.raises(
-                psycopg.OperationalError,
-                match="prepared statement did not exist|server closed the connection unexpectedly",
-            ),
-        ):
-            cur1.execute(prepared_query)
+        # Depending on the psycopg version, the statement may or may not work on
+        # client 1. Starting with psycopg 3.3.5, it recognizes the "DISCARD"
+        # command, resets its prepared statement cache, and prepares the
+        # statement again on the next call. In earlier versions, you get a
+        # "prepared statement did not exist" error. We're not trying to test
+        # psycopg here, so skip it.
+        #
+        # cur1.execute(prepared_query)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -49,7 +49,14 @@ def test_prepared_statement_params(bouncer):
             cur2.execute(prepared_query, params=(1,), prepare=True)
 
 
-def test_deallocate_all(bouncer):
+@pytest.mark.parametrize("command", ["DISCARD ALL", "DEALLOCATE ALL"])
+def test_discard_or_deallocate_all(bouncer, command):
+    """
+    Client sends a "DEALLOCATE ALL" command (or "DISCARD ALL", which has the
+    same effect). pgbouncer recognizes it and resets the client's prepared
+    statement cache. This scenario is implemented with raw libpq calls to
+    bypass psycopg's special DISCARD ALL handling.
+    """
     bouncer.admin(f"set pool_mode=transaction")
     prepared_query = "SELECT 1"
     with bouncer.cur() as cur1, bouncer.cur() as cur2:
@@ -61,8 +68,8 @@ def test_deallocate_all(bouncer):
         # prepared query for client 2
         cur2.execute(prepared_query, prepare=True)
 
-        # execute DEALLOCATE ALL on client 1
-        cur1.execute("DEALLOCATE ALL")
+        # execute DISCARD / DEALLOCATE ALL on client 1
+        cur1.execute(command)
 
         # Run the prepared query again on server 2 and client 2
         cur2.execute(prepared_query)
@@ -77,34 +84,6 @@ def test_deallocate_all(bouncer):
             ),
         ):
             cur1.execute(prepared_query)
-
-
-def test_discard_all(bouncer):
-    bouncer.admin(f"set pool_mode=transaction")
-    prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1, bouncer.cur() as cur2:
-        # prepare query on client 1
-        cur1.execute(prepared_query, prepare=True)
-        # Run the prepared query again on same server and client
-        cur1.execute(prepared_query)
-
-        # prepared query for client 2
-        cur2.execute(prepared_query, prepare=True)
-
-        # execute DISCARD ALL on client 1
-        cur1.execute("DISCARD ALL")
-
-        # Run the prepared query again on client 2
-        cur2.execute(prepared_query)
-
-        # Depending on the psycopg version, the statement may or may not work on
-        # client 1. Starting with psycopg 3.3.5, it recognizes the "DISCARD"
-        # command, resets its prepared statement cache, and prepares the
-        # statement again on the next call. In earlier versions, you get a
-        # "prepared statement did not exist" error. We're not trying to test
-        # psycopg here, so skip it.
-        #
-        # cur1.execute(prepared_query)
 
 
 def test_parse_larger_than_pkt_buf(bouncer):

--- a/test/test_prepared.py
+++ b/test/test_prepared.py
@@ -58,32 +58,41 @@ def test_discard_or_deallocate_all(bouncer, command):
     bypass psycopg's special DISCARD ALL handling.
     """
     bouncer.admin(f"set pool_mode=transaction")
-    prepared_query = "SELECT 1"
-    with bouncer.cur() as cur1, bouncer.cur() as cur2:
-        # prepare query on client 1
-        cur1.execute(prepared_query, prepare=True)
-        # Run the prepared query again on same server and client
-        cur1.execute(prepared_query)
+    with bouncer.conn() as conn1, bouncer.conn() as conn2:
+        # prepare and execute query on client 1
+        result = conn1.pgconn.prepare(b"mystmt", b"SELECT 1")
+        assert result.status == pq.ExecStatus.COMMAND_OK
 
-        # prepared query for client 2
-        cur2.execute(prepared_query, prepare=True)
+        result = conn1.pgconn.exec_prepared(b"mystmt", ())
+        assert result.status == pq.ExecStatus.TUPLES_OK
+        assert result.get_value(0, 0) == b"1"
+
+        # prepare and execute query on client 2
+        result = conn2.pgconn.prepare(b"mystmt", b"SELECT 2")
+        assert result.status == pq.ExecStatus.COMMAND_OK
+
+        result = conn2.pgconn.exec_prepared(b"mystmt", ())
+        assert result.status == pq.ExecStatus.TUPLES_OK
+        assert result.get_value(0, 0) == b"2"
 
         # execute DISCARD / DEALLOCATE ALL on client 1
-        cur1.execute(command)
+        result = conn1.pgconn.exec_(command.encode("utf-8"))
+        assert result.status == pq.ExecStatus.COMMAND_OK
 
-        # Run the prepared query again on server 2 and client 2
-        cur2.execute(prepared_query)
+        # Execute the prepared query again on client 2
+        result = conn2.pgconn.exec_prepared(b"mystmt", ())
+        assert result.status == pq.ExecStatus.TUPLES_OK
+        assert result.get_value(0, 0) == b"2"
 
         # Confirm that the prepared query is not available anymore on
         # client 1
-        with (
-            bouncer.log_contains("prepared statement did not exist"),
-            pytest.raises(
-                psycopg.OperationalError,
-                match="prepared statement did not exist|server closed the connection unexpectedly",
-            ),
-        ):
-            cur1.execute(prepared_query)
+        result = conn1.pgconn.exec_prepared(b"mystmt", ())
+        assert result.status == pq.ExecStatus.FATAL_ERROR
+        assert (
+            b"prepared statement did not exist" in result.error_message
+            or b"server closed the connection unexpectedly" in result.error_message
+        )
+        assert bouncer.log_contains("prepared statement did not exist")
 
 
 def test_parse_larger_than_pkt_buf(bouncer):


### PR DESCRIPTION
psycopg 3.3.5 includes a change to catch DISCARD ALL commands issued by the client, making it re-prepare any prepared statements. The test_discard_all test depended on the old behavior, causing the test to fail with psycopg 3.3.5. Silence the failure by removing the query that behaved differently on psycopg 3.3.5 and older versions.

Fixes #1574. See https://github.com/psycopg/psycopg/pull/1307 for the psycopg change.