### PR TITLE
Add a meson implementation of the zip target

### DIFF
--- a/.github/workflows/pgbouncer-ci.yml
+++ b/.github/workflows/pgbouncer-ci.yml
@@ -431,7 +431,7 @@ jobs:
             "${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-postgresql" \
             "${MINGW_PACKAGE_PREFIX}-python" "${MINGW_PACKAGE_PREFIX}-python-pip" \
             "${MINGW_PACKAGE_PREFIX}-meson" "${MINGW_PACKAGE_PREFIX}-ninja" \
-            "${MINGW_PACKAGE_PREFIX}-pkgconf" zip
+            "${MINGW_PACKAGE_PREFIX}-pkgconf"
           echo "127.0.0.1   localhost" >> /etc/hosts
           pip install .
       - name: Build
@@ -443,14 +443,12 @@ jobs:
       - name: Install
         run: sh ci/run.sh install "$BUILD_SYSTEM"
       - name: Build zip
-        run: |
-          cd install
-          zip -r "../pgbouncer-windows.zip" .
+        run: meson compile -C build zip
       - name: Upload zip
         uses: actions/upload-artifact@v7
         with:
           name: pgbouncer-windows-zip
-          path: pgbouncer-*.zip
+          path: build/pgbouncer-*.zip
           if-no-files-found: error
       - name: Upload build logs
         if: ${{ !cancelled() }}

--- a/Makefile
+++ b/Makefile
@@ -181,13 +181,7 @@ w32zip = $(PACKAGE_TARNAME)-$(PACKAGE_VERSION)-windows-$(host_cpu).zip
 zip: $(w32zip)
 
 $(w32zip): pgbouncer.exe pgbevent.dll etc/pgbouncer.ini etc/userlist.txt README.md COPYRIGHT
-	rm -rf $(basename $@)
-	mkdir $(basename $@)
-	cp $^ $(basename $@)
-	$(STRIP) $(addprefix $(basename $@)/,$(filter %.exe %.dll,$(^F)))
-	zip -MM $@ $(addprefix $(basename $@)/,$(filter %.exe %.dll,$(^F)))
-# NB: zip -l for text files for end-of-line conversion
-	zip -MM -l $@ $(addprefix $(basename $@)/,$(filter-out %.exe %.dll,$(^F)))
+	$(PYTHON) $(srcdir)/win32/make-zip.py --strip='$(STRIP)' -o $@ $^
 
 .PHONY: tags
 tags:

