### PR TITLE
feat: add support for upstream TLSDirect

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -1003,6 +1003,23 @@ verify-full
     according to `server_tls_ca_file`.  Server host name must match
     certificate information.
 
+### server_tls_direct
+
+If set to 1, PgBouncer initiates a TLS handshake immediately upon TCP connect,
+without sending the PostgreSQL `SSLRequest` message first.  Use this when
+connecting to PostgreSQL 17+ servers or proxies that expect a direct TLS
+connection rather than the standard SSL-negotiation protocol (e.g. a
+TLS-terminating load balancer or stunnel).
+
+Certificate verification behaviour is controlled by `server_tls_sslmode` as
+normal: `require`, `verify-ca`, and `verify-full` all work correctly with
+`server_tls_direct = 1`.
+
+Setting `server_tls_direct = 1` together with `server_tls_sslmode = disable`
+is an error.
+
+Default: 0
+
 ### server_tls_ca_file
 
 Root certificate file to validate PostgreSQL server certificates.

--- a/etc/pgbouncer.ini
+++ b/etc/pgbouncer.ini
@@ -110,6 +110,9 @@ listen_port = 6432
 ;; disable, allow, prefer, require, verify-ca, verify-full
 ;server_tls_sslmode = prefer
 
+;; If set to 1, initiates a TLS handshake immediately upon TCP connect
+;server_tls_direct = 1
+
 ;; Path to that contains trusted CA certs
 ;server_tls_ca_file = <system default>
 

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -923,6 +923,7 @@ extern char *cf_client_tls_dheparams;
 extern char *cf_client_tls_ecdhecurve;
 
 extern int cf_server_tls_sslmode;
+extern int cf_server_tls_direct;
 extern char *cf_server_tls_protocols;
 extern char *cf_server_tls_ca_file;
 extern char *cf_server_tls_cert_file;

--- a/include/sbuf.h
+++ b/include/sbuf.h
@@ -115,10 +115,17 @@ extern int client_accept_sslmode;
  * Same as client_accept_sslmode, but for server connections.
  */
 extern int server_connect_sslmode;
+/*
+ * Mirrors cf_server_tls_direct after a successful sbuf_tls_setup().
+ * When non-zero, server connections skip the SSLRequest negotiation and
+ * initiate a direct TLS handshake immediately after TCP connect.
+ */
+extern int server_connect_tls_direct;
 
 bool sbuf_tls_setup(void);
 bool sbuf_tls_accept(SBuf *sbuf)  _MUSTCHECK;
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
+bool sbuf_tls_connect_direct(SBuf *sbuf, const char *hostname)  _MUSTCHECK;
 
 bool sbuf_pause(SBuf *sbuf) _MUSTCHECK;
 void sbuf_continue(SBuf *sbuf);

--- a/lib/usual/tls/tls_client.c
+++ b/lib/usual/tls/tls_client.c
@@ -183,6 +183,24 @@ int tls_connect_fds(struct tls *ctx, int fd_read, int fd_write,
 		goto err;
 	}
 
+	/*
+	 * Advertise the "postgresql" ALPN protocol.  This is required for
+	 * PostgreSQL 17+ direct TLS connections (RFC 7301) and is harmless
+	 * for STARTTLS connections where PostgreSQL ignores ALPN.
+	 * Mirrors PG_ALPN_PROTOCOL_VECTOR in tls_server.c.
+	 */
+	{
+		static const unsigned char alpn_protos[] = {
+			10, 'p', 'o', 's', 't', 'g', 'r', 'e', 's', 'q', 'l'
+		};
+		if (SSL_CTX_set_alpn_protos(ctx->ssl_ctx,
+					    alpn_protos,
+					    sizeof(alpn_protos)) != 0) {
+			tls_set_errorx(ctx, "failed to set ALPN protocols");
+			goto err;
+		}
+	}
+
 	if (tls_configure_ssl(ctx) != 0)
 		goto err;
 	if (tls_configure_keypair(ctx, ctx->ssl_ctx, ctx->config->keypair, 0) != 0)

--- a/src/main.c
+++ b/src/main.c
@@ -195,6 +195,7 @@ char *cf_client_tls_dheparams;
 char *cf_client_tls_ecdhecurve;
 
 int cf_server_tls_sslmode;
+int cf_server_tls_direct;	/* bool: skip SSLRequest, do direct TLS handshake */
 char *cf_server_tls_protocols;
 char *cf_server_tls_ca_file;
 char *cf_server_tls_cert_file;
