### PR TITLE
Add `auth_query_client_addr` option to pass client IP to auth_query

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -566,6 +566,20 @@ that no password that the client offers will be accepted.
 
 Default: `SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin`
 
+### auth_query_client_addr
+
+Whether the client's connecting address is passed to `auth_query` as a
+second query parameter (`$2`), in addition to the user name (`$1`).
+
+This allows an `auth_query` function to implement IP-based allow/deny listing for logins, by inspecting the address and raising an error
+(or returning no rows) for addresses that should not be allowed to
+authenticate.
+
+The address is a numeric IPv4 or IPv6 address, or the literal string
+`unix` for Unix domain socket connections.
+
+Default: 0
+
 ### auth_dbname
 
 Database name in the `[database]` section to be used for authentication purposes. This

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -148,6 +148,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; must have 2 columns - username and password hash.
 ;auth_query = SELECT rolname, CASE WHEN rolvaliduntil < pg_catalog.now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin
 
+;; Also pass the client's connecting address to "auth_query" as a second
+;; parameter ($2), so it can implement IP-based allow/deny lists.
+;auth_query_client_addr = 0
+
 ;; Authentication database that can be set globally to run "auth_query".
 ;auth_dbname =
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -878,6 +878,7 @@ extern char *cf_resolv_conf;
 extern int cf_auth_type;
 extern char *cf_auth_file;
 extern char *cf_auth_query;
+extern int cf_auth_query_client_addr;
 extern char *cf_auth_user;
 extern char *cf_auth_hba_file;
 extern char *cf_auth_dbname;

--- a/src/client.c
+++ b/src/client.c
@@ -169,6 +169,7 @@ static void start_auth_query(PgSocket *client, const char *username)
 	int res;
 	PktBuf *buf;
 	const char *auth_query = client->db->auth_query ? client->db->auth_query : cf_auth_query;
+	char client_addr[PGADDR_BUF];
 
 	/* have to fetch user info from db */
 	PgDatabase *auth_db = prepare_auth_database(client);
