### PR TITLE
Send NULL for a user pool_size that is not set

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -547,10 +547,10 @@ name
 :   The user name
 
 pool_size
-:   The user's override pool_size. or NULL if not set.
+:   The user's override pool_size, or NULL if not set.
 
 reserve_pool_size
-:   The user's override reserve_pool_size. or NULL if not set.
+:   The user's override reserve_pool_size, or NULL if not set.
 
 pool_mode
 :   The user's override pool_mode, or NULL if not set.

--- a/src/admin.c
+++ b/src/admin.c
@@ -398,12 +398,19 @@ static bool admin_show_users(PgSocket *admin, const char *arg)
 		"max_user_client_connections", "current_client_connections");
 	statlist_for_each(item, &user_list) {
 		PgGlobalUser *user = container_of(item, PgGlobalUser, head);
-		char pool_size_str[12] = "";
-		char res_pool_size_str[12] = "";
-		if (user->pool_size >= 0)
-			snprintf(pool_size_str, sizeof(pool_size_str), "%9d", user->pool_size);
-		if (user->res_pool_size >= 0)
-			snprintf(res_pool_size_str, sizeof(res_pool_size_str), "%9d", user->res_pool_size);
+		char pool_size_buf[12], res_pool_size_buf[12];
+		/* pool_size and reserve_pool_size are NULL when unset, as pool_mode is */
+		const char *pool_size_str = NULL;
+		const char *res_pool_size_str = NULL;
+
+		if (user->pool_size >= 0) {
+			snprintf(pool_size_buf, sizeof(pool_size_buf), "%d", user->pool_size);
+			pool_size_str = pool_size_buf;
+		}
+		if (user->res_pool_size >= 0) {
+			snprintf(res_pool_size_buf, sizeof(res_pool_size_buf), "%d", user->res_pool_size);
+			res_pool_size_str = res_pool_size_buf;
+		}
 		pool_mode_str = NULL;
 
 		cv.value_p = &user->pool_mode;

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -47,6 +47,7 @@ def test_show_user(bouncer):
     Specifically we are trying to fix a bug where pool_size and reserve_pool_size
     would take its value from the previous row if a pool_size was not set for a later
     user. In this case test2's pool_size should not be impacted by test1's value.
+    An override that is not set is reported as NULL, like pool_mode in the same row.
     """
     config = f"""
     [databases]
@@ -62,17 +63,16 @@ def test_show_user(bouncer):
     pool_mode = session
 
     [users]
-    test1 = pool_size=1 reserve_pool_size=1
+    test1 = pool_size=1 reserve_pool_size=2
     test2 =
     """
 
     with bouncer.run_with_config(config):
         users = bouncer.admin(f"SHOW USERS", row_factory=dict_row)
         users = [user for user in users if user["name"] in ["test1", "test2"]]
-        assert ["1", ""] == [user["pool_size"].lstrip().rstrip() for user in users]
-        assert ["1", ""] == [
-            user["reserve_pool_size"].lstrip().rstrip() for user in users
-        ]
+        assert ["1", None] == [user["pool_size"] for user in users]
+        assert ["2", None] == [user["reserve_pool_size"] for user in users]
+        assert [None, None] == [user["pool_mode"] for user in users]
 
 
 def test_show(bouncer):


### PR DESCRIPTION
Fixes #1598.

pktbuf_write_DataRow writes a length of -1 for NULL and 0 for an empty string, so a client can tell the two apart -- but SHOW USERS sent the empty string for an unset pool_size or reserve_pool_size, leaving no way to distinguish "no override" from an override deliberately set to nothing.  pool_mode in the same row already sends NULL for precisely that meaning; send NULL for these two as well.  doc/usage.md has documented them as "or NULL if not set" for as long as they have existed.

Additionally, as long as we're in the area, drop the %9d fixed-width padding in favor of plain %d. This cosmetic change affects column alignment in tools like psql, not the data returned to any client.