@@ -333,6 +334,7 @@ static const struct CfKey bouncer_params [] = {
 	CF_ABS("server_tls_ca_file", CF_STR, cf_server_tls_ca_file, 0, ""),
 	CF_ABS("server_tls_cert_file", CF_STR, cf_server_tls_cert_file, 0, ""),
 	CF_ABS("server_tls_ciphers", CF_STR, cf_server_tls_ciphers, 0, "default"),
+	CF_ABS("server_tls_direct", CF_INT, cf_server_tls_direct, 0, "0"),
 	CF_ABS("server_tls_key_file", CF_STR, cf_server_tls_key_file, 0, ""),
 	CF_ABS("server_tls_protocols", CF_STR, cf_server_tls_protocols, 0, "secure"),
 	CF_ABS("server_tls_sslmode", CF_LOOKUP(sslmode_map), cf_server_tls_sslmode, 0, "prefer"),

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1458,9 +1458,15 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)
 			return false;
 	}
 
-	if (cf_server_tls_sslmode != SSLMODE_VERIFY_FULL)
-		hostname = NULL;
-
+	/*
+	 * Always pass the hostname to tls_connect_fds() so it is set as SNI in
+	 * the ClientHello.  SNI is needed for server-side backend routing
+	 * (e.g. cloud VPE endpoints) regardless of whether we verify the
+	 * server's certificate name.  Certificate name verification is already
+	 * controlled independently by tls_config_insecure_noverifyname() in
+	 * sbuf_tls_setup(), so nulling the hostname here only breaks SNI without
+	 * making connections any less strict.
+	 */
 	ctls = tls_client();
 	if (!ctls)
 		return false;

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1072,6 +1072,12 @@ static void sbuf_connect_cb(evutil_socket_t sock, short flags, void *arg)
 			goto failed;
 		if (!sbuf_call_proto(sbuf, SBUF_EV_CONNECT_OK))
 			return;
+		/*
+		 * If the proto handler already registered an event (e.g. a
+		 * direct-TLS handshake callback), don't overwrite it.
+		 */
+		if (sbuf->wait_type != W_NONE)
+			return;
 		if (!sbuf_wait_for_data(sbuf))
 			goto failed;
 		return;
@@ -1145,6 +1151,7 @@ static struct tls_config *client_accept_conf;
 int client_accept_sslmode;
 static struct tls_config *server_connect_conf;
 int server_connect_sslmode;
+int server_connect_tls_direct;
 
 /*
  * TLS setup
@@ -1246,6 +1253,9 @@ static bool tls_change_requires_reconnect(struct tls_config *new_server_connect_
 	if (server_connect_sslmode != cf_server_tls_sslmode) {
 		log_noise("new server_tls_sslmode detected");
 		return true;
+	} else if (server_connect_tls_direct != cf_server_tls_direct) {
+		log_noise("new server_tls_direct detected");
+		return true;
 	} else if (server_connect_conf == NULL) {
 		log_noise("no existing server tls config detected");
 		return true;
@@ -1295,6 +1305,11 @@ bool sbuf_tls_setup(void)
 	err = tls_init();
 	if (err)
 		fatal("tls_init failed");
+
+	if (cf_server_tls_direct && cf_server_tls_sslmode == SSLMODE_DISABLED) {
+		log_error("server_tls_direct requires server_tls_sslmode to not be 'disable'");
+		return false;
+	}
 
 	if (cf_server_tls_sslmode != SSLMODE_DISABLED) {
 		new_server_connect_conf = tls_config_new();
@@ -1360,6 +1375,7 @@ bool sbuf_tls_setup(void)
 	client_accept_sslmode = cf_client_tls_sslmode;
 	server_connect_conf = new_server_connect_conf;
 	server_connect_sslmode = cf_server_tls_sslmode;
+	server_connect_tls_direct = cf_server_tls_direct;
 	return true;
 failed:
 	usual_tls_free(new_client_accept_base);
@@ -1433,8 +1449,14 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)
 	struct tls *ctls;
 	int err;
 
-	if (!sbuf_pause(sbuf))
-		return false;
+	/*
+	 * Pause the current read event if one is registered.  When called from
+	 * the STARTTLS path (handle_sslchar) the socket is in W_RECV.
+	 */
+	if (sbuf->wait_type == W_RECV) {
+		if (!sbuf_pause(sbuf))
+			return false;
+	}
 
 	if (cf_server_tls_sslmode != SSLMODE_VERIFY_FULL)
 		hostname = NULL;
@@ -1461,6 +1483,27 @@ bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)
 
 	sbuf->tls_state = SBUF_TLS_DO_HANDSHAKE;
 	return true;