@@ -205,7 +206,13 @@ static void start_auth_query(PgSocket *client, const char *username)
 	res = 0;
 	buf = pktbuf_dynamic(512);
 	if (buf) {
-		pktbuf_write_ExtQuery(buf, auth_query, 1, username);
+		if (cf_auth_query_client_addr) {
+			pga_ntop(&client->remote_addr, client_addr, sizeof(client_addr));
+			pktbuf_write_ExtQuery(buf, auth_query, 2, username, client_addr);
+		} else {
+			pktbuf_write_ExtQuery(buf, auth_query, 1, username);
+		}
+
 		res = pktbuf_send_immediate(buf, client->link);
 		pktbuf_free(buf);
 		/*

--- a/src/main.c
+++ b/src/main.c
@@ -123,6 +123,7 @@ char *cf_auth_ident_file;
 char *cf_auth_ldap_options;
 char *cf_auth_user;
 char *cf_auth_query;
+int cf_auth_query_client_addr;
 char *cf_auth_dbname;
 char *cf_track_extra_parameters;
 
@@ -265,6 +266,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("auth_ident_file", CF_STR, cf_auth_ident_file, 0, NULL),
 	CF_ABS("auth_ldap_options", CF_STR, cf_auth_ldap_options, 0, NULL),
 	CF_ABS("auth_query", CF_STR, cf_auth_query, 0, "SELECT rolname, CASE WHEN rolvaliduntil < now() THEN NULL ELSE rolpassword END FROM pg_authid WHERE rolname=$1 AND rolcanlogin"),
+	CF_ABS("auth_query_client_addr", CF_INT, cf_auth_query_client_addr, 0, "0"),
 	CF_ABS("auth_type", CF_LOOKUP(auth_type_map), cf_auth_type, 0, "md5"),
 	CF_ABS("auth_user", CF_STR, cf_auth_user, 0, NULL),
 	CF_ABS("autodb_idle_timeout", CF_TIME_USEC, cf_autodb_idle_timeout, 0, "3600"),

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1270,6 +1270,101 @@ def test_auth_query_no_set_commands(bouncer, pg):
         pg.sql("DROP FUNCTION IF EXISTS auth_check_search_path(TEXT)")
 
 
+def test_auth_query_client_addr_allowed(bouncer, pg):
+    """
+    Check that when auth_query_client_addr is enabled, the client's
+    connecting address is passed to auth_query as a second parameter, and
+    that a login from an allowed address succeeds.
+    """
+    pg.sql("""
+        CREATE OR REPLACE FUNCTION auth_check_client_addr(username TEXT, client_addr TEXT)
+        RETURNS TABLE(usename name, passwd text) AS $$
+        BEGIN
+            IF client_addr <> '127.0.0.1' THEN
+                RAISE EXCEPTION 'client address % is not allowed', client_addr;
+            END IF;
+            RETURN QUERY SELECT u.usename, u.passwd FROM pg_shadow u WHERE u.usename = username;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER;
+    """)
+
+    config = f"""
+        [databases]
+        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT * FROM auth_check_client_addr($1, $2)'
+        [pgbouncer]
+        auth_query = SELECT * FROM auth_check_client_addr($1, $2)
+        auth_query_client_addr = 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+    """
+
+    try:
+        with bouncer.run_with_config(config):
+            bouncer.sql(
+                query="select 1",
+                user="stats",
+                password="stats",
+                dbname="postgres",
+            )
+    finally:
+        pg.sql("DROP FUNCTION IF EXISTS auth_check_client_addr(TEXT, TEXT)")
+
+
+def test_auth_query_client_addr_denied(bouncer, pg):
+    """
+    Check that when auth_query_client_addr is enabled, auth_query can use
+    the client's connecting address to deny a login, e.g. to implement an
+    IP-based deny list.
+    """
+    pg.sql("""
+        CREATE OR REPLACE FUNCTION auth_check_client_addr(username TEXT, client_addr TEXT)
+        RETURNS TABLE(usename name, passwd text) AS $$
+        BEGIN
+            RAISE EXCEPTION 'client address % is not allowed', client_addr;
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER;
+    """)
+
+    config = f"""
+        [databases]
+        postgres = host={bouncer.pg.host} port={bouncer.pg.port} auth_query='SELECT * FROM auth_check_client_addr($1, $2)'
+        [pgbouncer]
+        auth_query = SELECT * FROM auth_check_client_addr($1, $2)
+        auth_query_client_addr = 1
+        auth_user = pswcheck
+        stats_users = stats
+        listen_addr = {bouncer.host}
+        admin_users = pgbouncer
+        auth_type = md5
+        auth_file = {bouncer.auth_path}
+        listen_port = {bouncer.port}
+        logfile = {bouncer.log_path}
+        auth_dbname = postgres
+    """
+
+    try:
+        with (
+            bouncer.run_with_config(config),
+            bouncer.log_contains("client address 127.0.0.1 is not allowed"),
+            pytest.raises(psycopg.OperationalError, match="bouncer config error"),
+        ):
+            bouncer.sql(
+                query="select 1",
+                user="stats",
+                password="stats",
+                dbname="postgres",
+            )
+    finally:
+        pg.sql("DROP FUNCTION IF EXISTS auth_check_client_addr(TEXT, TEXT)")
+
+
 @pytest.mark.md5
 @pytest.mark.skipif(
     "psycopg.pq.version() < 180000", reason="libpq 18+ required for protocol 3.2"


### PR DESCRIPTION
Adds a new `auth_query_client_addr` boolean setting.
When enabled, PGBouncer passes the client's connecting address as a second parameter
(`$2`) to `auth_query`, in addition to the user name (`$1`).

This lets a custom `auth_query` function (e.g. a `SECURITY DEFINER`
function) implement IP-based allow/deny lists for logins, which is
useful in shared/multi-tenant environments where PGBouncer sits in
front of many clients.

Default is `0` (off), so existing `auth_query` configurations are unaffected.

## Changes

- `auth_query_client_addr` config option (`include/bouncer.h`, `src/main.c`)
- `src/client.c`: conditionally binds the client address (via `pga_ntop`)
  as `$2` when the option is enabled
- Documentation in `doc/config.md` and an example in `etc/pgbouncer.ini`
- Tests in `test/test_auth.py` covering both the allow and deny cases

## Test plan

- [x] `pytest test/test_auth.py -k client_addr` - both new tests pass
- [x] Full `pytest test/` suite (waiting confirmation in CI, all green in local apart from the `test_discard_all` that needs https://github.com/pgbouncer/pgbouncer/pull/1575)
