### PR TITLE
Relaunch a DNS request whose resolver callback never fires (add dns_resolve_timeout)

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -802,6 +802,24 @@ How long DNS errors and NXDOMAIN DNS lookups can be cached. [seconds]
 
 Default: 15.0
 
+### dns_resolve_timeout
+
+Maximum time a hostname lookup may stay outstanding before PgBouncer re-issues
+it.
+
+PgBouncer normally re-issues a lookup only after the previous one has finished.
+If the in-process resolver never delivers a result for a request (a hung
+resolution), the request would otherwise stay pending forever: the hostname
+becomes permanently unresolvable (`SHOW DNS_HOSTS` shows it with no addresses)
+and only a restart clears it, even though a fresh resolver on the same host
+resolves the name. When this is set, PgBouncer relaunches a lookup that has been
+outstanding for longer than this, so it can recover without a restart.
+
+The value should be comfortably larger than a normal lookup (including resolver
+retries) so it never fires for a lookup that is merely slow. [seconds]
+
+Default: 0.0 (disabled)
+
 ### dns_zone_check_period
 
 Period to check if a zone serial has changed.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -383,6 +383,10 @@ auth_file = /etc/pgbouncer/userlist.txt
 ;; DNS negative result caching time
 ;dns_nxdomain_ttl = 15
 
+;; Re-issue a hostname lookup that stays outstanding this long (a hung
+;; resolution). 0 disables.
+;dns_resolve_timeout = 0
+
 ;; Custom resolv.conf file, to set custom DNS servers or other options
 ;; (default: empty = use OS settings)
 ;resolv_conf = /etc/pgbouncer/resolv.conf

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -872,6 +872,7 @@ extern int cf_server_round_robin;
 extern int cf_disable_pqexec;
 extern usec_t cf_dns_max_ttl;
 extern usec_t cf_dns_nxdomain_ttl;
+extern usec_t cf_dns_resolve_timeout;
 extern usec_t cf_dns_zone_check_period;
 extern char *cf_resolv_conf;
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -939,6 +939,12 @@ extern const struct CfLookup load_balance_hosts_map[];
 extern struct DNSContext *adns;
 extern struct HBA *parsed_hba;
 
+#ifdef CASSERT
+/* test-only DNS fault-injection flags, armed from PGB_TEST_DNS_FAULT in main() */
+extern int test_dns_hang;
+extern int test_dns_late_stale;
+#endif
+
 static inline PgSocket *first_socket(struct StatList *slist)
 {
 	if (statlist_empty(slist))

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -899,6 +899,10 @@ static struct DNSQuery *new_query(struct DNSRequest *req)
 	return q;
 }
 
+/* test-only: the request (and its epoch) whose first lookup was dropped */
+static struct DNSRequest *test_hung_req;
+static unsigned test_hung_epoch;
+
 /*
  * Issue (or re-issue) the backend query for a request and record when, so that
  * adns_check_stuck() can relaunch a request whose resolver callback never fires.
@@ -908,6 +912,25 @@ static void launch_request(struct DNSRequest *req)
 	struct DNSQuery *q;
 
 	req->launch_time = get_cached_time();
+
+	/*
+	 * Test-only fault injection: drop the first lookup so its callback never
+	 * fires, reproducing the "hung in-process resolver" that leaves a request
+	 * pending forever (see adns_check_stuck / test/test_dns_stuck.py). Active
+	 * only when the PGB_TEST_HANG_ONCE environment variable is set; a no-op in
+	 * normal operation.  Dropped before active++/new_query, so nothing leaks.
+	 */
+	if (getenv("PGB_TEST_HANG_ONCE")) {
+		static bool hung_once = false;
+		if (!hung_once) {
+			hung_once = true;
+			test_hung_req = req;
+			test_hung_epoch = req->epoch;
+			log_warning("TEST: dropping lookup of '%s' to simulate a hung resolution",
+				    req->name);
+			return;
+		}
+	}
 
 	req->ctx->active++;
 	q = new_query(req);
@@ -1384,8 +1407,33 @@ static void adns_check_stuck(struct DNSContext *ctx)
 	free(w.stuck);
 }
 
+/*
+ * Test-only: once a dropped ("hung") request has recovered via a relaunch,
+ * simulate its original query finally answering late, carrying the epoch it was
+ * launched for.  The epoch guard in got_result_gai() must discard this stale
+ * answer so it cannot clobber the fresh result.  Pair it with an active++ so the
+ * discard's active-- balances (a real late query would have taken one when it
+ * was launched).  Active only under PGB_TEST_LATE_STALE.
+ */
+static void test_late_stale(void)
+{
+	struct DNSRequest *req = test_hung_req;
+	struct DNSQuery q;
+
+	if (!req || !req->done || !getenv("PGB_TEST_LATE_STALE"))
+		return;
+	test_hung_req = NULL;
+
+	q.req = req;
+	q.epoch = test_hung_epoch;
+	log_warning("TEST: delivering late stale callback for '%s'", req->name);
+	req->ctx->active++;
+	got_result_gai(0, NULL, &q);
+}
+
 void adns_per_loop(struct DNSContext *ctx)
 {
 	impl_per_loop(ctx);
 	adns_check_stuck(ctx);
+	test_late_stale();
 }

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -85,6 +85,34 @@ struct DNSRequest {
 	struct addrinfo *oldres;
 
 	usec_t res_ttl;
+
+	/* when the currently-outstanding query was issued (see adns_check_stuck) */
+	usec_t launch_time;
+
+	/*
+	 * A request relaunched by adns_check_stuck() can briefly have more than one
+	 * query in flight, and a new resolution episode can start while an old query
+	 * is still outstanding.  epoch is bumped when a new episode starts (see
+	 * start_resolution), but not on a stuck relaunch; answered_epoch is the
+	 * highest epoch whose result has been delivered.  Each query carries the
+	 * epoch it was launched for (struct DNSQuery), and got_result_gai() accepts
+	 * only an answer newer than answered_epoch -- so a late answer from a
+	 * superseded query is discarded instead of clobbering the fresh result.
+	 */
+	unsigned epoch;
+	unsigned answered_epoch;
+};
+
+/*
+ * One per issued query.  Carries the epoch the query was launched for so a late
+ * answer from a superseded query (a stuck-relaunch duplicate, or a straggler
+ * from an earlier episode) can be recognised and discarded.  Passed to the
+ * backend as the callback argument and freed by the backend glue after
+ * got_result_gai() returns.
+ */
+struct DNSQuery {
+	struct DNSRequest *req;
+	unsigned epoch;
 };
 
 /* zone name serial */
