### PR TITLE
Say what an eviction made room for

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1930,11 +1930,12 @@ void launch_new_connection(PgPool *pool, bool evict_if_needed)
 			}
 
 			if (c && c->replication && !sending_auth_query(c)) {
-				while (evict_if_needed && pool_pool_size(pool) >= max) {
+				while (evict_if_needed && max >= pool_pool_size(pool)) {
 					if (!evict_pool_connection(pool))
 						break;
+					max = pool_server_count(pool);
 				}
-				if (pool_pool_size(pool) < max)
+				if (max < pool_pool_size(pool))
 					goto allow_new;
 			}
 			log_debug("launch_new_connection: pool full (%d >= %d)",

--- a/src/objects.c
+++ b/src/objects.c
@@ -1800,7 +1800,7 @@ bool evict_connection(PgDatabase *db)
 	}
 
 	if (oldest_connection) {
-		disconnect_server(oldest_connection, true, "evicted");
+		disconnect_server(oldest_connection, true, "evicted for max_db_connections");
 		return true;
 	}
 	return false;
@@ -1814,7 +1814,7 @@ bool evict_pool_connection(PgPool *pool)
 	oldest_connection = compare_connections_by_time(oldest_connection, last_socket(&pool->idle_server_list));
 
 	if (oldest_connection) {
-		disconnect_server(oldest_connection, true, "evicted");
+		disconnect_server(oldest_connection, true, "evicted for pool_size");
 		return true;
 	}
 	return false;
@@ -1841,7 +1841,7 @@ bool evict_user_connection(PgCredentials *user_credentials)
 	}
 
 	if (oldest_connection) {
-		disconnect_server(oldest_connection, true, "evicted");
+		disconnect_server(oldest_connection, true, "evicted for max_user_connections");
 		return true;
 	}
 	return false;

--- a/test/test_limits.py
+++ b/test/test_limits.py
@@ -595,10 +595,13 @@ async def test_max_db_connections(pg, bouncer):
     # some users, doesn't matter which ones
     users = ["muser1", "muser2", "puser1", "puser2", "postgres"]
 
-    # p2 has max_db_connections=4
-    await asyncio.gather(
-        *[bouncer.asleep(0.5, dbname="p2", user=u, times=2) for u in users]
-    )
+    # p2 has max_db_connections=4, so the five pools have to take connections
+    # off each other to get all their clients served, and the log should name
+    # the limit that made them do it.
+    with bouncer.log_contains(r"closing because: evicted for max_db_connections \(age"):
+        await asyncio.gather(
+            *[bouncer.asleep(0.5, dbname="p2", user=u, times=2) for u in users]
+        )
 
     # p2 in PgBouncer maps to p0 in Postgres
     assert pg.connection_count("p0", users=users) == 4
@@ -616,3 +619,20 @@ async def test_max_user_connections(pg, bouncer):
     )
 
     assert pg.connection_count("p7", users=["maxedout"]) == 3
+
+
+async def test_max_user_connections_eviction(pg, bouncer):
+    # maxedout has max_user_connections=3, so filling the p7a pool with the
+    # user's whole budget leaves a client on p7b, a separate pool over the same
+    # Postgres database, with no way in except by evicting one of those now
+    # idle connections. Only one, because the user's connection count is
+    # re-read after each eviction.
+    await bouncer.asleep(
+        0.5, dbname="p7a", user="maxedout", times=3, connect_timeout=10
+    )
+    assert pg.connection_count("p7", users=["maxedout"]) == 3
+
+    with bouncer.log_contains(
+        r"closing because: evicted for max_user_connections \(age", times=1
+    ):
+        bouncer.test(dbname="p7b", user="maxedout", connect_timeout=10)

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -293,6 +293,8 @@ async def test_replication_pool_size_mixed_clients(bouncer):
     await bouncer.asleep(0.5, times=2, **connect_args)
 
     # Then try to open a replication connection and ensure that it causes
-    # eviction of one of the normal connections
-    with bouncer.log_contains("closing because: evicted"):
+    # eviction of one of the normal connections. One, not both: the pool is a
+    # single server over its size, so the first eviction is all the room the
+    # replication client needs.
+    with bouncer.log_contains(r"closing because: evicted \(age", times=1):
         bouncer.test(**connect_args, replication="database")

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -296,5 +296,5 @@ async def test_replication_pool_size_mixed_clients(bouncer):
     # eviction of one of the normal connections. One, not both: the pool is a
     # single server over its size, so the first eviction is all the room the
     # replication client needs.
-    with bouncer.log_contains(r"closing because: evicted \(age", times=1):
+    with bouncer.log_contains(r"closing because: evicted for pool_size \(age", times=1):
         bouncer.test(**connect_args, replication="database")


### PR DESCRIPTION
Fixes #1596.

Root cause:
In src/objects.c, the loop read as while (evict_if_needed && pool_pool_size(pool) >= max), where max was a one-time snapshot of the server count taken before the loop started and never updated. Because neither operand changed while the loop ran, once the pool was full the condition stayed true until evict_pool_connection() ran out of idle servers to close - it evicted everything rather than stopping once there was room. The same inverted comparison meant an over-full pool (count > limit) failed the loop's entry condition entirely, so it skipped eviction and let the client open a new connection instead.

Secondary issue (log clarity):
Related to diagnosing this, all three eviction paths (max_db_connections, pool_size, max_user_connections) logged the same generic "evicted" reason, so there was no way to tell from the log which limit actually triggered an eviction.

Fix (this branch):
1. Compare the server count against the limit in the correct direction, and re-read the count after each eviction so the loop stops as soon as there's room — instead of relying on a stale snapshot.
2. Give each of the three eviction paths its own log reason ("evicted for pool_size", "evicted for max_db_connections", "evicted for max_user_connections") so the log answers which limit was full.