+}
+
+/*
+ * Set up TLS for a direct-TLS server connection (no SSLRequest round-trip)
+ * and immediately start the handshake.  Called from handle_connect() at
+ * SBUF_EV_CONNECT_OK time, when wait_type is W_NONE.
+ */
+bool sbuf_tls_connect_direct(SBuf *sbuf, const char *hostname)
+{
+	if (!sbuf_tls_connect(sbuf, hostname))
+		return false;
+
+	/*
+	 * Kick the TLS handshake right away.  handle_tls_handshake() will
+	 * either complete synchronously (TLS_WANT_POLLIN / TLS_WANT_POLLOUT
+	 * registers a one-shot callback) or fire SBUF_EV_TLS_READY when done.
+	 * We must NOT call sbuf_continue() here — that would attempt recv()
+	 * before the handshake completes and see EOF from PG.
+	 */
+	sbuf->pkt_action = SBUF_TLS_IN_HANDSHAKE;
+	return handle_tls_handshake(sbuf);
 }
 
 /*
@@ -1602,6 +1645,7 @@ static void sbuf_possible_direct_tls_startup_cb(evutil_socket_t fd, short flags,
 
 int client_accept_sslmode = SSLMODE_DISABLED;
 int server_connect_sslmode = SSLMODE_DISABLED;
+int server_connect_tls_direct;
 
 bool sbuf_tls_setup(void)
 {
@@ -1612,6 +1656,10 @@ bool sbuf_tls_accept(SBuf *sbuf)
 	return false;
 }
 bool sbuf_tls_connect(SBuf *sbuf, const char *hostname)
+{
+	return false;
+}
+bool sbuf_tls_connect_direct(SBuf *sbuf, const char *hostname)
 {
 	return false;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -723,7 +723,15 @@ static bool handle_connect(PgSocket *server)
 		disconnect_server(server, false, "peer server was not necessary anymore, because client cancel connection was already closed");
 	} else {
 		/* proceed with login */