@@ -229,7 +257,7 @@ const char *adns_get_backend(void)
 
 struct GaiRequest {
 	struct List node;
-	struct DNSRequest *req;
+	struct DNSQuery *q;
 	struct gaicb gairq;
 };
 
@@ -254,7 +282,8 @@ static void dns_signal(int f, short ev, void *arg)
 
 		/* got one */
 		list_del(&rq->node);
-		got_result_gai(e, rq->gairq.ar_result, rq->req);
+		got_result_gai(e, rq->gairq.ar_result, rq->q);
+		free(rq->q);
 		free(rq);
 	}
 }
@@ -286,7 +315,7 @@ static bool impl_init(struct DNSContext *ctx)
 	return true;
 }
 
-static void impl_launch_query(struct DNSRequest *req)
+static void impl_launch_query(struct DNSRequest *req, struct DNSQuery *q)
 {
 	static const struct addrinfo hints = { .ai_socktype = SOCK_STREAM };
 
@@ -300,7 +329,7 @@ static void impl_launch_query(struct DNSRequest *req)
 		goto failed2;
 
 	list_init(&grq->node);
-	grq->req = req;
+	grq->q = q;
 	grq->gairq.ar_name = req->name;
 	grq->gairq.ar_request = &hints;
 	list_append(&gctx->gairq_list, &grq->node);
@@ -321,6 +350,7 @@ failed:
 	list_del(&grq->node);
 	free(grq);
 failed2:
+	free(q);
 	req->done = true;
 	deliver_info(req);
 }
@@ -394,14 +424,23 @@ static bool impl_init(struct DNSContext *ctx)
 	return true;
 }
 
-static void impl_launch_query(struct DNSRequest *req)
+/* evdns callback: unwrap the per-query token, deliver, then free it */
+static void evdns_result_cb(int result, struct addrinfo *res, void *arg)
+{
+	struct DNSQuery *q = arg;
+
+	got_result_gai(result, res, q);
+	free(q);
+}
+
+static void impl_launch_query(struct DNSRequest *req, struct DNSQuery *q)
 {
 	static const struct addrinfo hints = { .ai_socktype = SOCK_STREAM };
 
 	struct evdns_getaddrinfo_request *gai_req;
 	struct evdns_base *dns = req->ctx->edns;
 
-	gai_req = evdns_getaddrinfo(dns, req->name, NULL, &hints, got_result_gai, req);
+	gai_req = evdns_getaddrinfo(dns, req->name, NULL, &hints, evdns_result_cb, q);
 	log_noise("dns: evdns_getaddrinfo(%s)=%p", req->name, gai_req);
 }
 
@@ -562,21 +601,22 @@ re_set:
 /* called by c-ares on dns reply */
 static void xares_host_cb(void *arg, int status, int timeouts, struct hostent *h)
 {
-	struct DNSRequest *req = arg;
+	struct DNSQuery *q = arg;
 	struct addrinfo *res = NULL;
 
-	log_noise("dns: xares_host_cb(%s)=%s", req->name, ares_strerror(status));
+	log_noise("dns: xares_host_cb(%s)=%s", q->req->name, ares_strerror(status));
 	if (status == ARES_SUCCESS) {
 		res = convert_hostent(h);
-		got_result_gai(0, res, req);
+		got_result_gai(0, res, q);
 	} else {
-		log_debug("DNS lookup failed: %s - %s", req->name, ares_strerror(status));
-		got_result_gai(0, res, req);
+		log_debug("DNS lookup failed: %s - %s", q->req->name, ares_strerror(status));
+		got_result_gai(0, res, q);
 	}
+	free(q);
 }
 
 /* send hostname query */
-static void impl_launch_query(struct DNSRequest *req)
+static void impl_launch_query(struct DNSRequest *req, struct DNSQuery *q)
 {
 	struct XaresMeta *meta = req->ctx->edns;
 	int af;
@@ -596,7 +636,7 @@ static void impl_launch_query(struct DNSRequest *req)
 	af = AF_UNSPEC;
 #endif
 	log_noise("dns: ares_gethostbyname(%s)", req->name);
-	ares_gethostbyname(meta->chan, req->name, af, xares_host_cb, req);
+	ares_gethostbyname(meta->chan, req->name, af, xares_host_cb, q);
 
 	meta->got_events = true;
 }
