### PR TITLE
Release the test suite's port locks when teardown or setup fails

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -105,10 +105,12 @@ def shared_setup(tmp_path_factory, worker_id):
                 finished_count_file.write_text(str(finished_count))
 
 
-@pytest.fixture(autouse=True, scope="session")
-def pg(tmp_path_factory, cert_dir):
-    """Starts a new Postgres db that is shared for tests in this process"""
-    pg = Postgres(tmp_path_factory.getbasetemp() / "pgdata")
+def setup_pg(pg, cert_dir):
+    """Initializes and starts the Postgres db that the tests share
+
+    Creates the HBA entries, databases and roles that the suite expects to
+    already be there.
+    """
     pg.initdb()
     os.truncate(pg.hba_path, 0)
 
@@ -174,9 +176,19 @@ def pg(tmp_path_factory, cert_dir):
         pg.sql("set password_encryption = 'on'; create user puser1 password 'foo';")
         pg.sql("set password_encryption = 'on'; create user puser2 password 'wrong';")
 
-    yield pg
 
-    pg.cleanup()
+@pytest.fixture(autouse=True, scope="session")
+def pg(tmp_path_factory, cert_dir):
+    """Starts a new Postgres db that is shared for tests in this process"""
+    pg = Postgres(tmp_path_factory.getbasetemp() / "pgdata")
+
+    # The constructor already took a port lock that only cleanup() hands back.
+    try:
+        setup_pg(pg, cert_dir)
+
+        yield pg
+    finally:
+        pg.cleanup()
 
 
 @pytest.fixture
@@ -184,11 +196,12 @@ async def proxy(pg, tmp_path):
     """Starts a new proxy process"""
     proxy = Proxy(pg)
 
-    proxy.start()
+    try:
+        proxy.start()
 
-    yield proxy
-
-    proxy.cleanup()
+        yield proxy
+    finally:
+        proxy.cleanup()
 
 
 @pytest.fixture
@@ -196,11 +209,12 @@ async def bouncer(pg, tmp_path):
     """Starts a new PgBouncer process"""
     bouncer = Bouncer(pg, tmp_path / "bouncer")
 
-    await bouncer.start()
+    try:
+        await bouncer.start()
 
-    yield bouncer
-
-    await bouncer.cleanup()
+        yield bouncer
+    finally:
+        await bouncer.cleanup()
 
 
 @pytest.fixture
@@ -210,13 +224,19 @@ async def bouncer_with_openldap(pg, tmp_path, monkeypatch):
     ldap = OpenLDAP(tmp_path)
     bouncer.ldap = ldap
     monkeypatch.setenv("LDAPCONF", str(tmp_path / "ldap/ldap.conf"))
-    ldap.startup()
-    await bouncer.start()
 
-    yield bouncer
+    try:
+        ldap.startup()
+        await bouncer.start()
 
-    ldap.cleanup()
-    await bouncer.cleanup()
+        yield bouncer
+    finally:
+        # Nested, so that a failure in the LDAP teardown still lets the bouncer
+        # hand its port back.
+        try:
+            ldap.cleanup()
+        finally:
+            await bouncer.cleanup()
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_peering.py
+++ b/test/test_peering.py
@@ -20,21 +20,32 @@ async def peers(pg, tmp_path):
 
     peers[3] = Bouncer(pg, tmp_path / "bouncer3", port=peers[1].port)
 
-    for own_index, bouncer in peers.items():
-        with bouncer.ini_path.open("a") as f:
-            f.write("so_reuseport=1\n")
-            f.write(f"peer_id={own_index}\n")
-            f.write("[peers]\n")
-            for other_index, peer in peers.items():
-                if own_index == other_index:
-                    continue
-                f.write(f"{other_index} = host={peer.admin_host} port={peer.port}\n")
+    try:
+        for own_index, bouncer in peers.items():
+            with bouncer.ini_path.open("a") as f:
+                f.write("so_reuseport=1\n")
+                f.write(f"peer_id={own_index}\n")
+                f.write("[peers]\n")
+                for other_index, peer in peers.items():
+                    if own_index == other_index:
+                        continue
+                    f.write(
+                        f"{other_index} = host={peer.admin_host} port={peer.port}\n"
+                    )
 
-    await asyncio.gather(*[p.start() for p in peers.values()])
+        await asyncio.gather(*[p.start() for p in peers.values()])
 
-    yield peers
-
-    await asyncio.gather(*[p.cleanup() for p in peers.values()])
+        yield peers
+    finally:
+        # return_exceptions, so that one peer failing to clean up does not leave
+        # the others pending and holding their ports. Only peers[1] owns a port
+        # lock, and its cleanup() yields, so it is the one that loses out.
+        results = await asyncio.gather(
+            *[p.cleanup() for p in peers.values()], return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
 
 
 def test_peering_without_own_index(peers):

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -31,11 +31,12 @@ async def bouncer_tls(pg, tmp_path):
         pg, tmp_path / "bouncer", base_ini_path=TEST_DIR / "ssl" / "test.ini"
     )
 
