### PR TITLE
Correctly handle tracked parameters that are not reported by the server

### DIFF
--- a/src/varcache.c
+++ b/src/varcache.c
@@ -191,7 +191,8 @@ static int apply_var(PktBuf *pkt, const char *key,
 		/*
 		 * This happens when a parameter is in track_extra_parameters but
 		 * PostgreSQL does not report it in ParameterStatus (e.g. enable_seqscan,
-		 * or default_transaction_read_only on PG <= 13), so pool->orig_vars is NULL.
+		 * or search_path on PG <= 17), so the parameter is not set in
+		 * pool->orig_vars.
 		 * A previous client configured this setting in its StartupMessage / connection
 		 * options (so sval is non-NULL), and now a client without this startup
 		 * parameter connects (cval is NULL).

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -173,17 +173,43 @@ static int apply_var(PktBuf *pkt, const char *key,
 	unsigned len;
 	const char *tmp;
 
-	/* if unset, skip */
-	if (!cval || !sval)
+	/* if both are unset, skip */
+	if (!cval && !sval)
 		return 0;
 
-	/* if equal, skip */
-	if (cval == sval)
-		return 0;
+	/* if both are set and equal, skip */
+	if (cval && sval) {
+		if (cval == sval)
+			return 0;
 
-	/* ignore case difference */
-	if (strcasecmp(cval->str, sval->str) == 0)
-		return 0;
+		/* ignore case difference */
+		if (strcasecmp(cval->str, sval->str) == 0)
+			return 0;
+	}
+
+	if (!cval) {
+		/*
+		 * This happens when a parameter is in track_extra_parameters but
+		 * PostgreSQL does not report it in ParameterStatus (e.g. enable_seqscan,
+		 * or default_transaction_read_only on PG <= 13), so pool->orig_vars is NULL.
+		 * A previous client configured this setting in its StartupMessage / connection
+		 * options (so sval is non-NULL), and now a client without this startup
+		 * parameter connects (cval is NULL).
+		 * Reset the parameter back to its session default on the server.
+		 */
+		len = snprintf(buf, sizeof(buf), "RESET %s;", key);
+		if (len < sizeof(buf)) {
+			pktbuf_put_bytes(pkt, buf, len);
+		} else {
+			char *buf2 = malloc(len + 1);
+			if (!buf2)
+				die("failed to allocate memory in apply_var");
+			snprintf(buf2, len + 1, "RESET %s;", key);
+			pktbuf_put_bytes(pkt, buf2, len);
+			free(buf2);
+		}
+		return 1;
+	}
 
 	/* parameters that are marked GUC_LIST_QUOTE are returned already fully quoted
 	 * re-quoting them using pg_quote_literal will result in malformed values. */
@@ -206,12 +232,12 @@ static int apply_var(PktBuf *pkt, const char *key,
 	if (len < sizeof(buf)) {
 		pktbuf_put_bytes(pkt, buf, len);
 	} else {
-		char *buf2 = malloc(sizeof(char)*len);
+		char *buf2 = malloc(len + 1);
 
 		if (!buf2)
 			die("failed to allocate memory in apply_var");
 
-		snprintf(buf2, len, "SET %s=%s;", key, tmp);
+		snprintf(buf2, len + 1, "SET %s=%s;", key, tmp);
 		pktbuf_put_bytes(pkt, buf2, len);
 
 		free(buf2);
@@ -264,6 +290,15 @@ void varcache_set_canonical(PgSocket *server, PgSocket *client)
 			strpool_incref(server_val);
 			strpool_decref(client_val);
 			client->vars.var_list[lk->idx] = server_val;
+		} else if (client_val && !server_val) {
+			slog_debug(server, "varcache_set_canonical: server var %s set to client value %s",
+				   lk->name, client_val->str);
+			strpool_incref(client_val);
+			server->vars.var_list[lk->idx] = client_val;
+		} else if (!client_val && server_val) {
+			slog_debug(server, "varcache_set_canonical: server var %s reset to NULL", lk->name);
+			strpool_decref(server_val);
+			server->vars.var_list[lk->idx] = NULL;
 		}
 	}
 }

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1004,10 +1004,7 @@ async def test_unreported_param_startup(bouncer):
     apply_var() must apply the variable when sval is NULL and reset it when a
     client without the variable connects.
     """
-    bouncer.write_ini(
-        "track_extra_parameters = enable_seqscan\n"
-        "default_pool_size = 1"
-    )
+    bouncer.write_ini("track_extra_parameters = enable_seqscan\ndefault_pool_size = 1")
     await bouncer.restart()
     bouncer.admin("set pool_mode=transaction")
     bouncer.admin("set verbose=2")
@@ -1036,7 +1033,3 @@ async def test_unreported_param_startup(bouncer):
         bouncer.cur(dbname="p1", options="-c enable_seqscan=off") as cur1,
     ):
         assert cur1.execute("SHOW enable_seqscan").fetchone()[0] == "off"
-
-
-
-

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -993,3 +993,50 @@ async def test_server_login_large_packets(bouncer):
     # Simply connecting exercises the server login path: the server sends
     # ParameterStatus, BackendKeyData, ReadyForQuery etc.
     bouncer.test()
+
+
+async def test_unreported_param_startup(bouncer):
+    """Test that startup parameters tracked via track_extra_parameters are applied.
+
+    When track_extra_parameters includes a parameter that PostgreSQL does not report
+    via ParameterStatus (such as enable_seqscan), PgBouncer stores client->vars
+    from the startup options, but server->vars remains NULL. Consequently,
+    apply_var() must apply the variable when sval is NULL and reset it when a
+    client without the variable connects.
+    """
+    bouncer.write_ini(
+        "track_extra_parameters = enable_seqscan\n"
+        "default_pool_size = 1"
+    )
+    await bouncer.restart()
+    bouncer.admin("set pool_mode=transaction")
+    bouncer.admin("set verbose=2")
+
+    # Client 1 sets enable_seqscan=off in startup options.
+    # It should emit SET enable_seqscan='off' only once across multiple transactions.
+    with (
+        bouncer.log_contains(r"varcache_apply: .*SET enable_seqscan='off'", times=1),
+        bouncer.cur(dbname="p1", options="-c enable_seqscan=off") as cur1,
+    ):
+        assert cur1.execute("SHOW enable_seqscan").fetchone()[0] == "off"
+        assert cur1.execute("SHOW enable_seqscan").fetchone()[0] == "off"
+
+    # Client 2 connects without startup options to the same pool (default_pool_size=1).
+    # The server connection should have enable_seqscan reset to DEFAULT ('on').
+    with (
+        bouncer.log_contains(r"varcache_apply: .*RESET enable_seqscan;", times=1),
+        bouncer.cur(dbname="p1") as cur2,
+    ):
+        assert cur2.execute("SHOW enable_seqscan").fetchone()[0] == "on"
+        assert cur2.execute("SHOW enable_seqscan").fetchone()[0] == "on"
+
+    # Client 1 connects again and should still have 'off' applied.
+    with (
+        bouncer.log_contains(r"varcache_apply: .*SET enable_seqscan='off'", times=1),
+        bouncer.cur(dbname="p1", options="-c enable_seqscan=off") as cur1,
+    ):
+        assert cur1.execute("SHOW enable_seqscan").fetchone()[0] == "off"
+
+
+
+


### PR DESCRIPTION
It's possible to configure PgBouncer such that a parameter is tracked in the varcache, while the backing postgres server doesn't actually report it using ParameterStatus. This would cause buggy behaviour when the client set such a parameter in its startup packet. This fixes that.

This becomes particularly relevant now that PG18 has made search_path a `GUC_REPORT` setting. This is very useful for PgBouncer and  we'd like to track `search_path` by default, but that shouldn't cause bugs on older versions.

In passing fixes a small out-of-bounds write of a null byte.

Related to #1573