@@ -847,6 +887,52 @@ void adns_free_context(struct DNSContext *ctx)
 	}
 }
 
+/* allocate a per-query token stamped with the request's current epoch */
+static struct DNSQuery *new_query(struct DNSRequest *req)
+{
+	struct DNSQuery *q = malloc(sizeof(*q));
+
+	if (q) {
+		q->req = req;
+		q->epoch = req->epoch;
+	}
+	return q;
+}
+
+/*
+ * Issue (or re-issue) the backend query for a request and record when, so that
+ * adns_check_stuck() can relaunch a request whose resolver callback never fires.
+ */
+static void launch_request(struct DNSRequest *req)
+{
+	struct DNSQuery *q;
+
+	req->launch_time = get_cached_time();
+
+	req->ctx->active++;
+	q = new_query(req);
+	if (!q) {
+		/* out of memory: fail this launch; deliver_info() balances active */
+		req->done = true;
+		deliver_info(req);
+		return;
+	}
+	impl_launch_query(req, q);
+}
+
+/*
+ * Start a new resolution episode: bump the epoch so the next answer is accepted
+ * (and any straggler from a superseded episode is discarded) and issue the query.
+ * A stuck relaunch (adns_check_stuck) instead calls launch_request() directly, so
+ * it stays in the same episode and the first answer -- from whichever query --
+ * wins.
+ */
+static void start_resolution(struct DNSRequest *req)
+{
+	req->epoch++;
+	launch_request(req);
+}
+
 struct DNSToken *adns_resolve(struct DNSContext *ctx, const char *name, adns_callback_f cb_func, void *cb_arg)
 {
 	int namelen = strlen(name);
@@ -876,8 +962,7 @@ struct DNSToken *adns_resolve(struct DNSContext *ctx, const char *name, adns_cal
 
 		zone_register(ctx, req);
 
-		ctx->active++;
-		impl_launch_query(req);
+		start_resolution(req);
 	}
 
 	/* remember user callback */
@@ -894,8 +979,7 @@ struct DNSToken *adns_resolve(struct DNSContext *ctx, const char *name, adns_cal
 		if (req->res_ttl < get_cached_time()) {
 			log_noise("dns: ttl over: %s", req->name);
 			req_reset(req);
-			ctx->active++;
-			impl_launch_query(req);
+			start_resolution(req);
 		} else {
 			deliver_info(req);
 		}
@@ -941,7 +1025,27 @@ static void check_req_result_changes(struct DNSRequest *req)
 /* struct addrinfo -> deliver_info() */
 static void got_result_gai(int result, struct addrinfo *res, void *arg)
 {
-	struct DNSRequest *req = arg;
+	struct DNSQuery *q = arg;
+	struct DNSRequest *req = q->req;
+
+	/*
+	 * A request relaunched by adns_check_stuck() can have more than one query
+	 * in flight, and a new resolution episode can start while an old query is
+	 * still outstanding.  Each query carries the epoch it was launched for, so
+	 * accept only an answer newer than the one already delivered; discard a late
+	 * answer from a superseded query (a same-episode duplicate, or a straggler
+	 * from an earlier episode) so it cannot clobber the fresh result or mark good
+	 * addresses dirty.  The query still counted against ctx->active when it was
+	 * launched, so drop it here.
+	 */
+	if (q->epoch <= req->answered_epoch) {
+		log_noise("dns: discarding superseded result for '%s'", req->name);
+		if (res)
+			freeaddrinfo(res);
+		req->ctx->active--;
+		return;
+	}
+	req->answered_epoch = q->epoch;
 
 	req_reset(req);
 
@@ -1121,8 +1225,7 @@ static void zone_requeue(struct DNSContext *ctx, struct DNSZone *z)
 		if (!req->done)
 			continue;
 		req->res_ttl = 0;
-		ctx->active++;
-		impl_launch_query(req);
+		start_resolution(req);
 	}
 }
 
@@ -1207,7 +1310,82 @@ void adns_walk_zones(struct DNSContext *ctx, adns_walk_zone_f cb, void *arg)
 	aatree_walk(&ctx->zone_tree, AA_WALK_IN_ORDER, walk_zone, &w);
 }
 