-    await bouncer_tls.start()
+    try:
+        await bouncer_tls.start()
 
-    yield bouncer_tls
-
-    await bouncer_tls.cleanup()
+        yield bouncer_tls
+    finally:
+        await bouncer_tls.cleanup()
 
 
 def test_server_ssl(pg, bouncer_tls, cert_dir):

--- a/test/test_ssl_eof.py
+++ b/test/test_ssl_eof.py
@@ -19,9 +19,11 @@ async def bouncer(pg, tmp_path):
     bouncer = Bouncer(
         pg, tmp_path / "bouncer", base_ini_path=TEST_DIR / "ssl" / "test.ini"
     )
-    await bouncer.start()
-    yield bouncer
-    await bouncer.cleanup()
+    try:
+        await bouncer.start()
+        yield bouncer
+    finally:
+        await bouncer.cleanup()
 
 
 def _abrupt_tls_close(host, port, ca_file):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1132,17 +1132,22 @@ class Bouncer(QueryRunner):
         self.aprocess = None
 
     async def stop(self):
-        if not WINDOWS:
-            self.sigquit()
-        else:
-            # Windows does not have SIGQUIT, so call terminate() twice to
-            # trigger fast exit
-            if self.process is not None:
-                self.process.terminate()
-                self.process.terminate()
-            if self.aprocess is not None:
-                self.aprocess.terminate()
-                self.aprocess.terminate()
+        # Only signal a process that is still alive. asyncio's send_signal()
+        # raises ProcessLookupError once the child has exited, unlike the
+        # subprocess one, so signalling a PgBouncer that already died -- a
+        # config it refused, say -- would replace that failure with this one.
+        if self.running():
+            if not WINDOWS:
+                self.sigquit()
+            else:
+                # Windows does not have SIGQUIT, so call terminate() twice to
+                # trigger fast exit
+                if self.process is not None:
+                    self.process.terminate()
+                    self.process.terminate()
+                if self.aprocess is not None:
+                    self.aprocess.terminate()
+                    self.aprocess.terminate()
 
         await self.wait_for_exit()
 
@@ -1209,13 +1214,16 @@ class Bouncer(QueryRunner):
 
     async def cleanup(self):
         try:
-            cleanup_test_leftovers(self)
-            await self.stop()
+            try:
+                cleanup_test_leftovers(self)
+                await self.stop()
+            finally:
+                self.print_logs()
         finally:
-            self.print_logs()
-
-        if self.port_lock:
-            self.port_lock.release()
+            # print_logs() asserts on the log contents, so it fails whenever
+            # PgBouncer logged an Assert. Hand the port back regardless.
+            if self.port_lock:
+                self.port_lock.release()
 
     def write_ini(self, config):
         """Writes a config to the ini file of this PgBouncer
@@ -1302,11 +1310,19 @@ class OpenLDAP:
         return self.ldaps_port_lock.port
 
     def stop(self):
+        if not self.slapd_pid_file.exists():
+            # startup() failed, so there is no slapd to signal. Returning here
+            # keeps the teardown from replacing that failure with a confusing
+            # missing-pid-file one.
+            return
+
         with self.slapd_pid_file.open("r") as pid_file:
             pid = pid_file.read()
         os.kill(int(pid), signal.SIGTERM)
 
     def cleanup(self):
-        self.stop()
-        self.ldap_port_lock.release()
-        self.ldaps_port_lock.release()
+        try:
+            self.stop()
+        finally:
+            self.ldap_port_lock.release()
+            self.ldaps_port_lock.release()


### PR DESCRIPTION
Fixes #1592.

- Wrap each fixture body in try/finally so cleanup always runs, even if setup raises before the yield.
- Move Bouncer.cleanup()'s lock release into a finally, so a failing print_logs() assertion can no longer block it.
- Give OpenLDAP.cleanup() the same try/finally treatment around its stop() call.
- test_peering.py's fixture uses asyncio.gather(..., return_exceptions=True) across all four peer cleanups, so one peer failing to clean up doesn't leave the others pending and holding their ports.

Side fixes needed to make the above safe
Making cleanup unconditional meant teardown now reliably calls into processes that may have already exited, which surfaced two more bugs:
- Bouncer.stop() now checks self.running() before signaling. asyncio's send_signal() raises ProcessLookupError on an already-exited process (the subprocess equivalent doesn't), so a bouncer that had already died — say, from a bad config — would have that real error overwritten by a teardown crash.
- OpenLDAP.stop() now checks that the pid file exists before reading and signaling it, to avoid the same failure mode if slapd never started.

Known gap (not fixed)
If an exception is raised inside __init__ after a lock has been acquired, nothing holds a reference to that lock to release it. OpenLDAP.__init__ is the one place that takes two locks back-to-back, so it's most exposed, but nothing exercises this path today. Left as a documented limitation rather than fixed.