### PR TITLE
Begin the wait timer when the queueing begins, not when the query begins

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -476,8 +476,12 @@ sv_login
 maxwait
 :   How long the first (oldest) client in the queue has waited, in seconds.
     If this starts increasing, then the current pool of servers does
-    not handle requests quickly enough.  The reason may be either an overloaded
-    server or just too small of a **pool_size** setting.
+    not handle requests quickly enough.  The reason may be an overloaded
+    server, just too small of a **pool_size** setting, or the pool having no
+    server connection yet at all: a slow connect, a slow TLS handshake,
+    **PAUSE**, or a server that is down.  A pool that is only warming up
+    therefore reports a small nonzero value while its first client waits for
+    that first connection.
 
 maxwait_us
 :   Microsecond part of the maximum waiting time.

--- a/include/objects.h
+++ b/include/objects.h
@@ -96,6 +96,8 @@ bool use_server_socket(int fd, PgAddr *addr, const char *dbname, const char *use
 
 void activate_client(PgSocket *client);
 
+usec_t socket_wait_time(PgSocket *sk);
+
 void change_client_state(PgSocket *client, SocketState newstate);
 void change_server_state(PgSocket *server, SocketState newstate);
 

--- a/src/admin.c
+++ b/src/admin.c
@@ -677,8 +677,7 @@ static void socket_row(PktBuf *buf, PgSocket *sk, const char *state, bool debug)
 	char infobuf[96] = "";
 	VarCache *v = &sk->vars;
 	const struct PStr *application_name = v->var_list[VAppName];
-	usec_t now = get_cached_time();
-	usec_t wait_time = sk->query_start ? now - sk->query_start : 0;
+	usec_t wait_time = socket_wait_time(sk);
 	char *replication;
 
 	if (io) {
@@ -899,7 +898,6 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 	PgPool *pool;
 	PktBuf *buf;
 	PgSocket *waiter;
-	usec_t now = get_cached_time();
 	usec_t max_wait;
 	struct CfValue cv;
 	struct CfValue load_balance_hosts_lookup;
@@ -930,7 +928,7 @@ static bool admin_show_pools(PgSocket *admin, const char *arg)
 	statlist_for_each(item, &pool_list) {
 		pool = container_of(item, PgPool, head);
 		waiter = first_socket(&pool->waiting_client_list);
-		max_wait = (waiter && waiter->query_start) ? now - waiter->query_start : 0;
+		max_wait = waiter ? socket_wait_time(waiter) : 0;
 		pool_mode = probably_wrong_pool_pool_mode(pool);
 
 		load_balance_hosts_str = NULL;

--- a/src/objects.c
+++ b/src/objects.c
@@ -843,6 +843,45 @@ void activate_client(PgSocket *client)
 }
 
 /*
+ * What SHOW POOLS.maxwait and SHOW CLIENTS/SOCKETS.wait report for a socket.
+ *
+ * The first branch is not a wait: a client with a query in flight counts from
+ * query_start, which is the query's age, and is also the clock query_timeout
+ * acts on.  It is kept because that is what these columns have always shown
+ * for such a client.  For a client that is really queued it makes no
+ * difference which of the two you pick: handle_client_work() sets query_start
+ * and change_client_state() sets wait_start from the same cached clock read of
+ * one event loop iteration, so they are equal, and maxwait therefore agrees
+ * with the wait_start that SHOW STATS.total_wait_time and query_wait_notify
+ * count from.
+ *
+ * The remaining branches are the wait proper.  A client queued before it ever
+ * issued a query - during login, while its pool still has no server connection
+ * - has no query_start, so it counts from wait_start, the moment
+ * change_client_state() put it on the waiting list.  A queued cancel request
+ * has neither, so it counts from request_time, which is what
+ * cancel_wait_timeout uses.  A socket that is not waiting, including every
+ * server socket, has waited no time.
+ */
+usec_t socket_wait_time(PgSocket *sk)
+{
+	usec_t now = get_cached_time();
+
+	if (sk->query_start)
+		return now - sk->query_start;
+
+	switch (sk->state) {
+	case CL_WAITING:
+	case CL_WAITING_LOGIN:
+		return now - sk->wait_start;
+	case CL_WAITING_CANCEL:
+		return now - sk->request_time;
+	default:
+		return 0;
+	}
+}
+
+/*
  * Don't let clients queue at all if there is no working server connection.
  *
  * It must still allow following cases:

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -1,3 +1,6 @@
+import asyncio
+import socket
+import struct
 import threading
 import time
 
@@ -5,7 +8,7 @@ import psycopg
 import pytest
 from psycopg.rows import dict_row
 
-from .utils import Bouncer, capture, run
+from .utils import Bouncer, PortLock, capture, run
 
 
 def test_reload_error(bouncer):
@@ -278,6 +281,117 @@ def test_client_states(bouncer):
     # Cleanup
     cur_1.close()
     conn_1.close()
+
+
+async def await_show_rows(bouncer, command, count, timeout=20, **match):
+    """
+    Poll an admin SHOW command until `count` of its rows match `match`.
+
+    Returns the matching rows. Unlike utils.wait_until() this yields to the
+    event loop, so it can be used to wait for connections opened with atest().
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        rows = [
+            row
+            for row in bouncer.admin(command, row_factory=dict_row)
+            if all(row[column] == value for column, value in match.items())
+        ]
+        if len(rows) == count:
+            return rows
+        assert time.monotonic() < deadline, f"{command}: {rows}"
+        await asyncio.sleep(0.1)
+
+
+async def test_maxwait_for_clients_queued_before_their_first_query(bouncer):
+    """
+    Test that `maxwait` and `wait` count a client that was queued before it
+    ever sent a query.
+
+    A client that arrives while its pool has no server connection is parked
+    during login, so it never sets query_start. `query_wait_timeout` counts
+    such a client down from when it was queued, and `maxwait`/`wait` have to
+    report that same wait instead of 0, or a stuck pool looks idle.
+    """
+    # Nothing has used this pool yet, so it has no welcome message to hand a
+    # new client, and while the pooler is paused it will not open a server
+    # connection to get one. Clients that arrive now queue up during login.
+    bouncer.admin("PAUSE")
+    start = time.monotonic()
+    # These clients stay queued for as long as this test watches them, which is
+    # well past libpq's default connect_timeout of 3s that utils.py sets.
+    queued = [bouncer.atest(dbname="p0", connect_timeout=30) for _ in range(2)]
+
+    try:
+        await await_show_rows(
+            bouncer, "SHOW CLIENTS", 2, database="p0", state="waiting"
+        )
+        await asyncio.sleep(2)
+
+        [pool] = await await_show_rows(
+            bouncer, "SHOW POOLS", 1, database="p0", cl_waiting=2
+        )
+        clients = await await_show_rows(
+            bouncer, "SHOW CLIENTS", 2, database="p0", state="waiting"
+        )
+        elapsed = time.monotonic() - start
+
+        maxwait = pool["maxwait"] + pool["maxwait_us"] / 1_000_000
+        assert 1 <= maxwait <= elapsed + 1
+
+        for client in clients:
+            wait = client["wait"] + client["wait_us"] / 1_000_000
+            assert 1 <= wait <= elapsed + 1
+    finally:
+        bouncer.admin("RESUME")
+        await asyncio.gather(*queued, return_exceptions=True)
+
+
+async def test_wait_for_a_queued_cancel_request(bouncer):
+    """
+    Test that `wait` counts a cancel request that is queued for a connection.
+
+    A cancel request sets neither query_start nor wait_start, so it needs its
+    own clock: `cancel_wait_timeout` counts it down from its request_time, and
+    `wait` has to report that same wait instead of 0.
+    """
+    # A cancel request whose key names another peer is queued on that peer's
+    # pool until a connection to the peer can be opened. Nothing listens on
+    # this port, so the connection keeps failing and the request keeps waiting.
+    #
+    # The port is taken from PortLock even though nothing will ever bind it:
+    # the point is that no other test's fixture may bind it either, because
+    # anything answering there would let the cancel request through.
+    dead_peer = PortLock()
+    bouncer.write_ini(f"peer_id = 1\n[peers]\n2 = host=127.0.0.1 port={dead_peer.port}")
+    await bouncer.restart()
+
+    try:
+        # So that the request is not disconnected while we are watching it.
+        bouncer.admin("set cancel_wait_timeout=0")
+
+        with socket.create_connection((bouncer.host, bouncer.port)) as sock:
+            start = time.monotonic()
+            # A CancelRequest for peer 2. PgBouncer reads the peer id out of
+            # the 2nd and 3rd byte of the 8 byte key, and the forwarding TTL
+            # out of the last 2 bits of the 8th, so the key needs no real
+            # client behind it to be routed to the peer's pool.
+            sock.sendall(struct.pack("!IIII", 16, 80877102, 2 << 16, 0b11))
+
+            await await_show_rows(
+                bouncer, "SHOW CLIENTS", 1, state="waiting_cancel_req"
+            )
+            await asyncio.sleep(2)
+
+            [request] = await await_show_rows(
+                bouncer, "SHOW CLIENTS", 1, state="waiting_cancel_req"
+            )
+            elapsed = time.monotonic() - start
+
+            wait = request["wait"] + request["wait_us"] / 1_000_000
+            assert 1 <= wait <= elapsed + 1
+    finally:
+        dead_peer.release()
 
 
 def test_kill_db(bouncer: "Bouncer"):


### PR DESCRIPTION
Fixes #1588.

Several console surfaces (SHOW POOLS maxwait/maxwait_us, SHOW CLIENTS wait/wait_us, SHOW SOCKETS wait/wait_us, and the janitor's query_timeout/query_wait_timeout checks) derived a socket's wait time from query_start alone. That field is only set once a client has issued a query, so a client queued before that point - most notably during login (auth_query, PAM/LDAP, or any pool with no server connection yet) or as a queued cancel request - reported a wait of 0 for as long as it sat there. That is exactly the case query_wait_timeout is supposed to be counting down, so an operator watching a stuck pool could see "cl_waiting=2, maxwait=0" and be surprised when those clients were later disconnected by a clock the console never showed.

PgSocket already has wait_start, set by change_client_state() whenever a client goes onto the waiting list, and request_time, set for queued cancel requests. This adds a socket_wait_time() helper in objects.c that prefers query_start (so an in-flight query still reports its own age, unchanged), falls back to wait_start for CL_WAITING/ CL_WAITING_LOGIN, falls back to request_time for CL_WAITING_CANCEL, and otherwise returns 0. All four call sites (admin_show_pools, socket_row, and the janitor's two open-coded loops) now go through this helper instead of reading query_start directly. This only changes what gets reported; no timeout's behavior changes, since for a truly waiting client all of these clocks were cached from the same event-loop iteration.

Added test_maxwait_for_clients_queued_before_their_first_query and test_wait_for_a_queued_cancel_request to cover the two previously-blind cases, and extended doc/usage.md's explanation of maxwait to note that a pool with no server connection yet can now also produce a rising value. A known separate bug is left in place and commented: the janitor's query_timeout check still doesn't guard against query_start == 0 the way its query_wait_timeout counterpart does.