+/*
+ * Relaunch a request whose resolver callback never fired.
+ *
+ * A request is relaunched only once it is ->done: adns_resolve() does so in its
+ * req->done branch, and zone_requeue() skips !done requests.  So if the
+ * in-process resolver never calls back (a hung resolution), the request stays
+ * pending forever, and every later resolution of that name attaches to the
+ * stuck request without issuing a new query -- the name is then permanently
+ * unresolvable (SHOW DNS_HOSTS shows it empty, servers stay at (bad-af)) even
+ * though a fresh resolver on the same host resolves it, and only a restart
+ * clears it.  When dns_resolve_timeout is set, relaunch any request that has
+ * been pending longer than that so recovery does not require a restart.
+ */
+struct StuckWalk {
+	usec_t now;
+	struct DNSRequest **stuck;
+	int count;
+	int alloc;
+};
+
+static void collect_stuck_cb(struct AANode *node, void *arg)
+{
+	struct StuckWalk *w = arg;
+	struct DNSRequest *req = container_of(node, struct DNSRequest, node);
+	struct DNSRequest **tmp;
+	int n;
+
+	if (req->done)
+		return;
+	if (w->now - req->launch_time < cf_dns_resolve_timeout)
+		return;
+
+	if (w->count == w->alloc) {
+		n = w->alloc ? w->alloc * 2 : 16;
+		tmp = realloc(w->stuck, n * sizeof(*tmp));
+		if (!tmp)
+			return;	/* out of memory: relaunch what we have, retry the rest next scan */
+		w->stuck = tmp;
+		w->alloc = n;
+	}
+	w->stuck[w->count++] = req;
+}
+
+static void adns_check_stuck(struct DNSContext *ctx)
+{
+	static usec_t last_check;
+	usec_t now = get_cached_time();
+	struct StuckWalk w;
+	int i;
+
+	if (!cf_dns_resolve_timeout)
+		return;
+
+	/* limit the tree walk to once per second */
+	if (last_check && now - last_check < USEC)
+		return;
+	last_check = now;
+
+	/* collect first, then relaunch, so the tree is not mutated mid-walk */
+	w.now = now;
+	w.stuck = NULL;
+	w.count = 0;
+	w.alloc = 0;
+	aatree_walk(&ctx->req_tree, AA_WALK_IN_ORDER, collect_stuck_cb, &w);
+
+	for (i = 0; i < w.count; i++) {
+		struct DNSRequest *req = w.stuck[i];
+		log_warning("dns: lookup of '%s' still pending after %d s; relaunching",
+			    req->name, (int)((now - req->launch_time) / USEC));
+		launch_request(req);
+	}
+	free(w.stuck);
+}
+
 void adns_per_loop(struct DNSContext *ctx)
 {
 	impl_per_loop(ctx);
+	adns_check_stuck(ctx);
 }

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -899,9 +899,11 @@ static struct DNSQuery *new_query(struct DNSRequest *req)
 	return q;
 }
 
+#ifdef CASSERT
 /* test-only: the request (and its epoch) whose first lookup was dropped */
 static struct DNSRequest *test_hung_req;
 static unsigned test_hung_epoch;
+#endif
 
 /*
  * Issue (or re-issue) the backend query for a request and record when, so that
@@ -913,12 +915,15 @@ static void launch_request(struct DNSRequest *req)
 
 	req->launch_time = get_cached_time();
 
+#ifdef CASSERT
 	/*
-	 * Test-only fault injection: drop the first lookup so its callback never
+	 * Test-only fault injection, compiled only in cassert builds
+	 * (--enable-cassert / meson -Dcassert=true), like the atexit cleanup in
+	 * main.c: drop the first lookup so its callback never
 	 * fires, reproducing the "hung in-process resolver" that leaves a request
-	 * pending forever (see adns_check_stuck / test/test_dns_stuck.py). Active
-	 * only when the PGB_TEST_HANG_ONCE environment variable is set; a no-op in
-	 * normal operation.  Dropped before active++/new_query, so nothing leaks.
+	 * pending forever (see adns_check_stuck / test/test_dns_stuck.py). Armed by
+	 * the PGB_TEST_HANG_ONCE environment variable; a no-op otherwise.  Dropped
+	 * before active++/new_query, so nothing leaks.
 	 */
 	if (getenv("PGB_TEST_HANG_ONCE")) {
 		static bool hung_once = false;
@@ -931,6 +936,7 @@ static void launch_request(struct DNSRequest *req)
 			return;
 		}
 	}
+#endif
 
 	req->ctx->active++;
 	q = new_query(req);
@@ -1407,13 +1413,16 @@ static void adns_check_stuck(struct DNSContext *ctx)
 	free(w.stuck);
 }
 
+#ifdef CASSERT
 /*
- * Test-only: once a dropped ("hung") request has recovered via a relaunch,
- * simulate its original query finally answering late, carrying the epoch it was
- * launched for.  The epoch guard in got_result_gai() must discard this stale
- * answer so it cannot clobber the fresh result.  Pair it with an active++ so the
- * discard's active-- balances (a real late query would have taken one when it
- * was launched).  Active only under PGB_TEST_LATE_STALE.
+ * Test-only (compiled only in cassert builds, --enable-cassert /
+ * -Dcassert=true): once a dropped ("hung")
+ * request has recovered via a relaunch, simulate its original query finally
+ * answering late, carrying the epoch it was launched for.  The epoch guard in
+ * got_result_gai() must discard this stale answer so it cannot clobber the fresh
+ * result.  Pair it with an active++ so the discard's active-- balances (a real
+ * late query would have taken one when it was launched).  Armed by
+ * PGB_TEST_LATE_STALE.
  */
 static void test_late_stale(void)
 {
@@ -1430,10 +1439,13 @@ static void test_late_stale(void)
 	req->ctx->active++;
 	got_result_gai(0, NULL, &q);
 }
+#endif
 
 void adns_per_loop(struct DNSContext *ctx)
 {
 	impl_per_loop(ctx);
 	adns_check_stuck(ctx);
+#ifdef CASSERT
 	test_late_stale();
+#endif
 }

--- a/src/dnslookup.c
+++ b/src/dnslookup.c
@@ -919,13 +919,13 @@ static void launch_request(struct DNSRequest *req)
 	/*
 	 * Test-only fault injection, compiled only in cassert builds
 	 * (--enable-cassert / meson -Dcassert=true), like the atexit cleanup in
-	 * main.c: drop the first lookup so its callback never
-	 * fires, reproducing the "hung in-process resolver" that leaves a request
-	 * pending forever (see adns_check_stuck / test/test_dns_stuck.py). Armed by
-	 * the PGB_TEST_HANG_ONCE environment variable; a no-op otherwise.  Dropped
-	 * before active++/new_query, so nothing leaks.
+	 * main.c: drop the first lookup so its callback never fires, reproducing the
+	 * "hung in-process resolver" that leaves a request pending forever (see
+	 * adns_check_stuck / test/test_dns_stuck.py). Armed at startup from
+	 * PGB_TEST_DNS_FAULT (see main.c); a no-op otherwise.  Dropped before
+	 * active++/new_query, so nothing leaks.
 	 */
