### PR TITLE
Track all parameters that Postgres reports by default

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -237,22 +237,38 @@ Default: 0
 
 ### track_extra_parameters
 
-By default, PgBouncer tracks `client_encoding`, `datestyle`, `timezone`,
-`standard_conforming_strings` and `application_name` parameters per client. To
-allow other parameters to be tracked, they can be specified here, so that
-PgBouncer knows that they should be maintained in the client variable cache and
-restored in the server whenever the client becomes active.
+By default, PgBouncer tracks all the parameters that Postgres reports to the
+client and that can be changed by the client: `application_name`,
+`client_encoding`, `DateStyle`, `default_transaction_read_only`,
+`IntervalStyle`, `scram_iterations`, `search_path`, `session_authorization`,
+`standard_conforming_strings` and `TimeZone`. To allow other parameters to be
+tracked, they can be specified here, so that PgBouncer knows that they should be
+maintained in the client variable cache and restored in the server whenever the
+client becomes active.
 
 If you need to specify multiple values, use a comma-separated list (e.g.
-`search_path, IntervalStyle`)
+`some_extension.setting, other_extension.setting`)
 
-Note: Most parameters cannot be tracked this way. The only parameters that can
-be tracked are ones that Postgres reports to the client. Postgres has
-[an official list of parameters that it reports to the client](https://www.postgresql.org/docs/15/protocol-flow.html#PROTOCOL-ASYNC).
+Note: Most parameters cannot be fully tracked this way. PgBouncer only learns
+about changes made with `SET` for parameters that Postgres reports to the
+client. Postgres has
+[an official list of parameters that it reports to the client](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-ASYNC).
 Postgres extensions can change this list though, they can add parameters
 themselves that they also report, and they can start reporting already existing
 parameters that Postgres does not report.  Notably Citus 12.0+ causes Postgres
-to also report `search_path`.
+to also report `search_path`. Some of the parameters that are tracked by default
+are also only reported by newer Postgres versions: `default_transaction_read_only`
+since Postgres 14, `scram_iterations` since Postgres 16 and `search_path` since
+Postgres 18.
+
+For a tracked parameter that Postgres does not report (e.g. `search_path` on
+Postgres versions before 18), PgBouncer only knows the value that a client
+specified in its startup packet (or in the `options` startup parameter). That
+value is applied to the server connection whenever the client becomes active,
+and the parameter is reset to its default for clients that did not specify it.
+Changes made with `SET` after connecting are not tracked for such parameters, so
+they leak to other clients sharing the server connection, unless
+`server_reset_query_always` is used.
 
 The Postgres protocol allows specifying parameters settings, both directly as a
 parameter in the startup packet, or inside the [`options` startup
@@ -261,13 +277,13 @@ supported by `track_extra_parameters`. However, it's not possible to include
 `options` itself in `track_extra_parameters`, only the parameters contained in
 `options`.
 
-Default: IntervalStyle
+Default: empty
 
 ### ignore_startup_parameters
 
 By default, PgBouncer allows only parameters it can keep track of in startup
-packets: `client_encoding`, `datestyle`, `timezone` and
-`standard_conforming_strings`.  All others parameters will raise an error.  To
+packets (see `track_extra_parameters` for the list). All other parameters will
+raise an error.  To
 allow others parameters, they can be specified here, so that PgBouncer knows
 that they are handled by the admin and it can ignore them.
 

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -192,7 +192,7 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; Comma-separated list of parameters to track per client.  The
 ;; Postgres parameters listed here will be cached per client by
 ;; pgbouncer and restored in server every time the client runs a query.
-;track_extra_parameters = IntervalStyle
+;track_extra_parameters =
 
 ;; Comma-separated list of parameters to ignore when given in startup
 ;; packet.  Newer JDBC versions require the extra_float_digits here.

--- a/src/main.c
+++ b/src/main.c
@@ -358,7 +358,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("tcp_keepintvl", CF_INT, cf_tcp_keepintvl, 0, "0"),
 	CF_ABS("tcp_socket_buffer", CF_INT, cf_tcp_socket_buffer, 0, "0"),
 	CF_ABS("tcp_user_timeout", CF_INT, cf_tcp_user_timeout, 0, "0"),
-	CF_ABS("track_extra_parameters", CF_STR, cf_track_extra_parameters, CF_NO_RELOAD, "IntervalStyle"),
+	CF_ABS("track_extra_parameters", CF_STR, cf_track_extra_parameters, CF_NO_RELOAD, ""),
 	CF_ABS("transaction_timeout", CF_TIME_USEC, cf_transaction_timeout, 0, "0"),
 	CF_ABS("unix_socket_dir", CF_STR, cf_unix_socket_dir, CF_NO_RELOAD, DEFAULT_UNIX_SOCKET_DIR),
 #ifndef WIN32

--- a/src/varcache.c
+++ b/src/varcache.c
@@ -102,6 +102,10 @@ void init_var_lookup(const char *cf_track_extra_parameters)
 		"standard_conforming_strings",
 		"application_name",
 		"default_transaction_read_only",
+		"IntervalStyle",
+		"search_path",
+		"scram_iterations",
+		"session_authorization",
 		NULL
 	};
 	int idx = 0;

--- a/test/test.ini
+++ b/test/test.ini
@@ -93,7 +93,4 @@ tcp_keepalive = 0
 ; Otherwise bugs caused by EAGAIN are hard to debug.
 tcp_socket_buffer = 4096
 
-;track_extra_parameters is case sensitive.
-;bgbouncer will only track the parameters with GUC_REPORT flag set in Postgres
-track_extra_parameters = search_path, intervalstyle
 ignore_startup_parameters = extra_float_digits

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -448,9 +448,8 @@ def test_fast_close(bouncer):
 
 
 def test_track_extra_parameters(bouncer):
-    # test.ini has track_extra_parameters set to a list of Postgres
-    # parameters. Test that the parameters in the list in addition to the
-    # default hardcoded list of parameters are cached per client.
+    # Test that the default hardcoded list of tracked parameters are cached
+    # per client.
     bouncer.admin(f"set pool_mode=transaction")
 
     test_set = {
@@ -477,6 +476,16 @@ def test_track_extra_parameters(bouncer):
     if PG_MAJOR_VERSION >= 14:
         test_set["default_transaction_read_only"] = ["true", "false"]
         test_expected["default_transaction_read_only"] = ["on", "off"]
+
+    # scram_iterations was not marked as GUC_REPORT until server version 16
+    if PG_MAJOR_VERSION >= 16:
+        test_set["scram_iterations"] = ["1000", "2000"]
+        test_expected["scram_iterations"] = ["1000", "2000"]
+
+    # search_path was not marked as GUC_REPORT until server version 18
+    if PG_MAJOR_VERSION >= 18:
+        test_set["search_path"] = ["a, b", "c, d"]
+        test_expected["search_path"] = ["a, b", "c, d"]
 
     with bouncer.cur(dbname="p1") as cur1, bouncer.cur(dbname="p1") as cur2:
         for key in test_set:
@@ -1033,3 +1042,47 @@ async def test_unreported_param_startup(bouncer):
         bouncer.cur(dbname="p1", options="-c enable_seqscan=off") as cur1,
     ):
         assert cur1.execute("SHOW enable_seqscan").fetchone()[0] == "off"
+
+
+async def test_session_authorization_tracked(bouncer):
+    """Test that SET SESSION AUTHORIZATION does not leak to other clients.
+
+    session_authorization is in the static list of tracked parameters. A
+    superuser client that changes it in transaction mode should get it
+    re-applied on every transaction, and other clients sharing the same server
+    connection should get it reset to the login user.
+    """
+    bouncer.write_ini("default_pool_size = 1")
+    await bouncer.restart()
+    bouncer.admin("set pool_mode=transaction")
+    bouncer.admin("set verbose=2")
+
+    conn_args = dict(
+        dbname="user_passthrough", user="pswcheck", password="pgbouncer-check"
+    )
+
+    with bouncer.cur(**conn_args) as cur1, bouncer.cur(**conn_args) as cur2:
+        assert cur1.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"
+        assert cur2.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"
+
+        cur1.execute("SET SESSION AUTHORIZATION someuser")
+        assert cur1.execute("SHOW session_authorization").fetchone()[0] == "someuser"
+
+        # cur2 shares the single server connection, so PgBouncer has to switch
+        # session_authorization back and forth between the two clients.
+        with bouncer.log_contains(
+            r"varcache_apply: .*SET session_authorization='pswcheck'", times=1
+        ):
+            assert (
+                cur2.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"
+            )
+        with bouncer.log_contains(
+            r"varcache_apply: .*SET session_authorization='someuser'", times=1
+        ):
+            assert (
+                cur1.execute("SHOW session_authorization").fetchone()[0] == "someuser"
+            )
+
+        cur1.execute("RESET SESSION AUTHORIZATION")
+        assert cur1.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"
+        assert cur2.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1057,9 +1057,11 @@ async def test_session_authorization_tracked(bouncer):
     bouncer.admin("set pool_mode=transaction")
     bouncer.admin("set verbose=2")
 
-    conn_args = dict(
-        dbname="user_passthrough", user="pswcheck", password="pgbouncer-check"
-    )
+    conn_args = {
+        "dbname": "user_passthrough",
+        "user": "pswcheck",
+        "password": "pgbouncer-check",
+    }
 
     with bouncer.cur(**conn_args) as cur1, bouncer.cur(**conn_args) as cur2:
         assert cur1.execute("SHOW session_authorization").fetchone()[0] == "pswcheck"


### PR DESCRIPTION
Now that #1576 is merged there's basically no downside to tracking parameters anymore (except for a tiny amount of extra memory usage per connection). So let's start tracking all writable GUCs that Postgres sets the GUC_REPORT flag for. Most notably this starts tracking search_path by default.

Fixes #1176
Partially fixes #482
Fixes #1313
Related to #1573