--- a/meson.build
+++ b/meson.build
@@ -627,7 +627,7 @@ pgbouncer = executable('pgbouncer',
 if windows
   pgbevent_res = win.compile_resources('win32/eventmsg.rc',
                                        include_directories: pgbouncer_incdirs)
-  shared_module('pgbevent',
+  pgbevent = shared_module('pgbevent',
     'win32/pgbevent.c',
     pgbevent_res,
     name_prefix: '',
@@ -653,6 +653,32 @@ if pandoc.found()
   subdir('doc')
 else
   message('pandoc not found: man pages will not be built or installed')
+endif
+
+# ----------------------------------------------------------------------
+# Windows binary distribution zip
+# ----------------------------------------------------------------------
+
+if windows
+  # We use required: false here to not fail the entire Windows build
+  # if strip is not found.  But make-zip.py requires --strip, so the
+  # zip target will fail then.
+  strip_prog = find_program('strip', required: false)
+  strip_args = []
+  if strip_prog.found()
+    strip_args = ['--strip', strip_prog.full_path()]
+  else
+    message('strip not found, zip target will not work')
+  endif
+
+  custom_target('zip',
+    output: 'pgbouncer-@0@-windows-@1@.zip'.format(meson.project_version(),
+                                                   host_machine.cpu()),
+    input: [pgbouncer, pgbevent,
+            files('etc/pgbouncer.ini', 'etc/userlist.txt', 'README.md', 'COPYRIGHT')],
+    command: [python, files('win32/make-zip.py'), strip_args, '-o', '@OUTPUT@', '@INPUT@'],
+    build_by_default: false,
+  )
 endif
 
 pkgdocdir = get_option('datadir') / 'doc' / 'pgbouncer'

--- a/win32/make-zip.py
+++ b/win32/make-zip.py
@@ -1,0 +1,93 @@
+"""Build the Windows binary distribution zip.
+
+Usage: make-zip.py --strip PROG -o OUTPUT.zip FILE...
+
+The files are stored flat under a single top-level directory named
+after the archive (minus the .zip suffix).
+
+.exe and .dll inputs are stripped and stored verbatim.  Every other
+input is treated as text and is stored with CRLF line endings, so that
+the packaged configuration examples and documentation open correctly
+in Windows editors.  Note that the state of the files on disk depends
+on git core.autocrlf; we need to handle all variants of that.
+
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+import zipfile
+
+BINARY_SUFFIXES = (".exe", ".dll")
+
+# Any of the three line ending conventions, so the conversion is idempotent.
+EOL_RE = re.compile(rb"\r\n|\r|\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--strip",
+        metavar="PROG",
+        required=True,
+        help="strip program to run on the binaries",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        metavar="OUTPUT.zip",
+        dest="output",
+        required=True,
+        help="archive to write",
+    )
+    parser.add_argument("files", metavar="FILE", nargs="+")
+    args = parser.parse_args()
+
+    if not args.strip:
+        parser.error("--strip needs the name of a strip program")
+    if not args.output.endswith(".zip"):
+        parser.error(f"output file must end in .zip: {args.output}")
+    # The top-level directory inside the archive is named after the archive.
+    prefix = os.path.basename(args.output[: -len(".zip")])
+
+    binaries = [f for f in args.files if f.endswith(BINARY_SUFFIXES)]
+    texts = [f for f in args.files if not f.endswith(BINARY_SUFFIXES)]
+
+    # Keep the temporary directory next to the output file, so that the
+    # final os.replace() stays within one file system.  (On Windows,
+    # renaming across drives fails.)
+    outdir = os.path.dirname(os.path.abspath(args.output))
+    with tempfile.TemporaryDirectory(dir=outdir) as tmpdir:
+        tmpzip = os.path.join(tmpdir, "out.zip")
+        with zipfile.ZipFile(tmpzip, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in binaries:
+                add(zf, prefix, strip(f, args.strip, tmpdir), name=os.path.basename(f))
+            for f in texts:
+                add(zf, prefix, f, text=True)
+        os.replace(tmpzip, args.output)
+
+
+def strip(path, strip_prog, tmpdir):
+    """Return the path of a stripped copy of path, made in tmpdir."""
+    stripped = os.path.join(tmpdir, os.path.basename(path))
+    subprocess.run([strip_prog, "-o", stripped, path], check=True)
+    return stripped
+
+
+def add(zf, prefix, path, name=None, text=False):
+    """Store path in the archive as prefix/name, converting text to CRLF."""
+    info = zipfile.ZipInfo.from_file(path, f"{prefix}/{name or os.path.basename(path)}")
+    info.compress_type = zipfile.ZIP_DEFLATED
+    # Bit 0 of the internal attributes marks an entry as text.
+    info.internal_attr = 1 if text else 0
+    with open(path, "rb") as f:
+        data = f.read()
+    if text:
+        data = EOL_RE.sub(b"\r\n", data)
+    zf.writestr(info, data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The meson build system had no equivalent of the "make zip" target, so the Windows CI job just zipped up the whole install tree, but that resulted in different contents.

Move the archive assembly into win32/make-zip.py and run it from both the Makefile rule and a new meson "zip" target, so the two build systems produce the same archive.

(The cpu part of the zip archive created will be the same between make and meson for x86_64 and aarch64 but will differ for i686 vs. x86. But the latter is obsolete, so we don't need to worry about it too much.)

The end-of-line conversion is now a normalization of whatever the working tree holds rather than the plain LF -> CRLF substitution that "zip -l" does.  That substitution assumed the checkout used Unix line endings, which is not something we control: under core.autocrlf the files are already CRLF on disk, and "zip -l" would turn those into CR CR LF.  Normalizing means the archive is the same either way, and developers on Windows can still check the tree out with the line endings that are native for them.

---

Note that this is kind of a "must fix" for the next release. After the meson conversion, the zip tarballs for Windows are inconsistent with what previous releases produced. And even if we switched back to "make zip" for this, the line endings would come out incorrectly, because (apparently) GitHub Actions has a different core.autocrlf setting than what Cirrus used to have.