-	if (getenv("PGB_TEST_HANG_ONCE")) {
+	if (test_dns_hang) {
 		static bool hung_once = false;
 		if (!hung_once) {
 			hung_once = true;
@@ -1416,20 +1416,19 @@ static void adns_check_stuck(struct DNSContext *ctx)
 #ifdef CASSERT
 /*
  * Test-only (compiled only in cassert builds, --enable-cassert /
- * -Dcassert=true): once a dropped ("hung")
- * request has recovered via a relaunch, simulate its original query finally
- * answering late, carrying the epoch it was launched for.  The epoch guard in
- * got_result_gai() must discard this stale answer so it cannot clobber the fresh
- * result.  Pair it with an active++ so the discard's active-- balances (a real
- * late query would have taken one when it was launched).  Armed by
- * PGB_TEST_LATE_STALE.
+ * -Dcassert=true): once a dropped ("hung") request has recovered via a relaunch,
+ * simulate its original query finally answering late, carrying the epoch it was
+ * launched for.  The epoch guard in got_result_gai() must discard this stale
+ * answer so it cannot clobber the fresh result.  Pair it with an active++ so the
+ * discard's active-- balances (a real late query would have taken one when it
+ * was launched).  Armed at startup from PGB_TEST_DNS_FAULT (see main.c).
  */
 static void test_late_stale(void)
 {
 	struct DNSRequest *req = test_hung_req;
 	struct DNSQuery q;
 
-	if (!req || !req->done || !getenv("PGB_TEST_LATE_STALE"))
+	if (!req || !req->done || !test_dns_late_stale)
 		return;
 	test_hung_req = NULL;
 

--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,17 @@ struct event_base *pgb_event_base;
 /* async dns handler */
 struct DNSContext *adns;
 
+#ifdef CASSERT
+/*
+ * Test-only DNS fault-injection flags (cassert builds only). Not configuration:
+ * armed once at startup from the PGB_TEST_DNS_FAULT environment variable (see
+ * main()) and read by the hooks in dnslookup.c, so nothing test-related touches
+ * the config surface or the resolve hot path.
+ */
+int test_dns_hang;
+int test_dns_late_stale;
+#endif
+
 struct HBA *parsed_hba;
 struct Ident *parsed_ident;
 
@@ -1046,6 +1057,20 @@ int main(int argc, char *argv[])
 	 * make use of things that will be cleaned up.
 	 */
 	atexit(cleanup);
+
+	/*
+	 * Arm the test-only DNS fault-injection hooks once, here at startup, from
+	 * PGB_TEST_DNS_FAULT (a comma-separated list, e.g. "hang" or
+	 * "hang,late-stale"). Reading it here keeps getenv() off the resolve path;
+	 * the hooks in dnslookup.c only test the cached flags. See test_dns_stuck.py.
+	 */
+	{
+		const char *fault = getenv("PGB_TEST_DNS_FAULT");
+		if (fault) {
+			test_dns_hang = strstr(fault, "hang") != NULL;
+			test_dns_late_stale = strstr(fault, "late-stale") != NULL;
+		}
+	}
 #endif
 
 	init_objects();

--- a/src/main.c
+++ b/src/main.c
@@ -1009,6 +1009,9 @@ int main(int argc, char *argv[])
 #ifdef USE_SYSTEMD
 			printf("systemd: yes\n");
 #endif
+#ifdef CASSERT
+			printf("cassert: yes\n");
+#endif
 			return 0;
 		case 'd':
 			cf_daemon = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,7 @@ int cf_server_round_robin;
 int cf_disable_pqexec;
 usec_t cf_dns_max_ttl;
 usec_t cf_dns_nxdomain_ttl;
+usec_t cf_dns_resolve_timeout;
 usec_t cf_dns_zone_check_period;
 char *cf_resolv_conf;
 unsigned int cf_max_packet_size;
@@ -285,6 +286,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("disable_pqexec", CF_INT, cf_disable_pqexec, CF_NO_RELOAD, "0"),
 	CF_ABS("dns_max_ttl", CF_TIME_USEC, cf_dns_max_ttl, 0, "15"),
 	CF_ABS("dns_nxdomain_ttl", CF_TIME_USEC, cf_dns_nxdomain_ttl, 0, "15"),
+	CF_ABS("dns_resolve_timeout", CF_TIME_USEC, cf_dns_resolve_timeout, 0, "0"),
 	CF_ABS("dns_zone_check_period", CF_TIME_USEC, cf_dns_zone_check_period, 0, "0"),
 	CF_ABS("idle_transaction_timeout", CF_TIME_USEC, cf_idle_transaction_timeout, 0, "0"),
 	CF_ABS("ignore_startup_parameters", CF_STR, cf_ignore_startup_params, 0, ""),

--- a/src/main.c
+++ b/src/main.c
@@ -907,8 +907,6 @@ static void xfree(char **ptr_p)
 _UNUSED
 static void cleanup(void)
 {
-	adns_free_context(adns);
-	adns = NULL;
 	hba_free(parsed_hba);
 	parsed_hba = NULL;
 	ident_free(parsed_ident);
@@ -916,6 +914,14 @@ static void cleanup(void)
 
 	admin_cleanup();
 	objects_cleanup();
+
+	/*
+	 * Free the DNS context only after objects_cleanup(): disconnecting a server
+	 * that is still resolving calls adns_cancel() on its DNS token, which must
+	 * still be valid here (adns_free_context() frees every request and token).
+	 */
+	adns_free_context(adns);
+	adns = NULL;
 	sbuf_cleanup();
 
 	event_base_free(pgb_event_base);

--- a/test/test_dns_stuck.py
+++ b/test/test_dns_stuck.py
@@ -4,7 +4,7 @@ import time
 import psycopg
 import pytest
 
-from .utils import Bouncer
+from .utils import CASSERT, Bouncer
 
 # PgBouncer relaunches a DNS request only once it is ->done (see
 # src/dnslookup.c). If the in-process resolver never delivers a result for a
@@ -14,7 +14,14 @@ from .utils import Bouncer
 #
 # The PGB_TEST_HANG_ONCE environment variable is a test-only hook (see
 # launch_request() in src/dnslookup.c) that drops the first lookup so its
-# callback never fires, reproducing the hang deterministically.
+# callback never fires, reproducing the hang deterministically. That hook, like
+# the atexit cleanup in main.c, is compiled only in cassert builds
+# (--enable-cassert / meson -Dcassert=true), so skip this module when it is
+# absent (e.g. release, macOS/Windows CI).
+pytestmark = pytest.mark.skipif(
+    not CASSERT,
+    reason="DNS fault-injection hooks require a --enable-cassert build",
+)
 
 DNS_DB = "dns_hang_db"
 

--- a/test/test_dns_stuck.py
+++ b/test/test_dns_stuck.py
@@ -1,0 +1,125 @@
+import asyncio
+import time
+
+import psycopg
+import pytest
+
+from .utils import Bouncer
+
+# PgBouncer relaunches a DNS request only once it is ->done (see
+# src/dnslookup.c). If the in-process resolver never delivers a result for a
+# request -- a hung resolution -- the request stays pending forever and the
+# hostname becomes permanently unresolvable, cleared only by a restart.
+# dns_resolve_timeout makes adns_per_loop() relaunch such a request.
+#
+# The PGB_TEST_HANG_ONCE environment variable is a test-only hook (see
+# launch_request() in src/dnslookup.c) that drops the first lookup so its
+# callback never fires, reproducing the hang deterministically.
+
+DNS_DB = "dns_hang_db"
+
+
+async def _start_hang_bouncer(pg, tmp_path, monkeypatch, dns_resolve_timeout):
+    monkeypatch.setenv("PGB_TEST_HANG_ONCE", "1")
+    bouncer = Bouncer(pg, tmp_path / "dns_hang")
+    # The base ini ends in the [pgbouncer] section, so these settings continue
+    # it; the [databases] section is added last (re-opening [pgbouncer] after a
+    # [databases] section would drop the earlier [pgbouncer] settings).
+    bouncer.write_ini(
+        f"dns_resolve_timeout = {dns_resolve_timeout}\n"
+        "query_wait_timeout = 4\n"
+        "\n"
+        "[databases]\n"
+        # host is a name (not an IP), so the lookup goes through the in-process
+        # resolver; it resolves to the test Postgres on localhost.
+        f"{DNS_DB} = host=localhost port={pg.port} dbname=p0 user=bouncer\n"
+    )
+    await bouncer.start()
+    return bouncer
+
+
+async def test_hung_dns_lookup_without_resolve_timeout_never_recovers(
+    pg, tmp_path, monkeypatch
+):
+    """Bug reproduction: with dns_resolve_timeout disabled (the default) a hung
+    lookup is never relaunched, so the database stays permanently unresolvable."""
+    bouncer = await _start_hang_bouncer(
+        pg, tmp_path, monkeypatch, dns_resolve_timeout=0
+    )
+    try:
+        # Every attempt fails: the lookup is pending forever and never re-issued.
+        for _ in range(3):
+            with pytest.raises(psycopg.OperationalError):
+                bouncer.test(dbname=DNS_DB)
+
+        log = bouncer.log_path.read_text()
+        assert "simulate a hung resolution" in log  # the injected hang fired
+        assert "relaunching" not in log  # and was never relaunched
+    finally:
+        await bouncer.cleanup()
+
+
+async def test_hung_dns_lookup_recovers_with_resolve_timeout(pg, tmp_path, monkeypatch):
+    """Fix: with dns_resolve_timeout set, the hung lookup is relaunched and the
+    database becomes resolvable again without restarting PgBouncer."""
+    bouncer = await _start_hang_bouncer(
+        pg, tmp_path, monkeypatch, dns_resolve_timeout=1
+    )
+    try:
+        deadline = time.monotonic() + 15
+        while True:
+            try:
+                bouncer.test(dbname=DNS_DB)
+                break  # recovered
+            except psycopg.OperationalError:
+                if time.monotonic() > deadline:
+                    raise
+                await asyncio.sleep(0.5)
+
+        log = bouncer.log_path.read_text()
+        assert "simulate a hung resolution" in log
+        assert "relaunching" in log
+    finally:
+        await bouncer.cleanup()
+
+
+async def test_late_stale_callback_does_not_clobber_recovered_result(
+    pg, tmp_path, monkeypatch
+):
+    """After a relaunch recovers the hostname, the original ("hung") query's late
+    answer must be discarded (epoch guard in got_result_gai) so it cannot clobber
+    the fresh result. PGB_TEST_LATE_STALE injects that late callback once the
+    request has recovered; the database must keep resolving afterward."""
+    monkeypatch.setenv("PGB_TEST_LATE_STALE", "1")
+    bouncer = await _start_hang_bouncer(
+        pg, tmp_path, monkeypatch, dns_resolve_timeout=1
+    )
+    try:
+        # Wait for the relaunch to recover the hostname.
+        deadline = time.monotonic() + 15
+        while True:
+            try:
+                bouncer.test(dbname=DNS_DB)
+                break
+            except psycopg.OperationalError:
+                if time.monotonic() > deadline:
+                    raise
+                await asyncio.sleep(0.5)
+
+        # The late stale callback fires on a following loop iteration.
+        deadline = time.monotonic() + 5
+        while "delivering late stale callback" not in bouncer.log_path.read_text():
+            if time.monotonic() > deadline:
+                raise AssertionError("late stale callback was not injected")
+            await asyncio.sleep(0.25)
+
+        # The fresh result survives: the database keeps resolving, and the stale
+        # answer was discarded rather than processed as a lookup failure.
+        for _ in range(3):
+            bouncer.test(dbname=DNS_DB)
+        # Without the guard the stale answer (result=0, no addrinfo) would be
+        # processed as a failed lookup of the host; the guard discards it.
+        log = bouncer.log_path.read_text()
+        assert "DNS lookup failed: localhost" not in log
+    finally:
+        await bouncer.cleanup()

--- a/test/test_dns_stuck.py
+++ b/test/test_dns_stuck.py
@@ -12,12 +12,12 @@ from .utils import CASSERT, Bouncer
 # hostname becomes permanently unresolvable, cleared only by a restart.
 # dns_resolve_timeout makes adns_per_loop() relaunch such a request.
 #
-# The PGB_TEST_HANG_ONCE environment variable is a test-only hook (see
-# launch_request() in src/dnslookup.c) that drops the first lookup so its
-# callback never fires, reproducing the hang deterministically. That hook, like
-# the atexit cleanup in main.c, is compiled only in cassert builds
-# (--enable-cassert / meson -Dcassert=true), so skip this module when it is
-# absent (e.g. release, macOS/Windows CI).
+# The PGB_TEST_DNS_FAULT environment variable arms a test-only hook (see
+# launch_request() in src/dnslookup.c) that drops the first lookup so its callback
+# never fires, reproducing the hang deterministically. That hook, like the atexit
+# cleanup in main.c, is compiled only in cassert builds (--enable-cassert / meson
+# -Dcassert=true), so skip this module when it is absent (e.g. release,
+# macOS/Windows CI).
 pytestmark = pytest.mark.skipif(
     not CASSERT,
     reason="DNS fault-injection hooks require a --enable-cassert build",
@@ -26,8 +26,16 @@ pytestmark = pytest.mark.skipif(
 DNS_DB = "dns_hang_db"
 
 
-async def _start_hang_bouncer(pg, tmp_path, monkeypatch, dns_resolve_timeout):
-    monkeypatch.setenv("PGB_TEST_HANG_ONCE", "1")
+async def _start_hang_bouncer(
+    pg, tmp_path, monkeypatch, dns_resolve_timeout, late_stale=False
+):
+    # Arm the cassert-only fault-injection hooks via PGB_TEST_DNS_FAULT, which
+    # PgBouncer reads once at startup (see main.c). Each test starts its own
+    # PgBouncer process, so this is scoped to the instance and never affects
+    # other tests.
+    monkeypatch.setenv(
+        "PGB_TEST_DNS_FAULT", "hang,late-stale" if late_stale else "hang"
+    )
     bouncer = Bouncer(pg, tmp_path / "dns_hang")
     # The base ini ends in the [pgbouncer] section, so these settings continue
     # it; the [databases] section is added last (re-opening [pgbouncer] after a
@@ -95,11 +103,10 @@ async def test_late_stale_callback_does_not_clobber_recovered_result(
 ):
     """After a relaunch recovers the hostname, the original ("hung") query's late
     answer must be discarded (epoch guard in got_result_gai) so it cannot clobber
-    the fresh result. PGB_TEST_LATE_STALE injects that late callback once the
+    the fresh result. The late-stale fault injects that late callback once the
     request has recovered; the database must keep resolving afterward."""
-    monkeypatch.setenv("PGB_TEST_LATE_STALE", "1")
     bouncer = await _start_hang_bouncer(
-        pg, tmp_path, monkeypatch, dns_resolve_timeout=1
+        pg, tmp_path, monkeypatch, dns_resolve_timeout=1, late_stale=True
     )
     try:
         # Wait for the relaunch to recover the hostname.

--- a/test/utils.py
+++ b/test/utils.py
@@ -236,6 +236,18 @@ TLS_SUPPORT = get_tls_support()
 DIRECT_TLS_SUPPORT = TLS_SUPPORT and PG_MAJOR_VERSION >= 17
 
 
+def get_cassert():
+    """Detect a cassert build (--enable-cassert / meson -Dcassert=true).
+
+    Test-only fault-injection hooks (e.g. those used by test_dns_stuck.py) are
+    compiled only in cassert builds, so `pgbouncer --version` reports it there.
+    """
+    return "cassert: yes" in capture([BOUNCER_EXE, "--version"], silent=True)
+
+
+CASSERT = get_cassert()
+
+
 # this is out of ephemeral port range for many systems hence
 # it is a lower change that it will conflict with "in-use" ports
 PORT_LOWER_BOUND = 10200


### PR DESCRIPTION
Fixes #1583

## Problem

PgBouncer re-issues a hostname lookup only once the request is `->done`: `adns_resolve()` relaunches in its `req->done` branch, and `zone_requeue()` skips requests that are not `->done`. So if the in-process resolver never delivers a result for a request — a hung resolution — the request stays pending forever, and every later resolution of that name attaches to the stuck request without issuing a new query. The database hostname then becomes permanently unresolvable (`SHOW DNS_HOSTS` shows it with no addresses, its servers stay at `(bad-af)`, clients get `server DNS lookup failed` / `server_login_retry`) even though a fresh resolver on the same host resolves the name — and only a restart clears it. There is no timeout on a pending resolution anywhere.

We hit this in production with the c-ares backend (PgBouncer 1.25.2, c-ares 1.34.6): reader pods stuck for 30+ days, cleared only by a pod restart, while `getent`, `dig`, a fresh c-ares channel, and a direct TCP connection to the DB all succeeded from the same pod. The upstream trigger is a c-ares `getaddrinfo` hang (the resolver returning no callback); this PR does not fix that c-ares race, but it removes PgBouncer's part of the failure — never retrying the stuck request — so the pooler recovers on its own.

Related upstream reports of "the in-process resolver never recovers": #383, #332, and the `RESET_DNS` request #882.

## Change

The first commit is a preparatory bug fix: `cleanup()` freed the DNS context (`adns_free_context()`, which frees every DNS token) *before* `objects_cleanup()` disconnected servers, so a server still resolving at exit had its DNS token freed and then cancelled (`adns_cancel()` → `list_del()` on freed memory) — a latent use-after-free reachable only in `--enable-cassert` builds (where `cleanup()` runs), which the new test surfaces under valgrind. It frees the DNS context after `objects_cleanup()`.

The main change adds a `dns_resolve_timeout` config option (default `0.0`, disabled). When set, `adns_per_loop()` relaunches any request that has been outstanding longer than the timeout, so a hung resolution recovers without a restart.

- `include/bouncer.h`, `src/main.c`: the new `CF_TIME_USEC` option.
- `src/dnslookup.c`:
  - `struct DNSRequest` gains `launch_time`, set by a new `launch_request()` helper (replacing the `ctx->active++; impl_launch_query()` pairs).
  - `adns_check_stuck()` walks the request tree once per second and relaunches stuck requests, collecting them into a dynamically-grown array first so the tree is not mutated mid-walk and no request is starved.
  - A relaunched request can briefly have several queries in flight, and a new resolution episode can start while an old query is still outstanding. `struct DNSRequest` gains an `epoch`/`answered_epoch` pair — a *new episode* (`start_resolution()`, from `adns_resolve()` and `zone_requeue()`) bumps `epoch`, a stuck relaunch does not — and each query is issued with a small per-query token (`struct DNSQuery`) stamped with the epoch it was launched for, threaded through all three backends as the callback argument. `got_result_gai()` accepts only an answer whose epoch is newer than `answered_epoch` and discards any superseded answer (a same-episode duplicate, or a straggler from an earlier episode), dropping its `ctx->active` count, so a late answer cannot clobber the fresh result or mark good addresses dirty.
- `doc/config.md`, `etc/pgbouncer.ini`: document the option.

The fix is always compiled and a no-op while `dns_resolve_timeout=0`, so it changes nothing by default. It builds warning-clean on all three DNS backends (c-ares, evdns, getaddrinfo_a).

## Test

`test/test_dns_stuck.py` (runs in the standard pytest suite, three cases pass):

- without `dns_resolve_timeout` (default) a hung lookup is never relaunched and the database stays unresolvable;
- with it set, the lookup is relaunched and the database resolves again without restarting PgBouncer;
- after recovery, a late answer from the original (superseded) query is discarded and does not clobber the fresh result — the database keeps resolving.

A normal DNS server can't produce a never-completing resolution (c-ares always eventually times out), so the tests reproduce the hang deterministically via minimal fault-injection hooks in `src/dnslookup.c`. They are compiled only in cassert builds (`#ifdef CASSERT`, like `main.c`'s `atexit` cleanup), so production binaries contain no test code, and are armed by the `PGB_TEST_DNS_FAULT` environment variable read once at startup in `main()` — following the standard debug-build fault-injection idiom (curl's `DEBUGBUILD` env vars, etcd's failpoints) rather than adding anything to the config surface. There is no `getenv()` on the resolve path. A cassert build advertises itself via `pgbouncer --version`, and the test suite skips when the hooks are absent.

## Notes / open questions for maintainers

- Should the default be a protective non-zero value rather than disabled?
- The per-query epoch token means a late answer is accepted only if newer than what was already delivered, so a straggler from any earlier episode is discarded rather than cancelled — no per-query cancel API is required (the legacy `ares_gethostbyname()` path doesn't expose one). The one remaining corner is a *synchronous* launch failure (only the `getaddrinfo_a` path has one) that delivers a failure without advancing `answered_epoch`; a real answer from a concurrent same-episode query is then still accepted, which is the desired recovery, and any straggler is corrected on the next refresh. Happy to adjust if a maintainer wants that path to advance `answered_epoch` too.