-		if (server_connect_sslmode > SSLMODE_DISABLED && !is_unix) {
+		if (server_connect_tls_direct && !is_unix) {
+			slog_noise(server, "P: direct TLS");
+			/*
+			 * Start TLS handshake immediately — no SSLRequest round-trip.
+			 * On completion SBUF_EV_TLS_READY fires and send_startup_message()
+			 * is called, same as the STARTTLS path.
+			 */
+			res = sbuf_tls_connect_direct(&server->sbuf, server->host);
+		} else if (server_connect_sslmode > SSLMODE_DISABLED && !is_unix) {
 			slog_noise(server, "P: SSL request");
 			res = send_sslreq_packet(server);
 			if (res)

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -513,3 +513,141 @@ def test_system_error_propagation(bouncer_tls, cert_dir):
         # since it is expected.
         except psycopg.errors.ConfigFileError as e:
             assert "RELOAD failed" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# server_tls_direct tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_basic(pg, bouncer_tls, cert_dir):
+    """Bouncer connects to PG using direct TLS (no SSLRequest round-trip)."""
+    root = cert_dir / "TestCA1" / "ca.crt"
+
+    # Enable SSL on PG, allow only SSL connections (reject plain TCP)
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{root}'")
+    pg.ssl_access("all", "trust")
+    pg.nossl_access("all", "reject")
+    pg.reload()
+
+    bouncer_tls.write_ini(f"server_tls_sslmode = require")
+    bouncer_tls.write_ini(f"server_tls_ca_file = {root}")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+    bouncer_tls.admin("reload")
+
+    with bouncer_tls.log_contains(r"SSL established"):
+        bouncer_tls.test()
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_verify_full(pg, bouncer_tls, cert_dir):
+    """Direct TLS works with verify-full — cert validation is orthogonal to transport."""
+    root = cert_dir / "TestCA1" / "ca.crt"
+
+    # Enable SSL on PG, allow only SSL connections (reject plain TCP)
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{root}'")
+    pg.ssl_access("all", "trust")
+    pg.nossl_access("all", "reject")
+    pg.reload()
+
+    bouncer_tls.write_ini(f"server_tls_sslmode = verify-full")
+    bouncer_tls.write_ini(f"server_tls_ca_file = {root}")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+    bouncer_tls.admin("reload")
+
+    with bouncer_tls.log_contains(r"SSL established"):
+        bouncer_tls.test()
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_plain_server_fails(pg, bouncer_tls, cert_dir):
+    """Direct TLS against a plain-TCP server fails — no fallback to unencrypted."""
+    bouncer_tls.write_ini("server_tls_sslmode = require")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+    bouncer_tls.admin("reload")
+
+    # PostgreSQL with ssl=off speaks plain TCP; the direct TLS handshake will fail
+    pg.configure("ssl=off")
+    pg.restart()
+
+    with pytest.raises(psycopg.OperationalError):
+        bouncer_tls.test(connect_timeout=4)
+
+
+def test_server_tls_direct_disabled_sslmode_rejected(bouncer_tls):
+    """server_tls_direct=1 combined with sslmode=disable must be rejected at reload."""
+    bouncer_tls.write_ini("server_tls_sslmode = disable")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+
+    with bouncer_tls.log_contains(
+        r"server_tls_direct requires server_tls_sslmode to not be 'disable'"
+    ):
+        try:
+            bouncer_tls.admin("RELOAD")
+        except psycopg.errors.ConfigFileError:
+            pass
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_reconnect_on_flag_change(bouncer_tls, pg, cert_dir):
+    """Changing server_tls_direct triggers pool reconnect (marks connections dirty)."""
+    root = cert_dir / "TestCA1" / "ca.crt"
+    bouncer_tls.default_db = "pTxnPool"
+
+    # Start with STARTTLS (server_tls_direct=0), SSL required
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{root}'")
+    pg.ssl_access("all", "trust")
+    pg.reload()
+
+    bouncer_tls.write_ini(f"server_tls_sslmode = require")
+    bouncer_tls.write_ini(f"server_tls_ca_file = {root}")
+    bouncer_tls.write_ini("server_tls_direct = 0")
+    bouncer_tls.admin("reload")
+
+    with bouncer_tls.cur() as cur:
+        assert pg.connection_count(dbname="p0") == 1
+        # Switch to direct TLS — should mark the STARTTLS connection as dirty
+        bouncer_tls.write_ini("server_tls_direct = 1")
+
+        with bouncer_tls.log_contains(
+            r"pTxnPool.*database configuration changed|pTxnPool.*obsolete connection"
+        ):
+            bouncer_tls.admin("RELOAD")
+            cur.execute("SELECT 1")
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_alpn_negotiated(pg, bouncer_tls, cert_dir):
+    """ALPN 'postgresql' is negotiated — PG 17 rejects connections without it."""
+    root = cert_dir / "TestCA1" / "ca.crt"
+
+    # Enable SSL on PG, allow only SSL connections (reject plain TCP)
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{root}'")
+    pg.ssl_access("all", "trust")
+    pg.nossl_access("all", "reject")
+    pg.reload()
+
+    bouncer_tls.write_ini(f"server_tls_sslmode = require")
+    bouncer_tls.write_ini(f"server_tls_ca_file = {root}")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+    bouncer_tls.admin("reload")
+
+    # If ALPN negotiation failed PG 17+ would have rejected the connection outright;
+    # a successful query through pg_stat_ssl confirms TLS + ALPN both worked.
+    result = bouncer_tls.sql("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+    assert result and result[0][0] is True

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -651,3 +651,27 @@ def test_server_tls_direct_alpn_negotiated(pg, bouncer_tls, cert_dir):
     # a successful query through pg_stat_ssl confirms TLS + ALPN both worked.
     result = bouncer_tls.sql("SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
     assert result and result[0][0] is True
+
+
+@pytest.mark.skipif(
+    "not DIRECT_TLS_SUPPORT", reason="Direct TLS requires PG 17+ with TLS support"
+)
+def test_server_tls_direct_sni_sent_for_non_verify_full(pg, bouncer_tls, cert_dir):
+    """SNI is sent in the ClientHello even when sslmode is not verify-full."""
+    root = cert_dir / "TestCA1" / "ca.crt"
+
+    pg.configure("ssl=on")
+    pg.configure(f"ssl_ca_file='{root}'")
+    pg.ssl_access("all", "trust")
+    pg.nossl_access("all", "reject")
+    pg.reload()
+
+    bouncer_tls.write_ini("server_tls_sslmode = verify-ca")
+    bouncer_tls.write_ini(f"server_tls_ca_file = {root}")
+    bouncer_tls.write_ini("server_tls_direct = 1")
+    bouncer_tls.admin("reload")
+
+    # A successful query proves the handshake completed — which requires SNI
+    # because the server only accepts hostssl connections.
+    with bouncer_tls.log_contains(r"SSL established"):
+        bouncer_tls.test()


### PR DESCRIPTION
What: attempt in addressing the remaining part of https://github.com/pgbouncer/pgbouncer/issues/1203 as per https://github.com/pgbouncer/pgbouncer/issues/1203#issuecomment-3182650069 and adding support for upstream tlsdirect