### PR TITLE
Prevent segfaults when a replication client disconnects

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -816,6 +816,11 @@ static bool sbuf_process_pending(SBuf *sbuf)
 				goto need_more_data;
 			}
 			Assert(sbuf->pkt_remain > 0);
+
+			/* callback may have closed sbuf and freed io */
+			io = sbuf->io;
+			if (!io)
+				return false;
 		}
 
 		if (sbuf->pkt_action == ACT_SKIP || sbuf->pkt_action == ACT_CALL) {
@@ -837,6 +842,10 @@ static bool sbuf_process_pending(SBuf *sbuf)
 			if (!sbuf_call_proto(sbuf, SBUF_EV_PKT_CALLBACK)) {
 				goto need_more_data;
 			}
+			/* callback may have closed sbuf and freed io */
+			io = sbuf->io;
+			if (!io)
+				return false;
 		/* fallthrough */
 		/* after callback, skip pkt */
 		case ACT_SKIP:


### PR DESCRIPTION
# Summary

Prevent a pgbouncer segfault when a `replication=database` client disconnects while it still has a replication-protocol simple query in flight.

## Fix

- After each sbuf_call_proto() callback (the packet-header callback around line 815, and the SBUF_EV_PKT_CALLBACK case around line 842), the local io pointer is now re-read from sbuf->io.
- If the callback closed the socket (which frees the IO buffer and NULLs sbuf->io), the function now returns false instead of continuing to dereference the stale io pointer.

## Doc 

Flowchart documenting the logical branch that leads to the error: https://github.com/kevinwatson/pgbouncer-client-disconnect-segfault/blob/main/CRASH.md#1-the-branch-that-kills-it

# Testing

Test app to reproduce the issue:

https://github.com/kevinwatson/pgbouncer-client-disconnect-segfault
